### PR TITLE
Bug Fix #233 Custom Border

### DIFF
--- a/src/pixbuf-renderer.c
+++ b/src/pixbuf-renderer.c
@@ -435,6 +435,10 @@ static void pixbuf_renderer_init(PixbufRenderer *pr)
 
 	pr->stereo_mode = PR_STEREO_NONE;
 
+	pr->color.red =0;
+	pr->color.green =0;
+	pr->color.blue =0;
+
 	pr->renderer = pr_backend_renderer_new(pr);
 
 	pr->renderer2 = NULL;
@@ -904,23 +908,18 @@ void pixbuf_renderer_set_color(PixbufRenderer *pr, GdkColor *color)
 
 	g_return_if_fail(IS_PIXBUF_RENDERER(pr));
 
-	widget = GTK_WIDGET(pr);
-
-	if (color) {
-		GdkColor *slot;
-
-		style = gtk_style_copy(gtk_widget_get_style(widget));
-		slot = &style->bg[GTK_STATE_NORMAL];
-
-		slot->red = color->red;
-		slot->green = color->green;
-		slot->blue = color->blue;
+	if (color)
+		{
+		pr->color.red = color->red;
+		pr->color.green = color->green;
+		pr->color.blue = color->blue;
 		}
-	else {
-		style = gtk_style_copy(gtk_widget_get_default_style());
-	}
-
-	gtk_widget_set_style(widget, style);
+	else
+		{
+		pr->color.red = 0;
+		pr->color.green = 0;
+		pr->color.blue = 0;
+		}
 
 	pr->renderer->update_viewport(pr->renderer);
 	if (pr->renderer2) pr->renderer2->update_viewport(pr->renderer2);

--- a/src/pixbuf-renderer.h
+++ b/src/pixbuf-renderer.h
@@ -161,7 +161,7 @@ struct _PixbufRenderer
 	gboolean autofit_limit;
 	gint autofit_limit_size;
 
-
+	GdkColor color;
 
 	/*< private >*/
 	gboolean in_drag;

--- a/src/renderer-tiles.c
+++ b/src/renderer-tiles.c
@@ -219,7 +219,7 @@ static void rt_border_draw(RendererTiles *rt, gint x, gint y, gint w, gint h)
 				   pr->viewport_width, pr->viewport_height,
 				   &rx, &ry, &rw, &rh))
 			{
-			cairo_set_source_rgb(cr, 0, 0, 0);
+			cairo_set_source_rgb(cr, (double)pr->color.red/65535, (double)pr->color.green/65535, (double)pr->color.blue/65535);
 			cairo_rectangle(cr, rx + rt->stereo_off_x, ry + rt->stereo_off_y, rw, rh);
 			cairo_fill(cr);
 			cairo_destroy(cr);
@@ -236,7 +236,7 @@ static void rt_border_draw(RendererTiles *rt, gint x, gint y, gint w, gint h)
 				   pr->x_offset, pr->viewport_height,
 				   &rx, &ry, &rw, &rh))
 			{
-			cairo_set_source_rgb(cr, 0, 0, 0);
+			cairo_set_source_rgb(cr, (double)pr->color.red/65535, (double)pr->color.green/65535, (double)pr->color.blue/65535);
 			cairo_rectangle(cr, rx + rt->stereo_off_x, ry + rt->stereo_off_y, rw, rh);
 			cairo_fill(cr);
 			rt_overlay_draw(rt, rx, ry, rw, rh, NULL);
@@ -247,7 +247,7 @@ static void rt_border_draw(RendererTiles *rt, gint x, gint y, gint w, gint h)
 				   pr->viewport_width - pr->vis_width - pr->x_offset, pr->viewport_height,
 				   &rx, &ry, &rw, &rh))
 			{
-			cairo_set_source_rgb(cr, 0, 0, 0);
+			cairo_set_source_rgb(cr, (double)pr->color.red/65535, (double)pr->color.green/65535, (double)pr->color.blue/65535);
 			cairo_rectangle(cr, rx + rt->stereo_off_x, ry + rt->stereo_off_y, rw, rh);
 			cairo_fill(cr);
 			rt_overlay_draw(rt, rx, ry, rw, rh, NULL);
@@ -261,7 +261,7 @@ static void rt_border_draw(RendererTiles *rt, gint x, gint y, gint w, gint h)
 				   pr->vis_width, pr->y_offset,
 				   &rx, &ry, &rw, &rh))
 			{
-			cairo_set_source_rgb(cr, 0, 0, 0);
+			cairo_set_source_rgb(cr, (double)pr->color.red/65535, (double)pr->color.green/65535, (double)pr->color.blue/65535);
 			cairo_rectangle(cr, rx + rt->stereo_off_x, ry + rt->stereo_off_y, rw, rh);
 			cairo_fill(cr);
 			rt_overlay_draw(rt, rx, ry, rw, rh, NULL);
@@ -272,7 +272,7 @@ static void rt_border_draw(RendererTiles *rt, gint x, gint y, gint w, gint h)
 				   pr->vis_width, pr->viewport_height - pr->vis_height - pr->y_offset,
 				   &rx, &ry, &rw, &rh))
 			{
-			cairo_set_source_rgb(cr, 0, 0, 0);
+			cairo_set_source_rgb(cr, (double)pr->color.red/65535, (double)pr->color.green/65535, (double)pr->color.blue/65535);
 			cairo_rectangle(cr, rx + rt->stereo_off_x, ry + rt->stereo_off_y, rw, rh);
 			cairo_fill(cr);
 			rt_overlay_draw(rt, rx, ry, rw, rh, NULL);


### PR DESCRIPTION
https://github.com/BestImageViewer/geeqie/issues/233

In the change from v1.1 to v1.2 (GTK3 and cairo were part of this), the
custom border was ignored and simply set to black.
Perhaps it was not possible to get a "good" solution with the current
design.
Possibly this change is not the best solution, but nevertheless it
should be sufficient until a better version is produced.