### PR TITLE
Thumbnail all files if filtering is disabled.

### DIFF
--- a/src/thumb.c
+++ b/src/thumb.c
@@ -337,7 +337,7 @@ gboolean thumb_loader_start(ThumbLoader *tl, FileData *fd)
 
 	if (!tl->fd) tl->fd = file_data_ref(fd);
 
-	if (tl->fd->format_class != FORMAT_CLASS_IMAGE && tl->fd->format_class != FORMAT_CLASS_RAWIMAGE && tl->fd->format_class != FORMAT_CLASS_VIDEO)
+	if (tl->fd->format_class != FORMAT_CLASS_IMAGE && tl->fd->format_class != FORMAT_CLASS_RAWIMAGE && tl->fd->format_class != FORMAT_CLASS_VIDEO && !options->file_filter.disable)
 		{
 		thumb_loader_set_fallback(tl);
 		return FALSE;

--- a/src/thumb_standard.c
+++ b/src/thumb_standard.c
@@ -668,7 +668,7 @@ gboolean thumb_loader_std_start(ThumbLoaderStd *tl, FileData *fd)
 
 
 	tl->fd = file_data_ref(fd);
-	if (!stat_utf8(fd->path, &st) || (tl->fd->format_class != FORMAT_CLASS_IMAGE && tl->fd->format_class != FORMAT_CLASS_RAWIMAGE && tl->fd->format_class != FORMAT_CLASS_VIDEO))
+	if (!stat_utf8(fd->path, &st) || (tl->fd->format_class != FORMAT_CLASS_IMAGE && tl->fd->format_class != FORMAT_CLASS_RAWIMAGE && tl->fd->format_class != FORMAT_CLASS_VIDEO && !options->file_filter.disable))
 		{
 		thumb_loader_std_set_fallback(tl);
 		return FALSE;


### PR DESCRIPTION
If the user has disabled filtering by file extension, then we should
also disable that filtering when generating/loading thumbnails. Fixes
regression from 9be75e3431104d6a3a0c80324a8e3ac60316be13.