### PR TITLE
A small parameter type fix for "motion-notify-event" signal handlers

### DIFF
--- a/src/collect-table.c
+++ b/src/collect-table.c
@@ -1593,11 +1593,11 @@ static void collection_table_scroll(CollectTable *ct, gboolean scroll)
  *-------------------------------------------------------------------
  */
 
-static gboolean collection_table_motion_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer data)
+static gboolean collection_table_motion_cb(GtkWidget *widget, GdkEventMotion *event, gpointer data)
 {
 	CollectTable *ct = data;
 
-	collection_table_motion_update(ct, (gint)bevent->x, (gint)bevent->y, FALSE);
+	collection_table_motion_update(ct, (gint)event->x, (gint)event->y, FALSE);
 
 	return FALSE;
 }

--- a/src/fullscreen.c
+++ b/src/fullscreen.c
@@ -99,7 +99,7 @@ static void fullscreen_hide_mouse_reset(FullScreenData *fs)
 	fs->hide_mouse_id = g_timeout_add(FULL_SCREEN_HIDE_MOUSE_DELAY, fullscreen_hide_mouse_cb, fs);
 }
 
-static gboolean fullscreen_mouse_moved(GtkWidget *widget, GdkEventButton *bevent, gpointer data)
+static gboolean fullscreen_mouse_moved(GtkWidget *widget, GdkEventMotion *event, gpointer data)
 {
 	FullScreenData *fs = data;
 

--- a/src/image.c
+++ b/src/image.c
@@ -63,7 +63,7 @@ static void image_click_cb(PixbufRenderer *pr, GdkEventButton *event, gpointer d
 		}
 }
 
-static void image_drag_cb(PixbufRenderer *pr, GdkEventButton *event, gpointer data)
+static void image_drag_cb(PixbufRenderer *pr, GdkEventMotion *event, gpointer data)
 {
 	ImageWindow *imd = data;
 	gint width, height;
@@ -993,7 +993,7 @@ void image_set_button_func(ImageWindow *imd,
 }
 
 void image_set_drag_func(ImageWindow *imd,
-			   void (*func)(ImageWindow *, GdkEventButton *event, gdouble dx, gdouble dy, gpointer),
+			   void (*func)(ImageWindow *, GdkEventMotion *event, gdouble dx, gdouble dy, gpointer),
 			   gpointer data)
 {
 	imd->func_drag = func;

--- a/src/image.h
+++ b/src/image.h
@@ -36,7 +36,7 @@ void image_set_button_func(ImageWindow *imd,
 	void (*func)(ImageWindow *, GdkEventButton *event, gpointer),
 	gpointer data);
 void image_set_drag_func(ImageWindow *imd,
-	void (*func)(ImageWindow *, GdkEventButton *event, gdouble dx, gdouble dy, gpointer),
+	void (*func)(ImageWindow *, GdkEventMotion *event, gdouble dx, gdouble dy, gpointer),
 	gpointer data);
 void image_set_scroll_func(ImageWindow *imd,
 	void (*func)(ImageWindow *, GdkEventScroll *event, gpointer),

--- a/src/layout_image.c
+++ b/src/layout_image.c
@@ -1722,7 +1722,7 @@ static void layout_image_scroll_cb(ImageWindow *imd, GdkEventScroll *event, gpoi
 		}
 }
 
-static void layout_image_drag_cb(ImageWindow *imd, GdkEventButton *event, gdouble dx, gdouble dy, gpointer data)
+static void layout_image_drag_cb(ImageWindow *imd, GdkEventMotion *event, gdouble dx, gdouble dy, gpointer data)
 {
 	gint i;
 	LayoutWindow *lw = data;
@@ -1793,7 +1793,7 @@ static void layout_image_button_inactive_cb(ImageWindow *imd, GdkEventButton *ev
 
 }
 
-static void layout_image_drag_inactive_cb(ImageWindow *imd, GdkEventButton *event, gdouble dx, gdouble dy, gpointer data)
+static void layout_image_drag_inactive_cb(ImageWindow *imd, GdkEventMotion *event, gdouble dx, gdouble dy, gpointer data)
 {
 	LayoutWindow *lw = data;
 	gint i = image_idx(lw, imd);

--- a/src/pixbuf-renderer.c
+++ b/src/pixbuf-renderer.c
@@ -1303,9 +1303,9 @@ void pr_render_complete_signal(PixbufRenderer *pr)
 		}
 }
 
-static void pr_drag_signal(PixbufRenderer *pr, GdkEventButton *bevent)
+static void pr_drag_signal(PixbufRenderer *pr, GdkEventMotion *event)
 {
-	g_signal_emit(pr, signals[SIGNAL_DRAG], 0, bevent);
+	g_signal_emit(pr, signals[SIGNAL_DRAG], 0, event);
 }
 
 static void pr_update_pixel_signal(PixbufRenderer *pr)
@@ -1954,7 +1954,7 @@ void pixbuf_renderer_set_scroll_center(PixbufRenderer *pr, gdouble x, gdouble y)
  *-------------------------------------------------------------------
  */
 
-static gboolean pr_mouse_motion_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer data)
+static gboolean pr_mouse_motion_cb(GtkWidget *widget, GdkEventMotion *event, gpointer data)
 {
 	PixbufRenderer *pr;
 	gint accel;
@@ -1967,25 +1967,25 @@ static gboolean pr_mouse_motion_cb(GtkWidget *widget, GdkEventButton *bevent, gp
 	 * See http://bugzilla.gnome.org/show_bug.cgi?id=587714 for more. */
 	gint x, y;
 #if GTK_CHECK_VERSION(3,0,0)
-	device_manager = gdk_display_get_device_manager(gdk_window_get_display(bevent->window));
+	device_manager = gdk_display_get_device_manager(gdk_window_get_display(event->window));
 	device = gdk_device_manager_get_client_pointer(device_manager);
-	gdk_window_get_device_position(bevent->window, device, &x, &y, NULL);
+	gdk_window_get_device_position(event->window, device, &x, &y, NULL);
 #else
-	gdk_window_get_pointer (bevent->window, &x, &y, NULL);
+	gdk_window_get_pointer (event->window, &x, &y, NULL);
 #endif
-	bevent->x = x;
-	bevent->y = y;
+	event->x = x;
+	event->y = y;
 
 	pr = PIXBUF_RENDERER(widget);
 
 	if (pr->scroller_id)
 		{
-		pr->scroller_xpos = bevent->x;
-		pr->scroller_ypos = bevent->y;
+		pr->scroller_xpos = event->x;
+		pr->scroller_ypos = event->y;
 		}
 
-	pr->x_mouse = bevent->x;
-	pr->y_mouse = bevent->y;
+	pr->x_mouse = event->x;
+	pr->y_mouse = event->y;
 	pr_update_pixel_signal(pr);
 
 	if (!pr->in_drag || !gdk_pointer_is_grabbed()) return FALSE;
@@ -1999,7 +1999,7 @@ static gboolean pr_mouse_motion_cb(GtkWidget *widget, GdkEventButton *bevent, gp
 		widget_set_cursor(widget, GDK_FLEUR);
 		}
 
-	if (bevent->state & GDK_CONTROL_MASK)
+	if (event->state & GDK_CONTROL_MASK)
 		{
 		accel = PR_PAN_SHIFT_MULTIPLIER;
 		}
@@ -2009,19 +2009,19 @@ static gboolean pr_mouse_motion_cb(GtkWidget *widget, GdkEventButton *bevent, gp
 		}
 
 	/* do the scroll */
-	pixbuf_renderer_scroll(pr, (pr->drag_last_x - bevent->x) * accel,
-			       (pr->drag_last_y - bevent->y) * accel);
+	pixbuf_renderer_scroll(pr, (pr->drag_last_x - event->x) * accel,
+			       (pr->drag_last_y - event->y) * accel);
 
-	pr_drag_signal(pr, bevent);
+	pr_drag_signal(pr, event);
 
-	pr->drag_last_x = bevent->x;
-	pr->drag_last_y = bevent->y;
+	pr->drag_last_x = event->x;
+	pr->drag_last_y = event->y;
 
 	/* This is recommended by the GTK+ documentation, but does not work properly.
 	 * Use deprecated way until GTK+ gets a solution for correct motion hint handling:
 	 * http://bugzilla.gnome.org/show_bug.cgi?id=587714
 	 */
-	/* gdk_event_request_motions (bevent); */
+	/* gdk_event_request_motions (event); */
 	return FALSE;
 }
 

--- a/src/pixbuf-renderer.h
+++ b/src/pixbuf-renderer.h
@@ -226,7 +226,7 @@ struct _PixbufRendererClass
 	void (*update_pixel)(PixbufRenderer *pr);
 
 	void (*render_complete)(PixbufRenderer *pr);
-	void (*drag)(PixbufRenderer *pr, GdkEventButton *event);
+	void (*drag)(PixbufRenderer *pr, GdkEventMotion *event);
 };
 
 

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -479,7 +479,7 @@ struct _ImageWindow
 
 	/* button, scroll functions */
 	void (*func_button)(ImageWindow *, GdkEventButton *event, gpointer);
-	void (*func_drag)(ImageWindow *, GdkEventButton *event, gdouble dx, gdouble dy, gpointer);
+	void (*func_drag)(ImageWindow *, GdkEventMotion *event, gdouble dx, gdouble dy, gpointer);
 	void (*func_scroll)(ImageWindow *, GdkEventScroll *event, gpointer);
 	void (*func_focus_in)(ImageWindow *, gpointer);
 

--- a/src/ui_misc.c
+++ b/src/ui_misc.c
@@ -1201,7 +1201,7 @@ static gint sizer_default_handle_size(void)
 	return handle_size;
 }
 
