### PR TITLE
Fix crash after strange behaviour of the "Really Continue" dialog

### DIFF
--- a/src/ui_utildlg.c
+++ b/src/ui_utildlg.c
@@ -186,8 +186,15 @@ static gboolean generic_dialog_key_press_cb(GtkWidget *widget, GdkEventKey *even
 
 	if (event->keyval == GDK_KEY_Escape)
 		{
-		if (gd->cancel_cb) gd->cancel_cb(gd, gd->data);
-		else if (auto_close) generic_dialog_click_cb(widget, data);
+		if (gd->cancel_cb)
+			{
+			gd->cancel_cb(gd, gd->data);
+			if (auto_close) generic_dialog_close(gd);
+			}
+		else
+			{
+			if (auto_close) generic_dialog_click_cb(widget, data);
+			}
 		return TRUE;
 		}
 	return FALSE;


### PR DESCRIPTION
I got reports of a segfault in some cases when Copying files. To reproduce:

* Open Copy Files dialog to copy a file (for example) in home folder
* Select the same folder as target
* Choose Copy in the "Copy Files?" dialog

You get a "Really Continue" dialog - cancel this using Escape button.
"Copy Files" dialog reappears.
(You'll might notice that the dialog isn't closed, but still behind the new "Copy Files" dialog".)
Press Cancel in the "Copy Files" dialog.

Either the program crashes at once, or it takes some time.
This patch should fix it.

Closes #523.