### PR TITLE
Adds preliminary file clustering capability

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -144,6 +144,8 @@ geeqie_SOURCES = \
 	exiv2.cc	\
 	filecache.c	\
 	filecache.h	\
+	filecluster.c	\
+	filecluster.h	\
 	filedata.c	\
 	filedata.h	\
 	filefilter.c	\

--- a/src/filecluster.c
+++ b/src/filecluster.c
@@ -120,18 +120,30 @@ FileCluster *fileclusterlist_create_cluster(FileClusterList *fcl, GList *fd_item
 	return new_fc;
 }
 
+gboolean filecluster_has_head(FileCluster *fc, FileData *fd)
+{
+	if (!fd) return FALSE;
+	return filecluster_fd_equal(fc->head->data, fd);
+}
+
+gboolean filecluster_has_child(FileCluster *fc, FileData *fd)
+{
+	if (!fd) return FALSE;
+	return !filecluster_fd_equal(fc->head->data, fd);
+}
+
 gboolean fileclusterlist_has_head(FileClusterList *fcl, FileData *fd)
 {
 	FileCluster *fc = g_hash_table_lookup(fcl->clusters, fd);
 	if (!fc) return FALSE;
-	return filecluster_fd_equal(fc->head->data, fd);
+	return filecluster_has_head(fc, fd);
 }
 
 gboolean fileclusterlist_has_child(FileClusterList *fcl, FileData *fd)
 {
 	FileCluster *fc = g_hash_table_lookup(fcl->clusters, fd);
 	if (!fc) return FALSE;
-	return !filecluster_fd_equal(fc->head->data, fd);
+	return filecluster_has_child(fc, fd);
 }
 
 static gboolean fileclusterlist_should_hide(FileClusterList *fcl, FileData *fd)
@@ -141,7 +153,7 @@ static gboolean fileclusterlist_should_hide(FileClusterList *fcl, FileData *fd)
 	// Only difference vs. fileclusterlist_has_child.  Basically, if the node is a child, but
 	// we're showing children, then don't hide.
 	if (fc->show_children) return FALSE;
-	return !filecluster_fd_equal(fc->head->data, fd);
+	return filecluster_has_child(fc, fd);
 }
 
 // TODO(xsdg): pick a better name for this function

--- a/src/filecluster.c
+++ b/src/filecluster.c
@@ -124,22 +124,24 @@ gboolean fileclusterlist_has_head(FileClusterList *fcl, FileData *fd)
 {
 	FileCluster *fc = g_hash_table_lookup(fcl->clusters, fd);
 	if (!fc) return FALSE;
-	return fc->head->data == fd;
+	return filecluster_fd_equal(fc->head->data, fd);
 }
 
 gboolean fileclusterlist_has_child(FileClusterList *fcl, FileData *fd)
 {
 	FileCluster *fc = g_hash_table_lookup(fcl->clusters, fd);
 	if (!fc) return FALSE;
-	return fc->head->data != fd;
+	return !filecluster_fd_equal(fc->head->data, fd);
 }
 
 static gboolean fileclusterlist_should_hide(FileClusterList *fcl, FileData *fd)
 {
 	FileCluster *fc = g_hash_table_lookup(fcl->clusters, fd);
 	if (!fc) return FALSE;
-	if (fc->show_children) return FALSE;  // TODO(xsdg): new function "should_show"
-	return fc->head->data != fd;
+	// Only difference vs. fileclusterlist_has_child.  Basically, if the node is a child, but
+	// we're showing children, then don't hide.
+	if (fc->show_children) return FALSE;
+	return !filecluster_fd_equal(fc->head->data, fd);
 }
 
 // TODO(xsdg): pick a better name for this function

--- a/src/filecluster.c
+++ b/src/filecluster.c
@@ -62,12 +62,14 @@ FileClusterList *fileclusterlist_new()
 {
 	FileClusterList *fcl = g_new0(FileClusterList, 1);
 	fcl->clusters = g_hash_table_new(&filecluster_fd_hash, &filecluster_fd_equal);
+	return fcl;
 }
 
 FileCluster *filecluster_new()
 {
 	FileCluster *fc = g_new0(FileCluster, 1);
 	fc->show_children = FALSE;
+	return fc;
 }
 
 void fileclusterlist_free(FileClusterList *fcl)

