### PR TITLE
layout_util: fix passing an rvalue to WEXITSTATUS

### DIFF
--- a/src/layout_util.c
+++ b/src/layout_util.c
@@ -477,6 +477,7 @@ static void layout_menu_write_rotate(GtkToggleAction *action, gpointer data, gbo
 	gint run_result;
 	GenericDialog *gd;
 	GString *message;
+	int cmdstatus;
 
 	if (!layout_valid(&lw)) return;
 
@@ -511,7 +512,8 @@ static void layout_menu_write_rotate(GtkToggleAction *action, gpointer data, gbo
 		rotation = g_strdup_printf("%d", fd_n->user_orientation);
 		command = g_strconcat(GQ_BIN_DIR, "/geeqie-rotate -r ", rotation,
 								keep_date ? " -t \"" : " \"", fd_n->path, "\"", NULL);
-		run_result = WEXITSTATUS(runcmd(command));
+		cmdstatus = runcmd(command);
+		run_result = WEXITSTATUS(cmdstatus);
 		if (!run_result)
 			{
 			fd_n->user_orientation = 0;


### PR DESCRIPTION
Fixes #588.

Looks like that bug can be fixed just by making sure the return value of `runcmd` is assigned to a variable before passing it to `WEXITSTATUS`.