### PR TITLE
Add awk shebang to geocode-parameters.awk

### DIFF
--- a/plugins/geocode-parameters/geocode-parameters.awk
+++ b/plugins/geocode-parameters/geocode-parameters.awk
@@ -1,3 +1,4 @@
+#!/usr/bin/awk -f
 #
 # This file is used by the Search option "search on geo-position".
 # It is used to decode the results of internet or other searches


### PR DESCRIPTION
The Debian lintian tools gives a warning for the geocode-parameters awk script missing a proper shebang.