### PR TITLE
Correctly size image windows opened from collections

### DIFF
--- a/src/img-view.c
+++ b/src/img-view.c
@@ -871,6 +871,9 @@ static ViewWindow *real_view_window_new(FileData *fd, GList *list, CollectionDat
 	if (cd && info)
 		{
 		image_change_from_collection(vw->imd, cd, info, image_zoom_get_default(NULL));
+		/* Grab the fd so we can correctly size the window in
+		   the call to image_load_dimensions() below. */
+		fd = info->fd;
 		if (options->image.enable_read_ahead)
 			{
 			CollectInfo * r_info = collection_next_by_info(cd, info);


### PR DESCRIPTION
When opening a view window from a collection, get the the image size
info from the file so the new window is appropriately sized.