### PR TITLE
properly check return value of mmap

### DIFF
--- a/src/zonedetect.c
+++ b/src/zonedetect.c
@@ -503,7 +503,7 @@ ZoneDetect *ZDOpenDatabase(const char *path)
         lseek(library->fd, 0, SEEK_SET);
 
         library->mapping = mmap(NULL, (size_t)library->length, PROT_READ, MAP_PRIVATE | MAP_FILE, library->fd, 0);
-        if(!library->mapping) {
+        if(library->mapping == MAP_FAILED) {
             zdError(ZD_E_DB_MMAP, errno);
             goto fail;
         }


### PR DESCRIPTION
This check for the return value of the mmap function is wrong.

mmap returns MAP_FAILED (or -1) on errors, so the "if(!libary->mapping)" clause will never fail and the error code will not be called on failure of mmap.