### PR TITLE
Fix spelling mistake occured/occurred

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -1975,7 +1975,7 @@ static void print_job_throw_error(PrintWindow *pw, const gchar *message)
 				parent, TRUE, NULL, NULL);
 	generic_dialog_add_button(gd, GTK_STOCK_OK, NULL, NULL, TRUE);
 
-	buf = g_strdup_printf(_("An error occured printing to %s."), print_output_name(pw->output));
+	buf = g_strdup_printf(_("An error occurred printing to %s."), print_output_name(pw->output));
 	generic_dialog_add_message(gd, GTK_STOCK_DIALOG_ERROR, _("Printing error"), buf, TRUE);
 	g_free(buf);
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -279,11 +279,11 @@ static RemoteConnection *remote_client_open(const gchar *path)
 	return rc;
 }
 
-static sig_atomic_t sigpipe_occured = FALSE;
+static sig_atomic_t sigpipe_occurred = FALSE;
 
 static void sighandler_sigpipe(gint sig)
 {
-	sigpipe_occured = TRUE;
+	sigpipe_occurred = TRUE;
 }
 
 static gboolean remote_client_send(RemoteConnection *rc, const gchar *text)
@@ -296,7 +296,7 @@ static gboolean remote_client_send(RemoteConnection *rc, const gchar *text)
 	if (!rc || rc->server) return FALSE;
 	if (!text) return TRUE;
 
-	sigpipe_occured = FALSE;
+	sigpipe_occurred = FALSE;
 
 	new_action.sa_handler = sighandler_sigpipe;
 	sigemptyset(&new_action.sa_mask);


### PR DESCRIPTION
Spelling error reported by the Debian Lintian tool - unfortunately this affects translations too.