### PR TITLE
Use correct thumbnail dirs

### DIFF
--- a/src/thumb_standard.h
+++ b/src/thumb_standard.h
@@ -23,7 +23,11 @@
 #define THUMB_STANDARD_H
 
 
+#if GLIB_CHECK_VERSION (2, 34, 0)
+#define THUMB_FOLDER_GLOBAL ".cache/thumbnails"
+#else
 #define THUMB_FOLDER_GLOBAL ".thumbnails"
+#endif
 #define THUMB_FOLDER_LOCAL  ".thumblocal"
 #define THUMB_FOLDER_NORMAL "normal"
 #define THUMB_FOLDER_LARGE  "large"


### PR DESCRIPTION
Since glib 2.34, the thumbnails are in .cache/thumbnails, not in .thumbnails.
