### PR TITLE
Bug Fix #426: geeqie -r file:FILE crashes if FILE does not exist

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -516,6 +516,7 @@ static void gr_file_load(const gchar *text, GIOChannel *channel, gpointer data)
 	else
 		{
 		log_printf("remote sent filename that does not exist:\"%s\"\n", filename);
+		layout_set_path(NULL, homedir());
 		}
 
 	g_free(filename);
@@ -532,6 +533,7 @@ static void gr_config_load(const gchar *text, GIOChannel *channel, gpointer data
 	else
 		{
 		log_printf("remote sent filename that does not exist:\"%s\"\n", filename);
+		layout_set_path(NULL, homedir());
 		}
 
 	g_free(filename);


### PR DESCRIPTION
https://github.com/BestImageViewer/geeqie/issues/426

If the file does not exist, default to the home directory