### PR TITLE
Force focus to geeqie after leaving fullscreen

### DIFF
--- a/src/fullscreen.c
+++ b/src/fullscreen.c
@@ -364,6 +364,8 @@ void fullscreen_stop(FullScreenData *fs)
 
 	gtk_widget_destroy(fs->window);
 
+	gtk_window_present(fs->normal_window);
+
 	g_free(fs);
 }
 


### PR DESCRIPTION
On some multi-monitor setups / window manager
combinations, the geeqie main window does not
claim focus back after leaving fullscreen mode.

This fixes https://github.com/BestImageViewer/geeqie/issues/418