-static gboolean sizer_motion_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer data)
+static gboolean sizer_motion_cb(GtkWidget *widget, GdkEventMotion *event, gpointer data)
 {
 	SizerData *sd = data;
 	gint x, y;
@@ -1210,8 +1210,8 @@ static gboolean sizer_motion_cb(GtkWidget *widget, GdkEventButton *bevent, gpoin
 
 	if (!sd->in_drag) return FALSE;
 
-	x = sd->press_x - bevent->x_root;
-	y = sd->press_y - bevent->y_root;
+	x = sd->press_x - event->x_root;
+	y = sd->press_y - event->y_root;
 
 	w = sd->press_width;
 	h = sd->press_height;

--- a/src/view_file_icon.c
+++ b/src/view_file_icon.c
@@ -1372,12 +1372,12 @@ gboolean vficon_press_key_cb(GtkWidget *widget, GdkEventKey *event, gpointer dat
  *-------------------------------------------------------------------
  */
 
-static gboolean vficon_motion_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer data)
+static gboolean vficon_motion_cb(GtkWidget *widget, GdkEventMotion *event, gpointer data)
 {
 	ViewFile *vf = data;
 	IconData *id;
 
-	id = vficon_find_data_by_coord(vf, (gint)bevent->x, (gint)bevent->y, NULL);
+	id = vficon_find_data_by_coord(vf, (gint)event->x, (gint)event->y, NULL);
 	tip_update(vf, id);
 
 	return FALSE;


### PR DESCRIPTION
The "motion-notify-event" signal "event" parameter is a GdkEventMotion structure,
not GdkEventButton.
These are mostly compatible, let's use a correct one however.
