### PR TITLE
Fix compile warnings, and add -Werror to the default CFLAGS

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -17,6 +17,9 @@ dnl GNU General Public License for more details.
 AC_PREREQ(2.57)
 AC_INIT([geeqie], m4_esyscmd_s(git rev-parse --quiet --verify --short master), [geeqie-devel@lists.sourceforge.net], [], [http://www.geeqie.org/])
 
+# Add -Werror to the default CFLAGS
+CFLAGS+=" -Werror -Wno-error=deprecated-declarations"
+
 # Check for rightly dirs
 AC_CONFIG_SRCDIR([src/main.c])
 

--- a/src/cache_maint.c
+++ b/src/cache_maint.c
@@ -32,6 +32,7 @@
 #include "ui_spinner.h"
 #include "ui_tabcomp.h"
 #include "ui_utildlg.h"
+#include "window.h"
 
 
 typedef struct _CMData CMData;

--- a/src/layout.c
+++ b/src/layout.c
@@ -1728,7 +1728,7 @@ gboolean layout_tools_float_get(LayoutWindow *lw, gboolean *popped, gboolean *hi
 void layout_toolbar_toggle(LayoutWindow *lw)
 {
 	if (!layout_valid(&lw)) return;
-	if (!lw->toolbar) return;
+	if (!lw->toolbar[TOOLBAR_MAIN]) return;
 
 	lw->options.toolbar_hidden = !lw->options.toolbar_hidden;
 
@@ -2125,8 +2125,8 @@ LayoutWindow *layout_new_with_geometry(FileData *dir_fd, LayoutOptions *lop,
 
 	layout_config_parse(lw->options.style, lw->options.order,
 			    &lw->dir_location,  &lw->file_location, &lw->image_location);
-	if (lw->options.dir_view_type >= VIEW_DIR_TYPES_COUNT) lw->options.dir_view_type = 0;
-	if (lw->options.file_view_type >= VIEW_FILE_TYPES_COUNT) lw->options.file_view_type = 0;
+	if (lw->options.dir_view_type > DIRVIEW_LAST) lw->options.dir_view_type = 0;
+	if (lw->options.file_view_type > FILEVIEW_LAST) lw->options.file_view_type = 0;
 
 	/* divider positions */
 

--- a/src/layout_util.c
+++ b/src/layout_util.c
@@ -2134,7 +2134,7 @@ void layout_actions_setup(LayoutWindow *lw)
 					   menu_split_radio_entries, G_N_ELEMENTS(menu_split_radio_entries),
 					   0, G_CALLBACK(layout_menu_split_cb), lw);
 	gtk_action_group_add_radio_actions(lw->action_group,
-					   menu_view_dir_radio_entries, VIEW_DIR_TYPES_COUNT,
+					   menu_view_dir_radio_entries, DIRVIEW_LAST + 1 /* count */,
 					   0, G_CALLBACK(layout_menu_view_dir_as_cb), lw);
 	gtk_action_group_add_radio_actions(lw->action_group,
 					   menu_color_radio_entries, COLOR_PROFILE_FILE + COLOR_PROFILE_INPUTS,

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -410,7 +410,7 @@ static void config_window_close_cb(GtkWidget *widget, gpointer data)
 
 static void config_window_help_cb(GtkWidget *widget, gpointer data)
 {
-	GtkWidget *notebook = GTK_NOTEBOOK(data);
+	GtkWidget *notebook = GTK_WIDGET(data);
 	gint i;
 
 	static gchar *html_section[] =
@@ -426,7 +426,7 @@ static void config_window_help_cb(GtkWidget *widget, gpointer data)
 	"GuideOptionsBehavior.html"
 	};
 
-	i = gtk_notebook_get_current_page(notebook);
+	i = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
 	help_window_show(html_section[i]);
 }
 
@@ -1979,7 +1979,7 @@ static void intent_menu_cb(GtkWidget *combo, gpointer data)
 }
 
 static void add_intent_menu(GtkWidget *table, gint column, gint row, const gchar *text,
-			     guint option, guint *option_c)
+			     gint option, gint *option_c)
 {
 	GtkWidget *combo;
 	gint current = 0;

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -38,12 +38,18 @@ typedef enum {
 
 typedef enum {
 	DIRVIEW_LIST,
-	DIRVIEW_TREE
+	DIRVIEW_TREE,
+
+	// Keep this up to date!
+	DIRVIEW_LAST = DIRVIEW_TREE
 } DirViewType;
 
 typedef enum {
 	FILEVIEW_LIST,
-	FILEVIEW_ICON
+	FILEVIEW_ICON,
+
+	// Keep this up to date!
+	FILEVIEW_LAST = FILEVIEW_ICON
 } FileViewType;
 
 #define	CMD_COPY     "geeqie-copy-command.desktop"

--- a/src/view_dir.h
+++ b/src/view_dir.h
@@ -30,8 +30,6 @@ enum {
 	DIR_COLUMN_COUNT
 };
 
-#define VIEW_DIR_TYPES_COUNT 2
-
 ViewDir *vd_new(DirViewType type, FileData *dir_fd);
 
 void vd_set_select_func(ViewDir *vdl, void (*func)(ViewDir *vdl, FileData *fd, gpointer data), gpointer data);

--- a/src/view_file.h
+++ b/src/view_file.h
@@ -21,8 +21,6 @@
 #ifndef VIEW_FILE_H
 #define VIEW_FILE_H
 
-#define VIEW_FILE_TYPES_COUNT 2
-
 #define VFLIST(_vf_) ((ViewFileInfoList *)(_vf_->info))
 #define VFICON(_vf_) ((ViewFileInfoIcon *)(_vf_->info))
 


### PR DESCRIPTION
More specifically, sets default CFLAGS to "-g -O2 -Werror -Wno-error=deprecated-declarations"