--- a/src/filecluster.c
+++ b/src/filecluster.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2008 - 2016 The Geeqie Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "filecluster.h"
+
+static gboolean check_list_contains_sublist(GList *haystack, GList *needle)
+{
+	// TODO(xsdg): Optimize this!  Sort, then scan?
+	GList *h_work, *n_work;
+	for (n_work = needle; n_work; n_work = n_work->next)
+	{
+		gboolean found = FALSE;
+		for (h_work = haystack; h_work; h_work = h_work->next)
+		{
+			if (n_work == h_work)
+				{
+				found = TRUE;
+				break;
+				}
+		}
+
+		if (!found) return FALSE;
+	}
+
+	return TRUE;
+}
+
+FileClusterList *fileclusterlist_new()
+{
+	FileClusterList *fcl = g_new0(FileClusterList, 1);
+	fcl->clusters = g_hash_table_new(&g_direct_hash, &g_direct_equal);
+}
+
+FileCluster *filecluster_new()
+{
+	FileCluster *fc = g_new0(FileCluster, 1);
+}
+
+void fileclusterlist_free(FileClusterList *fcl)
+{
+	if (fcl->fd_list) g_list_free_full(fcl->fd_list, (GDestroyNotify)&filecluster_free);
+	g_hash_table_destroy(fcl->clusters);
+	g_free(fcl);
+}
+
+void filecluster_free(FileCluster *fc)
+{
+	g_free(fc);
+}
+
+FileCluster *fileclusterlist_create_cluster(FileClusterList *fcl, GList *fd_items)
+{
+	GList *work;
+	if (!fd_items) return NULL;
+	if (!check_list_contains_sublist(fcl->fd_list, fd_items)) return NULL;
+	for (work = fd_items; work; work = work->next)
+	{
+		FileData *fd = work->data;
+		if (g_hash_table_contains(fcl->clusters, fd)) return NULL;
+	}
+
+	FileCluster *new_fc = filecluster_new();
+	new_fc->items = g_list_copy(fd_items);
+	new_fc->head = new_fc->items;
+
+	return new_fc;
+}
+
+gboolean fileclusterlist_has_head(FileClusterList *fcl, FileData *fd)
+{
+	FileCluster *fc = g_hash_table_lookup(fcl->clusters, fd);
+	if (!fc) return FALSE;
+	return fc->head->data == fd;
+}
+
+gboolean fileclusterlist_has_child(FileClusterList *fcl, FileData *fd)
+{
+	FileCluster *fc = g_hash_table_lookup(fcl->clusters, fd);
+	if (!fc) return FALSE;
+	return fc->head->data != fd;
+}

--- a/src/filecluster.c
+++ b/src/filecluster.c
@@ -195,3 +195,5 @@ GList *fileclusterlist_remove_children_from_list(FileClusterList *fcl, GList *li
 
 	return list;
 }
