### PR TITLE
Fix memory leak

### DIFF
--- a/src/cellrenderericon.c
+++ b/src/cellrenderericon.c
@@ -692,7 +692,9 @@ gqv_cell_renderer_icon_render(GtkCellRenderer		*cell,
 
 	if (!pixbuf && !text)
 		{
+#if !GTK_CHECK_VERSION(3,0,0)
 		cairo_destroy(cr);
+#endif
 		return;
 		}
 

--- a/src/renderer-tiles.c
+++ b/src/renderer-tiles.c
@@ -222,9 +222,9 @@ static void rt_border_draw(RendererTiles *rt, gint x, gint y, gint w, gint h)
 			cairo_set_source_rgb(cr, (double)pr->color.red/65535, (double)pr->color.green/65535, (double)pr->color.blue/65535);
 			cairo_rectangle(cr, rx + rt->stereo_off_x, ry + rt->stereo_off_y, rw, rh);
 			cairo_fill(cr);
-			cairo_destroy(cr);
 			rt_overlay_draw(rt, rx, ry, rw, rh, NULL);
 			}
+		cairo_destroy(cr);
 		return;
 		}
 


### PR DESCRIPTION
Hi.

I think I found another code path, similar to that fixed in 03283a3, where `cairo_create` may get called and there is a possible return from the function (`rt_border_draw` in this case) without a corresponding `cairo_destroy`. The pull request here addresses this.

Thoughts?

Thank you for maintaining geeqie.