### PR TITLE
Permit reinstallation of symlink.

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -18,7 +18,7 @@ install-data-hook: html
 	if [ -x "$(GNOME_DOC_TOOL)" ]; then \
 		$(MKDIR_P) "$(DESTDIR)$(helpdir)" || exit 1; \
 		cd $(srcdir)/html; for f in * ; do $(INSTALL_DATA) "$$f" "$(DESTDIR)$(helpdir)/$$f" ; done; \
-		ln -s GuideIndex.html "$(DESTDIR)$(helpdir)/index.html" ; \
+		ln -s -f GuideIndex.html "$(DESTDIR)$(helpdir)/index.html" ; \
 	fi
 	
 uninstall-hook:


### PR DESCRIPTION
This uses ln -s -f so it can overwrite the destination,
rather than fail with EEXIST.