+
+/* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/filecluster.h
+++ b/src/filecluster.h
@@ -21,12 +21,19 @@
 
 #include "main.h"
 
-FileClusterList *fileclusterlist_new();
+// FileCluster methods.
 FileCluster *filecluster_new();  // internal?
-void fileclusterlist_free(FileClusterList *fcl);
 void filecluster_free(FileCluster *fc);
 
 gboolean filecluster_toggle_show_children(FileCluster *fc);
+gboolean filecluster_has_head(FileCluster *fc, FileData *fd);
+gboolean filecluster_has_child(FileCluster *fc, FileData *fd);
+
+
+// FileClusterList methods.
+
+FileClusterList *fileclusterlist_new();
+void fileclusterlist_free(FileClusterList *fcl);
 
 // Creates a cluster with items that must already be in the cluster list.  Will fail (and make no
 // changes) if any of the specified items isn't in the list, or if any of the items is already

--- a/src/filecluster.h
+++ b/src/filecluster.h
@@ -34,5 +34,6 @@ FileCluster *fileclusterlist_create_cluster(FileClusterList *fcl, GList *fd_item
 gboolean fileclusterlist_has_head(FileClusterList *fcl, FileData *fd);
 gboolean fileclusterlist_has_child(FileClusterList *fcl, FileData *fd);
 
+GList *filecluster_remove_children_from_list(FileClusterList *fcl, GList *list);
 
 #endif  // FILECLUSTER_H

--- a/src/filecluster.h
+++ b/src/filecluster.h
@@ -26,6 +26,8 @@ FileCluster *filecluster_new();  // internal?
 void fileclusterlist_free(FileClusterList *fcl);
 void filecluster_free(FileCluster *fc);
 
+gboolean filecluster_toggle_show_children(FileCluster *fc);
+
 // Creates a cluster with items that must already be in the cluster list.  Will fail (and make no
 // changes) if any of the specified items isn't in the list, or if any of the items is already
 // part of a different cluster.
@@ -34,6 +36,7 @@ FileCluster *fileclusterlist_create_cluster(FileClusterList *fcl, GList *fd_item
 gboolean fileclusterlist_has_head(FileClusterList *fcl, FileData *fd);
 gboolean fileclusterlist_has_child(FileClusterList *fcl, FileData *fd);
 
-GList *filecluster_remove_children_from_list(FileClusterList *fcl, GList *list);
+GList *fileclusterlist_next_non_child(FileClusterList *fcl, GList *list);
+GList *fileclusterlist_remove_children_from_list(FileClusterList *fcl, GList *list);
 
 #endif  // FILECLUSTER_H

--- a/src/filecluster.h
+++ b/src/filecluster.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2008 - 2016 The Geeqie Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef FILECLUSTER_H
+#define FILECLUSTER_H
+
+#include "main.h"
+
+typedef struct _FileCluster FileCluster;
+typedef struct _FileClusterList FileClusterList;
+
+// A FileCluster is a GList with HashTable access to each node (to perform contains() checks quickly).
+struct _FileCluster
+{
+	GList *head;
+	GList *items;
+};
+
+struct _FileClusterList
+{
+	// All of the elements in the list, regardless of whether they're part of a cluster or not.
+	GList *fd_list;
+
+	// A map from any clustered FileData to the FileCluster object that describes the cluster.
+	GHashTable *clusters;
+};
+
+FileClusterList *fileclusterlist_new();
+FileCluster *filecluster_new();  // internal?
+void fileclusterlist_free(FileClusterList *fcl);
+void filecluster_free(FileCluster *fc);
+
+// Creates a cluster with items that must already be in the cluster list.  Will fail (and make no
+// changes) if any of the specified items isn't in the list, or if any of the items is already
+// part of a different cluster.
+FileCluster *fileclusterlist_create_cluster(FileClusterList *fcl, GList *fd_items);
+
+gboolean fileclusterlist_has_head(FileClusterList *fcl, FileData *fd);
+gboolean fileclusterlist_has_child(FileClusterList *fcl, FileData *fd);
+
+
+#endif  // FILECLUSTER_H

--- a/src/filecluster.h
+++ b/src/filecluster.h
@@ -47,3 +47,5 @@ GList *fileclusterlist_next_non_child(FileClusterList *fcl, GList *list);
 GList *fileclusterlist_remove_children_from_list(FileClusterList *fcl, GList *list);
 
 #endif  // FILECLUSTER_H
+
+/* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/filecluster.h
+++ b/src/filecluster.h
@@ -21,25 +21,6 @@
 
 #include "main.h"
 
-typedef struct _FileCluster FileCluster;
-typedef struct _FileClusterList FileClusterList;
-
-// A FileCluster is a GList with HashTable access to each node (to perform contains() checks quickly).
-struct _FileCluster
-{
-	GList *head;
-	GList *items;
-};
-
-struct _FileClusterList
-{
-	// All of the elements in the list, regardless of whether they're part of a cluster or not.
-	GList *fd_list;
-
-	// A map from any clustered FileData to the FileCluster object that describes the cluster.
-	GHashTable *clusters;
-};
-
 FileClusterList *fileclusterlist_new();
 FileCluster *filecluster_new();  // internal?
 void fileclusterlist_free(FileClusterList *fcl);

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -271,6 +271,9 @@ typedef struct _CollectWindow CollectWindow;
 
 typedef struct _ImageWindow ImageWindow;
 
+typedef struct _FileCluster FileCluster;
+typedef struct _FileClusterList FileClusterList;
+
 typedef struct _FileData FileData;
 typedef struct _FileDataChangeInfo FileDataChangeInfo;
 
@@ -527,6 +530,22 @@ struct _ImageWindow
 	gint user_stereo;
 
 	gboolean mouse_wheel_mode;
+};
+
+// A FileCluster is a GList with HashTable access to each node (to perform contains() checks quickly).
+struct _FileCluster
+{
+	GList *head;
+	GList *items;
+};
+
+struct _FileClusterList
+{
+	// All of the elements in the list, regardless of whether they're part of a cluster or not.
+	GList *fd_list;
+
+	// A map from any clustered FileData to the FileCluster object that describes the cluster.
+	GHashTable *clusters;
 };
 
 #define FILEDATA_MARKS_SIZE 6
@@ -843,6 +862,7 @@ struct _ViewFile
 
 	FileData *dir_fd;
 	GList *list;
+	FileClusterList *cluster_list;
 
 	SortType sort_method;
 	gboolean sort_ascend;

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -256,7 +256,9 @@ typedef enum {
 	SELECTION_NONE		= 0,
 	SELECTION_SELECTED	= 1 << 0,
 	SELECTION_PRELIGHT	= 1 << 1,
-	SELECTION_FOCUS		= 1 << 2
+	SELECTION_FOCUS		= 1 << 2,
+	SELECTION_CLUSTER_HEAD	= 1 << 3,
+	SELECTION_CLUSTER_CHILD = 1 << 4
 } SelectionType;
 
 typedef struct _ImageLoader ImageLoader;
@@ -537,13 +539,11 @@ struct _FileCluster
 {
 	GList *head;
 	GList *items;
+	gboolean show_children;
 };
 
 struct _FileClusterList
 {
-	// All of the elements in the list, regardless of whether they're part of a cluster or not.
-	GList *fd_list;
-
 	// A map from any clustered FileData to the FileCluster object that describes the cluster.
 	GHashTable *clusters;
 };

--- a/src/ui_tree_edit.c
+++ b/src/ui_tree_edit.c
@@ -496,6 +496,7 @@ gint tree_path_to_row(GtkTreePath *tpath)
 void shift_color(GdkColor *src, gshort val, gint direction)
 {
 	gshort cs;
+	static gshort COLOR_MAX = 0xffff;
 
 	if (val == -1)
 		{
@@ -505,11 +506,11 @@ void shift_color(GdkColor *src, gshort val, gint direction)
 		{
 		val = CLAMP(val, 1, 100);
 		}
-	cs = 0xffff / 100 * val;
+	cs = COLOR_MAX / 100 * val;
 
 	/* up or down ? */
 	if (direction < 0 ||
-	    (direction == 0 &&((gint)src->red + (gint)src->green + (gint)src->blue) / 3 > 0xffff / 2))
+	    (direction == 0 &&((gint)src->red + (gint)src->green + (gint)src->blue) / 3 > COLOR_MAX / 2))
 		{
 		src->red = MAX(0 , src->red - cs);
 		src->green = MAX(0 , src->green - cs);
@@ -517,9 +518,9 @@ void shift_color(GdkColor *src, gshort val, gint direction)
 		}
 	else
 		{
-		src->red = MIN(0xffff, src->red + cs);
-		src->green = MIN(0xffff, src->green + cs);
-		src->blue = MIN(0xffff, src->blue + cs);
+		src->red = MIN(COLOR_MAX, src->red + cs);
+		src->green = MIN(COLOR_MAX, src->green + cs);
+		src->blue = MIN(COLOR_MAX, src->blue + cs);
 		}
 }
 

