### PR TITLE
src/options: fix build failure against gcc-10

### DIFF
--- a/src/bar_exif.h
+++ b/src/bar_exif.h
@@ -28,9 +28,6 @@ void bar_pane_exif_update_from_config(GtkWidget *pane, const gchar **attribute_n
 void bar_pane_exif_entry_add_from_config(GtkWidget *pane, const gchar **attribute_names, const gchar **attribute_values);
 
 /* these are exposed for when duplication of the exif bar's text is needed */
-
-const gchar **bar_exif_key_list;
-const gint bar_exif_key_count;
 GList *bar_pane_exif_list();
 
 #endif

--- a/src/options.c
+++ b/src/options.c
@@ -32,6 +32,9 @@
 #include "ui_fileops.h"
 #include "window.h"
 
+ConfOptions *options;
+CommandLine *command_line;
+
 ConfOptions *init_options(ConfOptions *options)
 {
 	gint i;

--- a/src/options.h
+++ b/src/options.h
@@ -326,8 +326,8 @@ struct _ConfOptions
 	GList *disabled_plugins;
 };
 
-ConfOptions *options;
-CommandLine *command_line;
+extern ConfOptions *options;
+extern CommandLine *command_line;
 
 ConfOptions *init_options(ConfOptions *options);
 void setup_default_options(ConfOptions *options);


### PR DESCRIPTION
On gcc-10 (and gcc-9 -fno-common) build fails as:

```
  CXXLD    geeqie
ld: ui_fileops.o:(.bss+0x0):
  multiple definition of `options'; ui_bookmark.o:(.bss+0x0): first defined here
ld: ui_fileops.o:(.bss+0x8):
  multiple definition of `command_line'; ui_bookmark.o:(.bss+0x8): first defined here
```

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.

Reported-by: Anthony Parsons
Bug: https://bugs.gentoo.org/706132