### PR TITLE
Add export-jpeg to POTFILES.in

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,6 +1,7 @@
 geeqie.desktop.in
 plugins/import/geeqie-import-geeqie.desktop.in
 plugins/import/geeqie-import-gqview.desktop.in
+plugins/export-jpeg/export-jpeg.desktop.in
 plugins/rotate/rotate.desktop.in
 plugins/symlink/symlink.desktop.in
 plugins/ufraw/geeqie-ufraw.desktop.in


### PR DESCRIPTION
The Fix for Export in JPG causes a build error, since plugins/export-jpeg/export-jpeg.desktop.in isn't added to po/POTFILES.in - tail of my build log:

> Making check in po
> make[2]: Entering directory '/build/geeqie-1.4+git20181018/po'
> INTLTOOL_EXTRACT="/usr/bin/intltool-extract" XGETTEXT="/usr/bin/xgettext" srcdir=. /usr/bin/intltool-update --gettext-package geeqie --pot
> rm -f missing notexist
> srcdir=. /usr/bin/intltool-update -m
> The following files contain translations and are currently not in use. Please
> consider adding these to the POTFILES.in file, located in the po/ directory.
> 
> plugins/export-jpeg/export-jpeg.desktop.in
> 
> If some of these files are left out on purpose then please add them to
> POTFILES.skip instead of POTFILES.in. A file 'missing' containing this list
> of left out files has been written in the current directory.
> Please report to geeqie-devel@lists.sourceforge.net
> if [ -r missing -o -r notexist ]; then \
>   exit 1; \
> fi
> make[2]: *** [Makefile:263: check] Error 1
> make[2]: Leaving directory '/build/geeqie-1.4+git20181018/po'
> make[1]: *** [Makefile:674: check-recursive] Error 1
> make[1]: Leaving directory '/build/geeqie-1.4+git20181018'
> dh_auto_test: make -j1 check VERBOSE=1 returned exit code 2
> make: *** [debian/rules:4: binary] Error 2
> dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
> I: copying local configuration
> E: Failed autobuilding of package
> I: unmounting dev/ptmx filesystem
> I: unmounting dev/pts filesystem
> I: unmounting dev/shm filesystem
> I: unmounting proc filesystem
> I: unmounting sys filesystem
> I: Cleaning COW directory
> I: forking: rm -rf /var/cache/pbuilder/build/cow.7264
> gbp:error: 'git-pbuilder' failed: it exited with 1