### PR TITLE
Bug fix: reads of uninitialized data

### DIFF
--- a/src/exif-common.c
+++ b/src/exif-common.c
@@ -885,7 +885,7 @@ static gchar *exif_build_formatted_countrycode(ExifData *exif)
 
 static gchar *exif_build_formatted_star_rating(ExifData *exif)
 {
-	gint n;
+	gint n = 0;
 
 	exif_get_integer(exif, "Xmp.xmp.Rating", &n);
 

--- a/src/view_dir_list.c
+++ b/src/view_dir_list.c
@@ -149,7 +149,7 @@ static gboolean vdlist_populate(ViewDir *vd, gboolean clear)
 	FileData *fd;
 	SortType sort_type = SORT_NAME;
 	gboolean sort_ascend = TRUE;
-	gchar *link;
+	gchar *link = NULL;
 
 	old_list = VDLIST(vd)->list;
 


### PR DESCRIPTION
There are a couple places where variables can be used without prior initialization.
`n` from `exif_build_formatted_star_rating()` is quite harmless, but `link` in `vdlist_populate()` being then passed to `free()` can cause a double-free, or a use-after-free.