### PR TITLE
Fix fullscreen spanning multiple monitors

### DIFF
--- a/src/fullscreen.c
+++ b/src/fullscreen.c
@@ -248,13 +248,6 @@ FullScreenData *fullscreen_start(GtkWidget *window, ImageWindow *imd,
 	gtk_window_set_decorated(GTK_WINDOW(fs->window), FALSE);
 	gtk_container_set_border_width(GTK_CONTAINER(fs->window), 0);
 
-	/* make window fullscreen -- let Gtk do it's job, don't screw it in any way */
-	gtk_window_fullscreen(GTK_WINDOW(fs->window));
-
-	/* move it to requested screen */
-	if (options->fullscreen.screen >= 0) {
-		gtk_window_set_screen(GTK_WINDOW(fs->window), screen);
-	}
 
 	/* keep window above others, if requested */
 	if (options->fullscreen.above) {
@@ -281,6 +274,22 @@ FullScreenData *fullscreen_start(GtkWidget *window, ImageWindow *imd,
 			GDK_HINT_WIN_GRAVITY | GDK_HINT_USER_POS | GDK_HINT_USER_SIZE);
 
 	gtk_widget_realize(fs->window);
+#if GTK_CHECK_VERSION(3,8,0)
+	if ((options->fullscreen.screen % 100) == 0) {
+		GdkWindow *gdkwin;
+		gdkwin = gtk_widget_get_window(fs->window);
+		if (gdkwin != NULL)
+			gdk_window_set_fullscreen_mode(gdkwin, GDK_FULLSCREEN_ON_ALL_MONITORS);
+	}
+#endif
+	/* make window fullscreen -- let Gtk do it's job, don't screw it in any way */
+	gtk_window_fullscreen(GTK_WINDOW(fs->window));
+
+	/* move it to requested screen */
+	if (options->fullscreen.screen >= 0) {
+		gtk_window_set_screen(GTK_WINDOW(fs->window), screen);
+
+	}
 
 	fs->imd = image_new(FALSE);
 


### PR DESCRIPTION
Commit a16635c ("Fix fullscreen - remove all the garbage
which breaks things and let Gtk do its job.")
broke fullscreen spanning multiple monitors.

Fix this for GTK3 by using gdk_window_set_fullscreen_mode().
Fixes #650.

Unfortunately, GTK2 has no equivalent.

Tested with kwin and icewm.
BTW, I found that in Icewm, selecting different monitors for fullscreen has no effect - with or without this patch. I'll try to debug that separately.