--- a/src/view_file/view_file.c
+++ b/src/view_file/view_file.c
@@ -25,6 +25,7 @@
 #include "collect.h"
 #include "collect-table.h"
 #include "editors.h"
+#include "filecluster.h"
 #include "layout.h"
 #include "menu.h"
 #include "thumb.h"
@@ -673,6 +674,7 @@ static void vf_destroy_cb(GtkWidget *widget, gpointer data)
 		gtk_widget_destroy(vf->popup);
 		}
 
+	fileclusterlist_free(vf->cluster_list);
 	file_data_unref(vf->dir_fd);
 	g_free(vf->info);
 	g_free(vf);
@@ -729,6 +731,7 @@ ViewFile *vf_new(FileViewType type, FileData *dir_fd)
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(vf->scrolled),
 				       GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
 
+	vf->cluster_list = fileclusterlist_new();
 	vf->filter = vf_marks_filter_init(vf);
 
 	vf->widget = gtk_vbox_new(FALSE, 0);

--- a/src/view_file/view_file_icon.c
+++ b/src/view_file/view_file_icon.c
@@ -1267,7 +1267,6 @@ gboolean vficon_press_key_cb(GtkWidget *widget, GdkEventKey *event, gpointer dat
 					fc = fileclusterlist_create_cluster(vf->cluster_list, VFICON(vf)->selection);
 					if (fc)
 						{
-						// TODO(xsdg): set CLUSTER_CHILD
 						vficon_selection_add(vf, VFICON(vf)->selection->data, SELECTION_CLUSTER_HEAD, NULL);
 						vf_refresh(vf);
 						}
@@ -1293,7 +1292,18 @@ gboolean vficon_press_key_cb(GtkWidget *widget, GdkEventKey *event, gpointer dat
 				FileCluster *fc = g_hash_table_lookup(vf->cluster_list->clusters, fd);
 				if (fc)
 					{
-					filecluster_toggle_show_children(fc);
+					if (filecluster_toggle_show_children(fc))
+						{
+						for (GList *work = fc->items; work; work = work->next)
+							{
+							// TODO(xsdg): This is broken because the FileData pointer stored in the
+							// cluster is different from the one just added to vf->list, even though
+							// they are equivalent.
+							FileData *fd = work->data;
+							if (work == fc->head) continue;
+							vficon_selection_add(vf, fd, SELECTION_CLUSTER_CHILD, NULL);
+							}
+						}
 					vf_refresh(vf);
 					}
 				}

--- a/src/view_file/view_file_list.c
+++ b/src/view_file/view_file_list.c
@@ -1669,7 +1669,7 @@ gboolean vflist_refresh(ViewFile *vf)
 			}
 
 		vf->list = file_data_filter_marks_list(vf->list, vf_marks_get_filter(vf));
