### PR TITLE
Shortcuts to folders

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -226,6 +226,8 @@ geeqie_SOURCES = \
 	search.h	\
 	secure_save.c	\
 	secure_save.h	\
+	shortcuts.c	\
+	shortcuts.h	\
 	similar.c	\
 	similar.h	\
 	slideshow.c	\

--- a/src/layout.c
+++ b/src/layout.c
@@ -46,7 +46,7 @@
 #include "bar.h"
 #include "bar_sort.h"
 #include "preferences.h"
-
+#include "shortcuts.h"
 #ifdef HAVE_LIRC
 #include "lirc.h"
 #endif
@@ -183,6 +183,20 @@ static gboolean layout_set_current_cb(GtkWidget *widget, GdkEventFocus *event, g
 	return FALSE;
 }
 
+static void layout_box_folders_changed_cb(GtkWidget *widget, gpointer data)
+{
+	LayoutWindow *lw;
+	GList *work;
+
+	work = layout_window_list;
+	while (work)
+		{
+		lw = work->data;
+		lw->options.folder_window.vdivider_pos = gtk_paned_get_position(GTK_PANED(widget));
+		work = work->next;
+		}
+}
+
 /*
  *-----------------------------------------------------------------------------
  * menu, toolbar, and dir view
@@ -272,6 +286,8 @@ static void layout_path_entry_tab_append_cb(const gchar *path, gpointer data, gi
 static GtkWidget *layout_tool_setup(LayoutWindow *lw)
 {
 	GtkWidget *box;
+	GtkWidget *box_folders;
+	GtkWidget *scd;
 	GtkWidget *menu_bar;
 	GtkWidget *tabcomp;
 	GtkWidget *toolbar;
@@ -300,14 +316,25 @@ static GtkWidget *layout_tool_setup(LayoutWindow *lw)
 			 G_CALLBACK(layout_path_entry_changed_cb), lw);
 #endif
 
+	box_folders = GTK_WIDGET(gtk_hpaned_new());
+	gtk_box_pack_start(GTK_BOX(box), box_folders, TRUE, TRUE, 0);
+
 	lw->vd = vd_new(lw->options.dir_view_type, lw->dir_fd);
 	vd_set_layout(lw->vd, lw);
 	vd_set_select_func(lw->vd, layout_vd_select_cb, lw);
 
 	lw->dir_view = lw->vd->widget;
-
-	gtk_box_pack_start(GTK_BOX(box), lw->dir_view, TRUE, TRUE, 0);
+	gtk_paned_add2(GTK_PANED(box_folders), lw->dir_view);
 	gtk_widget_show(lw->dir_view);
+
+	scd = shortcuts_new_default(lw);
+	gtk_paned_add1(GTK_PANED(box_folders), scd);
+	gtk_paned_set_position(GTK_PANED(box_folders), lw->options.folder_window.vdivider_pos);
+
+	gtk_widget_show(box_folders);
+
+	g_signal_connect(G_OBJECT(box_folders), "notify::position",
+			 G_CALLBACK(layout_box_folders_changed_cb), lw);
 
 	gtk_widget_show(box);
 
@@ -2277,6 +2304,9 @@ void layout_write_attributes(LayoutOptions *layout, GString *outstr, gint indent
 	WRITE_NL(); WRITE_INT(*layout, main_window.vdivider_pos);
 	WRITE_SEPARATOR();
 
+	WRITE_NL(); WRITE_INT(*layout, folder_window.vdivider_pos);
+	WRITE_SEPARATOR();
+
 	WRITE_NL(); WRITE_INT(*layout, float_window.x);
 	WRITE_NL(); WRITE_INT(*layout, float_window.y);
 	WRITE_NL(); WRITE_INT(*layout, float_window.w);
@@ -2350,6 +2380,8 @@ void layout_load_attributes(LayoutOptions *layout, const gchar **attribute_names
 		if (READ_BOOL(*layout, main_window.maximized)) continue;
 		if (READ_INT(*layout, main_window.hdivider_pos)) continue;
 		if (READ_INT(*layout, main_window.vdivider_pos)) continue;
+
+		if (READ_INT(*layout, folder_window.vdivider_pos)) continue;
 
 		if (READ_INT(*layout, float_window.x)) continue;
 		if (READ_INT(*layout, float_window.y)) continue;

--- a/src/shortcuts.c
+++ b/src/shortcuts.c
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2004 John Ellis
+ * Copyright (C) 2008 - 2016 The Geeqie Team
+ *
+ * Author: John Ellis
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "main.h"
+#include "shortcuts.h"
+
+#include "layout.h"
+#include "utilops.h"
+#include "ui_bookmark.h"
+#include "ui_fileops.h"
+#include "ui_misc.h"
+
+typedef struct _ShortcutsData ShortcutsData;
+struct _ShortcutsData
+{
+	GtkWidget *vbox;
+	GtkWidget *bookmarks;
+	LayoutWindow *lw;
+
+	FileDialog *dialog;
+	GtkWidget *dialog_name_entry;
+
+	GtkWidget *add_button;
+};
+
+#define SHORTCUTS     "shortcuts"
+
+static void shortcuts_bookmark_select(const gchar *path, gpointer data)
+{
+	ShortcutsData *scd = data;
+
+	layout_set_path(scd->lw, path);
+}
+
+static void shortcuts_add_close(ShortcutsData *scd)
+{
+	if (scd->dialog) file_dialog_close(scd->dialog);
+	scd->dialog_name_entry = NULL;
+	scd->dialog = NULL;
+}
+
+static void shortcuts_add_ok_cb(FileDialog *fd, gpointer data)
+{
+	ShortcutsData *scd = data;
+	const gchar *name = gtk_entry_get_text(GTK_ENTRY(scd->dialog_name_entry));
+	gboolean empty_name = (name[0] == '\0');
+
+	name = gtk_entry_get_text(GTK_ENTRY(scd->dialog_name_entry));
+
+	if (empty_name)
+		{
+		name = filename_from_path(fd->dest_path);
+		}
+
+	bookmark_list_add(scd->bookmarks, name, fd->dest_path);
+
+	shortcuts_add_close(scd);
+}
+
+static void shortcuts_add_cancel_cb(FileDialog *fd, gpointer data)
+{
+	ShortcutsData *scd = data;
+
+	shortcuts_add_close(scd);
+}
+
+static void shortcuts_add_cb(GtkWidget *button, gpointer data)
+{
+	ShortcutsData *scd = data;
+	GtkWidget *hbox;
+	const gchar *title;
+
+	if (scd->dialog)
+		{
+		gtk_window_present(GTK_WINDOW(GENERIC_DIALOG(scd->dialog)->dialog));
+		return;
+		}
+
+	title = _("Add Shortcut");
+	scd->dialog = file_util_file_dlg(title,
+					"add_shortcuts", button,
+					shortcuts_add_cancel_cb, scd);
+	file_dialog_add_button(scd->dialog, GTK_STOCK_OK, NULL, shortcuts_add_ok_cb, TRUE);
+
+	generic_dialog_add_message(GENERIC_DIALOG(scd->dialog), NULL, title, NULL);
+
+	file_dialog_add_path_widgets(scd->dialog, NULL, NULL, "add_shortcuts", NULL, NULL);
+
+	hbox = pref_box_new(GENERIC_DIALOG(scd->dialog)->vbox, FALSE, GTK_ORIENTATION_HORIZONTAL, PREF_PAD_GAP);
+
+	pref_label_new(hbox, _("Name:"));
+
+	scd->dialog_name_entry = gtk_entry_new();
+	gtk_box_pack_start(GTK_BOX(hbox), scd->dialog_name_entry, TRUE, TRUE, 0);
+	generic_dialog_attach_default(GENERIC_DIALOG(scd->dialog), scd->dialog_name_entry);
+	gtk_widget_show(scd->dialog_name_entry);
+
+	gtk_widget_show(GENERIC_DIALOG(scd->dialog)->dialog);
+}
+
+static void shortcuts_destroy(GtkWidget *widget, gpointer data)
+{
+	ShortcutsData *scd = data;
+
+	shortcuts_add_close(scd);
+
+	g_free(scd);
+}
+
+static void shortcuts_edit_button_free(gpointer data)
+{
+	g_free(data);
+}
+
+static GtkWidget *shortcuts_new(LayoutWindow *lw)
+{
+	ShortcutsData *scd;
+	GtkWidget *tbar;
+
+	if (!lw) return NULL;
+
+	scd = g_new0(ShortcutsData, 1);
+
+	scd->lw = lw;
+
+	scd->vbox = gtk_vbox_new(FALSE, PREF_PAD_GAP);
+	g_object_set_data(G_OBJECT(scd->vbox), "shortcuts_data", scd);
+	g_signal_connect(G_OBJECT(scd->vbox), "destroy",
+			G_CALLBACK(shortcuts_destroy), scd);
+
+	scd->bookmarks = bookmark_list_new(SHORTCUTS, shortcuts_bookmark_select, scd);
+	gtk_box_pack_start(GTK_BOX(scd->vbox), scd->bookmarks, TRUE, TRUE, 0);
+	gtk_widget_show(scd->bookmarks);
+
+	tbar = pref_toolbar_new(scd->vbox, GTK_TOOLBAR_ICONS);
+
+	scd->add_button = pref_toolbar_button(tbar, GTK_STOCK_ADD, NULL, FALSE,
+					_("Add Shortcut"),
+					G_CALLBACK(shortcuts_add_cb), scd);
+
+	return scd->vbox;
+}
+
+GtkWidget *shortcuts_new_from_config(LayoutWindow *lw, const gchar **attribute_names, const gchar **attribute_values)
+{
+	GtkWidget *shortcuts_bar;
+
+	shortcuts_bar = shortcuts_new(lw);
+	gtk_widget_show(shortcuts_bar);
+
+	return shortcuts_bar;
+}
+
+GtkWidget *shortcuts_new_default(LayoutWindow *lw)
+{
+	return shortcuts_new_from_config(lw, NULL, NULL);
+}
+
+/* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/shortcuts.h
+++ b/src/shortcuts.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2004 John Ellis
+ * Copyright (C) 2008 - 2016 The Geeqie Team
+ *
+ * Author: John Ellis
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef SHORTCUTS_H
+#define SHORTCUTS_H
+
+GtkWidget *shortcuts_new_default(LayoutWindow *lw);
+
+#endif
+/* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -606,6 +606,10 @@ struct _LayoutOptions
 	} float_window;
 
 	struct {
+		gint vdivider_pos;
+	} folder_window;
+
+	struct {
 		gint w;
 		gint h;
 	} properties_window;


### PR DESCRIPTION
Additional section in the folders pane to permit shortcuts (bookmarks) to
commonly used folders or images.

Shortcuts can be added using the "plus" symbol at the bottom of the pane, or drag-and-drop a folder (or image) onto the pane.
The pane can be hidden/revealed simply by dragging the vertical bar to/from the extreme left.
On the first-time run, the vertical divider will default to the far left.

Unfortunately I do not understand the design of Geeqie, and as a consequence the method of saving the position of the vertical divider is a real hack. Maybe someone can suggest a better way.

Even if there are no suggestions, maybe this could be put into the repository anyway. It works, and for me at least, it is a quick and easy way to get to working folders that are down a long chain.