### PR TITLE
NetBSD fixes

### DIFF
--- a/gen_changelog.sh
+++ b/gen_changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Script to update ChangeLog file,
 # it keeps "pre-svn" history and inserts git log at top,

--- a/src/image_load_j2k.c
+++ b/src/image_load_j2k.c
@@ -25,7 +25,6 @@
 
 #include "misc.h"
 
-#include <sys/sysinfo.h>
 #ifdef HAVE_J2K
 #include "openjpeg.h"
 

--- a/src/layout_util.c
+++ b/src/layout_util.c
@@ -60,6 +60,7 @@
 #include "metadata.h"
 #include "desktop_file.h"
 
+#include <sys/wait.h>
 #include <gdk/gdkkeysyms.h> /* for keyboard values */
 #include "keymap_template.c"
 


### PR DESCRIPTION
`sys/sysinfo.h` does not exist on NetBSD, but nothing seems to be used from it.
(If it is useful on other system, please autodetect it, or wrap it in `#ifndef __NetBSD__`.)

`sh` is sufficient for `gen_changelog.sh` and `/bin/bash` does not exist on NetBSD (you can install it, but then it's in `/usr/pkg/bin/bash` by default).

`sys/wait.h` is needed to get the `WEXITSTATUS` symbol.