-		vf->list = filecluster_remove_children_from_list(vf->cluster_list, vf->list);
+		vf->list = fileclusterlist_remove_children_from_list(vf->cluster_list, vf->list);
 		file_data_register_notify_func(vf_notify_cb, vf, NOTIFY_PRIORITY_MEDIUM);
 
 		DEBUG_1("%s vflist_refresh: sort", get_exec_time());

--- a/src/view_file/view_file_list.c
+++ b/src/view_file/view_file_list.c
@@ -27,6 +27,7 @@
 #include "dnd.h"
 #include "editors.h"
 #include "img-view.h"
+#include "filecluster.h"
 #include "layout.h"
 #include "layout_image.h"
 #include "menu.h"
@@ -1668,6 +1669,7 @@ gboolean vflist_refresh(ViewFile *vf)
 			}
 
 		vf->list = file_data_filter_marks_list(vf->list, vf_marks_get_filter(vf));
+		vf->list = filecluster_remove_children_from_list(vf->cluster_list, vf->list);
 		file_data_register_notify_func(vf_notify_cb, vf, NOTIFY_PRIORITY_MEDIUM);
 
 		DEBUG_1("%s vflist_refresh: sort", get_exec_time());


### PR DESCRIPTION
What's here so far only works with ViewFileIcon.
To use:
 + Right-click on the FileList and switch to Icon view.
 + Select multiple icons.
 + Hit `<Insert>` to cluster them.
 + Hit `F2` on any element of a cluster to expand and collapse that cluster.

Next step is to add support for ViewFileList, and then to tie them into the larger style/keybinding system (instead of hard-coding things)