### PR TITLE
Add four new preferences

### DIFF
--- a/src/img-view.c
+++ b/src/img-view.c
@@ -580,10 +580,12 @@ static void button_cb(ImageWindow *imd, GdkEventButton *event, gpointer data)
 	switch (event->button)
 		{
 		case MOUSE_BUTTON_LEFT:
-			view_step_next(vw);
+			if (options->image_lm_click_nav)
+				view_step_next(vw);
 			break;
 		case MOUSE_BUTTON_MIDDLE:
-			view_step_prev(vw);
+			if (options->image_lm_click_nav)
+				view_step_prev(vw);
 			break;
 		case MOUSE_BUTTON_RIGHT:
 			menu = view_popup_menu(vw);

--- a/src/layout_image.c
+++ b/src/layout_image.c
@@ -1405,11 +1405,11 @@ static void layout_image_button_cb(ImageWindow *imd, GdkEventButton *event, gpoi
 	switch (event->button)
 		{
 		case MOUSE_BUTTON_LEFT:
-			if (lw->split_mode == SPLIT_NONE)
+			if (options->image_lm_click_nav && lw->split_mode == SPLIT_NONE)
 				layout_image_next(lw);
 			break;
 		case MOUSE_BUTTON_MIDDLE:
-			if (lw->split_mode == SPLIT_NONE)
+			if (options->image_lm_click_nav && lw->split_mode == SPLIT_NONE)
 				layout_image_prev(lw);
 			break;
 		case MOUSE_BUTTON_RIGHT:

--- a/src/layout_util.c
+++ b/src/layout_util.c
@@ -203,7 +203,9 @@ static void layout_menu_new_window_cb(GtkAction *action, gpointer data)
 	LayoutWindow *nw;
 	LayoutOptions lop;
 	gboolean tmp = options->save_window_positions;
-	options->save_window_positions = FALSE; /* let the windowmanager decide for the first time */
+
+	if (!options->use_saved_window_positions_for_new_windows)
+		options->save_window_positions = FALSE; /* let the windowmanager decide for the first time */
 
 	layout_exit_fullscreen(lw);
 

--- a/src/main.c
+++ b/src/main.c
@@ -106,8 +106,8 @@ void keyboard_scroll_calc(gint *x, gint *y, GdkEventKey *event)
 		delta = 8;
 		}
 
-	*x = *x * delta;
-	*y = *y * delta;
+	*x = *x * delta * options->keyboard_scroll_step;
+	*y = *y * delta * options->keyboard_scroll_step;
 }
 
 

--- a/src/options.c
+++ b/src/options.c
@@ -55,6 +55,7 @@ ConfOptions *init_options(ConfOptions *options)
 	options->file_filter.disable_file_extension_checks = FALSE;
 
 	options->save_window_positions = TRUE;
+	options->use_saved_window_positions_for_new_windows = FALSE;
 	options->tools_restore_state = TRUE;
 
 	options->file_ops.confirm_delete = TRUE;
@@ -108,10 +109,12 @@ ConfOptions *init_options(ConfOptions *options)
 
 	options->lazy_image_sync = FALSE;
 	options->mousewheel_scrolls = FALSE;
+	options->image_lm_click_nav = TRUE;
 	options->open_recent_list_maxsize = 10;
 	options->place_dialogs_under_mouse = FALSE;
 
 	options->progressive_key_scrolling = TRUE;
+	options->keyboard_scroll_step = 1;
 
 	options->metadata.enable_metadata_dirs = FALSE;
 	options->metadata.save_in_image_file = FALSE;
@@ -143,6 +146,7 @@ ConfOptions *init_options(ConfOptions *options)
 	options->thumbnails.use_exif = FALSE;
 
 	options->tree_descend_subdirs = FALSE;
+	options->view_dir_list_single_click_enter = TRUE;
 	options->update_on_time_change = TRUE;
 
 	options->stereo.fixed_w = 1920;

--- a/src/options.h
+++ b/src/options.h
@@ -27,12 +27,15 @@ struct _ConfOptions
 {
 	/* ui */
 	gboolean progressive_key_scrolling;
+	guint keyboard_scroll_step;
 	gboolean place_dialogs_under_mouse;
 	gboolean mousewheel_scrolls;
+	gboolean image_lm_click_nav;
 	gboolean show_icon_names;
 
 	/* various */
 	gboolean tree_descend_subdirs;
+	gboolean view_dir_list_single_click_enter;
 
 	gboolean lazy_image_sync;
 	gboolean update_on_time_change;
@@ -44,6 +47,7 @@ struct _ConfOptions
 	gint dnd_icon_size;
 
 	gboolean save_window_positions;
+	gboolean use_saved_window_positions_for_new_windows;
 	gboolean tools_restore_state;
 
 	/* file ops */

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -218,6 +218,7 @@ static void config_window_apply(void)
 	options->file_ops.safe_delete_folder_maxsize = c_options->file_ops.safe_delete_folder_maxsize;
 	options->tools_restore_state = c_options->tools_restore_state;
 	options->save_window_positions = c_options->save_window_positions;
+	options->use_saved_window_positions_for_new_windows = c_options->use_saved_window_positions_for_new_windows;
 	options->image.zoom_mode = c_options->image.zoom_mode;
 	options->image.scroll_reset_method = c_options->image.scroll_reset_method;
 	options->image.zoom_2pass = c_options->image.zoom_2pass;
@@ -229,6 +230,8 @@ static void config_window_apply(void)
 	options->image.max_autofit_size = c_options->image.max_autofit_size;
 	options->image.use_clutter_renderer = c_options->image.use_clutter_renderer;
 	options->progressive_key_scrolling = c_options->progressive_key_scrolling;
+	options->keyboard_scroll_step = c_options->keyboard_scroll_step;
+
 	if (options->thumbnails.max_width != c_options->thumbnails.max_width
 	    || options->thumbnails.max_height != c_options->thumbnails.max_height
 	    || options->thumbnails.quality != c_options->thumbnails.quality)
@@ -260,6 +263,7 @@ static void config_window_apply(void)
 	options->slideshow.delay = c_options->slideshow.delay;
 
 	options->mousewheel_scrolls = c_options->mousewheel_scrolls;
+	options->image_lm_click_nav = c_options->image_lm_click_nav;
 
 	options->file_ops.enable_in_place_rename = c_options->file_ops.enable_in_place_rename;
 
@@ -312,6 +316,8 @@ static void config_window_apply(void)
 	options->rot_invariant_sim = c_options->rot_invariant_sim;
 
 	options->tree_descend_subdirs = c_options->tree_descend_subdirs;
+
+	options->view_dir_list_single_click_enter = c_options->view_dir_list_single_click_enter;
 
 	options->open_recent_list_maxsize = c_options->open_recent_list_maxsize;
 	options->dnd_icon_size = c_options->dnd_icon_size;
@@ -1534,8 +1540,13 @@ static void config_tab_windows(GtkWidget *notebook)
 
 	group = pref_group_new(vbox, FALSE, _("State"), GTK_ORIENTATION_VERTICAL);
 
-	pref_checkbox_new_int(group, _("Remember window positions"),
-			      options->save_window_positions, &c_options->save_window_positions);
+	ct_button = pref_checkbox_new_int(group, _("Remember window positions"),
+					  options->save_window_positions, &c_options->save_window_positions);
+
+	button = pref_checkbox_new_int(group, _("Use saved window positions also for new windows"),
+				       options->use_saved_window_positions_for_new_windows, &c_options->use_saved_window_positions_for_new_windows);
+	pref_checkbox_link_sensitivity(ct_button, button);
+
 	pref_checkbox_new_int(group, _("Remember tool state (float/hidden)"),
 			      options->tools_restore_state, &c_options->tools_restore_state);
 
@@ -2046,6 +2057,9 @@ static void config_tab_behavior(GtkWidget *notebook)
 	pref_checkbox_new_int(group, _("In place renaming"),
 			      options->file_ops.enable_in_place_rename, &c_options->file_ops.enable_in_place_rename);
 
+	pref_checkbox_new_int(group, _("List directory view uses single click to enter"),
+			      options->view_dir_list_single_click_enter, &c_options->view_dir_list_single_click_enter);
+
 	pref_spin_new_int(group, _("Open recent list maximum size"), NULL,
 			  1, 50, 1, options->open_recent_list_maxsize, &c_options->open_recent_list_maxsize);
 
@@ -2056,8 +2070,12 @@ static void config_tab_behavior(GtkWidget *notebook)
 
 	pref_checkbox_new_int(group, _("Progressive keyboard scrolling"),
 			      options->progressive_key_scrolling, &c_options->progressive_key_scrolling);
+	pref_spin_new_int(group, _("Keyboard scrolling step multiplier:"), NULL,
+			  1, 32, 1, options->keyboard_scroll_step, (int *)&c_options->keyboard_scroll_step);
 	pref_checkbox_new_int(group, _("Mouse wheel scrolls image"),
 			      options->mousewheel_scrolls, &c_options->mousewheel_scrolls);
+	pref_checkbox_new_int(group, _("Navigation by left or middle click on image"),
+			      options->image_lm_click_nav, &c_options->image_lm_click_nav);
 
 	group = pref_group_new(vbox, FALSE, _("Similarities"), GTK_ORIENTATION_VERTICAL);
 

--- a/src/rcfile.c
+++ b/src/rcfile.c
@@ -283,22 +283,26 @@ static void write_global_attributes(GString *outstr, gint indent)
 	WRITE_SEPARATOR();
 
 	WRITE_NL(); WRITE_BOOL(*options, tree_descend_subdirs);
+	WRITE_NL(); WRITE_BOOL(*options, view_dir_list_single_click_enter);
 	WRITE_NL(); WRITE_BOOL(*options, lazy_image_sync);
 	WRITE_NL(); WRITE_BOOL(*options, update_on_time_change);
 	WRITE_SEPARATOR();
 
 	WRITE_NL(); WRITE_BOOL(*options, progressive_key_scrolling);
+	WRITE_NL(); WRITE_UINT(*options, keyboard_scroll_step);
 
 	WRITE_NL(); WRITE_UINT(*options, duplicates_similarity_threshold);
 	WRITE_NL(); WRITE_BOOL(*options, rot_invariant_sim);
 	WRITE_SEPARATOR();
 
 	WRITE_NL(); WRITE_BOOL(*options, mousewheel_scrolls);
+	WRITE_NL(); WRITE_BOOL(*options, image_lm_click_nav);
 	WRITE_NL(); WRITE_INT(*options, open_recent_list_maxsize);
 	WRITE_NL(); WRITE_INT(*options, dnd_icon_size);
 	WRITE_NL(); WRITE_BOOL(*options, place_dialogs_under_mouse);
 
 	WRITE_NL(); WRITE_BOOL(*options, save_window_positions);
+	WRITE_NL(); WRITE_BOOL(*options, use_saved_window_positions_for_new_windows);
 	WRITE_NL(); WRITE_BOOL(*options, tools_restore_state);
 
 	/* File operations Options */
@@ -558,6 +562,7 @@ static gboolean load_global_params(const gchar **attribute_names, const gchar **
 		if (READ_BOOL(*options, show_icon_names)) continue;
 
 		if (READ_BOOL(*options, tree_descend_subdirs)) continue;
+		if (READ_BOOL(*options, view_dir_list_single_click_enter)) continue;
 		if (READ_BOOL(*options, lazy_image_sync)) continue;
 		if (READ_BOOL(*options, update_on_time_change)) continue;
 
@@ -565,14 +570,17 @@ static gboolean load_global_params(const gchar **attribute_names, const gchar **
 		if (READ_BOOL(*options, rot_invariant_sim)) continue;
 
 		if (READ_BOOL(*options, progressive_key_scrolling)) continue;
+		if (READ_UINT_CLAMP(*options, keyboard_scroll_step, 1, 32)) continue;
 
 		if (READ_BOOL(*options, mousewheel_scrolls)) continue;
+		if (READ_BOOL(*options, image_lm_click_nav)) continue;
 
 		if (READ_INT(*options, open_recent_list_maxsize)) continue;
 		if (READ_INT(*options, dnd_icon_size)) continue;
 		if (READ_BOOL(*options, place_dialogs_under_mouse)) continue;
 
 		if (READ_BOOL(*options, save_window_positions)) continue;
+		if (READ_BOOL(*options, use_saved_window_positions_for_new_windows)) continue;
 		if (READ_BOOL(*options, tools_restore_state)) continue;
 
 		/* Properties dialog options */

--- a/src/view_dir.c
+++ b/src/view_dir.c
@@ -1035,6 +1035,9 @@ gboolean vd_release_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer data)
 	GtkTreePath *tpath;
 	FileData *fd = NULL;
 
+	if (vd->type == DIRVIEW_LIST && !options->view_dir_list_single_click_enter)
+		return FALSE;
+
 	if (!vd->click_fd) return FALSE;
 	vd_color_set(vd, vd->click_fd, FALSE);
 

--- a/src/view_dir_list.c
+++ b/src/view_dir_list.c
@@ -406,16 +406,19 @@ gboolean vdlist_press_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer dat
 		}
 
 	vd->click_fd = fd;
-	vd_color_set(vd, vd->click_fd, TRUE);
+
+	if (options->view_dir_list_single_click_enter)
+		vd_color_set(vd, vd->click_fd, TRUE);
 
 	if (bevent->button == MOUSE_BUTTON_RIGHT)
 		{
 		vd->popup = vd_pop_menu(vd, vd->click_fd);
 		gtk_menu_popup(GTK_MENU(vd->popup), NULL, NULL, NULL, NULL,
 			       bevent->button, bevent->time);
+		return TRUE;
 		}
 
-	return TRUE;
+	return options->view_dir_list_single_click_enter;
 }
 
 void vdlist_destroy_cb(GtkWidget *widget, gpointer data)


### PR DESCRIPTION
This commit adds four new preferences:
* Whether to use saved window positions also for new windows (in case saved
window positions are enabled),
* Whether to enable navigation by left or middle click on image,
* Ability to set keyboard scrolling step multiplier,
* Whether list directory view uses single click to enter a directory or
GTK+ activation default (which is currently a double click).

Default values of all these preferences have been set in a such way to not
cause any changes in behavior for existing users.
