### PR TITLE
Fix typo in GuideReferenceConfig.html

### DIFF
--- a/web/help/GuideReferenceConfig.html
+++ b/web/help/GuideReferenceConfig.html
@@ -462,7 +462,7 @@ dd.answer div.label { float: left; }
 </ul>
 <p class="para block block-first">The following data lists the locations Geeqie uses for various actions. The uppercase symbols are environment variables. If they are not set on your system the fallback locations are listed in parentheses.</p>
 <p class="para block">
-    Geqqie will first attempt to load a configuration file from:
+    Geeqie will first attempt to load a configuration file from:
     <div dir="ltr" class=" block programlisting block-indent block-first"><pre class="programlisting">/etc/geeqie/geeqierc.xml</pre></div>
   </p>
 <p class="para block">It will then continue with the following locations.</p>


### PR DESCRIPTION
Simple typo in GuideReferenceConfig.html
