### PR TITLE
Use gtk_label_set_[x,y]align instead of gtk_misc_set_alignment

### DIFF
--- a/src/advanced_exif.c
+++ b/src/advanced_exif.c
@@ -403,7 +403,8 @@ GtkWidget *advanced_exif_new(void)
 	ew->label_file_name = gtk_label_new("");
 	gtk_label_set_ellipsize(GTK_LABEL(ew->label_file_name), PANGO_ELLIPSIZE_START);
 	gtk_label_set_selectable(GTK_LABEL(ew->label_file_name), TRUE);
-	gtk_misc_set_alignment(GTK_MISC(ew->label_file_name), 0.5, 0.5);
+	gtk_label_set_xalign(GTK_LABEL(ew->label_file_name), 0.5);
+	gtk_label_set_yalign(GTK_LABEL(ew->label_file_name), 0.5);
 	gtk_box_pack_start(GTK_BOX(box), ew->label_file_name, TRUE, TRUE, 0);
 	gtk_widget_show(ew->label_file_name);
 

--- a/src/bar.c
+++ b/src/bar.c
@@ -706,7 +706,8 @@ GtkWidget *bar_new(LayoutWindow *lw)
 	bd->label_file_name = gtk_label_new("");
 	gtk_label_set_ellipsize(GTK_LABEL(bd->label_file_name), PANGO_ELLIPSIZE_END);
 	gtk_label_set_selectable(GTK_LABEL(bd->label_file_name), TRUE);
-	gtk_misc_set_alignment(GTK_MISC(bd->label_file_name), 0.5, 0.5);
+	gtk_label_set_xalign(GTK_LABEL(bd->label_file_name), 0.5);
+	gtk_label_set_yalign(GTK_LABEL(bd->label_file_name), 0.5);
 	gtk_box_pack_start(GTK_BOX(box), bd->label_file_name, TRUE, TRUE, 0);
 	gtk_widget_show(bd->label_file_name);
 

--- a/src/bar_exif.c
+++ b/src/bar_exif.c
@@ -132,7 +132,8 @@ static void bar_pane_exif_setup_entry_box(PaneExifData *ped, ExifEntry *ee)
 	gtk_widget_show(ee->box);
 
 	ee->title_label = gtk_label_new(NULL);
-	gtk_misc_set_alignment(GTK_MISC(ee->title_label), horizontal ? 1.0 : 0.0, 0.5);
+	gtk_label_set_xalign(GTK_LABEL(ee->title_label), horizontal ? 1.0 : 0.0);
+	gtk_label_set_yalign(GTK_LABEL(ee->title_label), 0.5);
 	gtk_size_group_add_widget(ped->size_group, ee->title_label);
 	gtk_box_pack_start(GTK_BOX(ee->box), ee->title_label, FALSE, TRUE, 0);
 	gtk_widget_show(ee->title_label);
@@ -150,7 +151,8 @@ static void bar_pane_exif_setup_entry_box(PaneExifData *ped, ExifEntry *ee)
 //		gtk_label_set_width_chars(GTK_LABEL(ee->value_widget), 20);
 		gtk_label_set_ellipsize(GTK_LABEL(ee->value_widget), PANGO_ELLIPSIZE_END);
 //		gtk_widget_set_size_request(ee->value_widget, 100, -1);
-		gtk_misc_set_alignment(GTK_MISC(ee->value_widget), 0.0, 0.5);
+		gtk_label_set_xalign(GTK_LABEL(ee->value_widget), 0.0);
+		gtk_label_set_yalign(GTK_LABEL(ee->value_widget), 0.5);
 		}
 
 	gtk_box_pack_start(GTK_BOX(ee->box), ee->value_widget, TRUE, TRUE, 1);

--- a/src/cache_maint.c
+++ b/src/cache_maint.c
@@ -1197,7 +1197,8 @@ static GtkWidget *cache_manager_location_label(GtkWidget *group, const gchar *su
 	buf = g_strdup_printf(_("Location: %s"), subdir);
 	label = pref_label_new(group, buf);
 	g_free(buf);
-	gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
+	gtk_label_set_xalign(GTK_LABEL(label), 0.0);
+	gtk_label_set_yalign(GTK_LABEL(label), 0.5);
 
 	return label;
 }

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -2667,7 +2667,8 @@ static void config_tab_metadata(GtkWidget *notebook)
 	label = pref_label_new(group, _("Warning: Geeqie is built without Exiv2. Some options are disabled."));
 #endif
 	label = pref_label_new(group, _("Metadata are written in the following order. The process ends after first success."));
-	gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
+	gtk_label_set_xalign(GTK_LABEL(label), 0.0);
+	gtk_label_set_yalign(GTK_LABEL(label), 0.5);
 
 	ct_button = pref_checkbox_new_int(group, _("1) Save metadata in image files, or sidecar files, according to the XMP standard"),
 			      options->metadata.save_in_image_file, &c_options->metadata.save_in_image_file);
@@ -2680,7 +2681,8 @@ static void config_tab_metadata(GtkWidget *notebook)
 
 	text = g_strdup_printf(_("3) Save metadata in Geeqie private directory '%s'"), get_metadata_cache_dir());
 	label = pref_label_new(group, text);
-	gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
+	gtk_label_set_xalign(GTK_LABEL(label), 0.0);
+	gtk_label_set_yalign(GTK_LABEL(label), 0.5);
 	gtk_misc_set_padding(GTK_MISC(label), 22, 0);
 	g_free(text);
 

--- a/src/ui_misc.c
+++ b/src/ui_misc.c
@@ -89,7 +89,8 @@ GtkWidget *pref_group_new(GtkWidget *parent_box, gboolean fill,
 	gtk_widget_show(vbox);
 
 	label = gtk_label_new(text);
-	gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
+	gtk_label_set_xalign(GTK_LABEL(label), 0.0);
+	gtk_label_set_yalign(GTK_LABEL(label), 0.5);
 	pref_label_bold(label, TRUE, FALSE);
 
 	gtk_box_pack_start(GTK_BOX(vbox), label, FALSE, FALSE, 0);
@@ -265,7 +266,8 @@ GtkWidget *pref_button_new(GtkWidget *parent_box, const gchar *stock_id,
 		if (text)
 			{
 			label = gtk_label_new_with_mnemonic(text);
-			gtk_misc_set_alignment(GTK_MISC(label), 0.5, 0.5);
+			gtk_label_set_xalign(GTK_LABEL(label), 0.5);
+			gtk_label_set_yalign(GTK_LABEL(label), 0.5);
 			gtk_label_set_mnemonic_widget(GTK_LABEL(label), button);
 			}
 

--- a/src/ui_utildlg.c
+++ b/src/ui_utildlg.c
@@ -309,12 +309,14 @@ GtkWidget *generic_dialog_add_message(GenericDialog *gd, const gchar *icon_stock
 		{
 		label = pref_label_new(vbox, heading);
 		pref_label_bold(label, TRUE, TRUE);
-		gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
+		gtk_label_set_xalign(GTK_LABEL(label), 0.0);
+		gtk_label_set_yalign(GTK_LABEL(label), 0.5);
 		}
 	if (text)
 		{
 		label = pref_label_new(vbox, text);
-		gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
+		gtk_label_set_xalign(GTK_LABEL(label), 0.0);
+		gtk_label_set_yalign(GTK_LABEL(label), 0.5);
 		gtk_label_set_line_wrap(GTK_LABEL(label), TRUE);
 		}
 

--- a/src/utilops.c
+++ b/src/utilops.c
@@ -98,7 +98,8 @@ static void generic_dialog_add_image(GenericDialog *gd, GtkWidget *box,
 
 		head = pref_label_new(vbox, header1);
 		pref_label_bold(head, TRUE, FALSE);
-		gtk_misc_set_alignment(GTK_MISC(head), 0.0, 0.5);
+		gtk_label_set_xalign(GTK_LABEL(head), 0.0);
+		gtk_label_set_yalign(GTK_LABEL(head), 0.5);
 		}
 
 	imd = image_new(FALSE);
@@ -130,7 +131,8 @@ static void generic_dialog_add_image(GenericDialog *gd, GtkWidget *box,
 
 			head = pref_label_new(vbox, header2);
 			pref_label_bold(head, TRUE, FALSE);
-			gtk_misc_set_alignment(GTK_MISC(head), 0.0, 0.5);
+			gtk_label_set_xalign(GTK_LABEL(head), 0.0);
+			gtk_label_set_yalign(GTK_LABEL(head), 0.5);
 			}
 
 		imd = image_new(FALSE);
@@ -1491,7 +1493,8 @@ static void box_append_safe_delete_status(GenericDialog *gd)
 	label = pref_label_new(gd->vbox, buf);
 	g_free(buf);
 
-	gtk_misc_set_alignment(GTK_MISC(label), 1.0, 0.5);
+	gtk_label_set_xalign(GTK_LABEL(label), 1.0);
+	gtk_label_set_yalign(GTK_LABEL(label), 0.5);
 	gtk_widget_set_sensitive(label, FALSE);
 }
 
@@ -1592,7 +1595,8 @@ static void file_util_dialog_init_dest_folder(UtilityData *ud)
 	generic_dialog_add_message(GENERIC_DIALOG(fdlg), NULL, ud->messages.question, NULL, FALSE);
 
 	label = pref_label_new(GENERIC_DIALOG(fdlg)->vbox, _("Choose the destination folder."));
-	gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.5);
+	gtk_label_set_xalign(GTK_LABEL(label), 0.0);
+	gtk_label_set_yalign(GTK_LABEL(label), 0.5);
 	pref_spacer(GENERIC_DIALOG(fdlg)->vbox, 0);
 
 	if (options->with_rename)
@@ -2105,7 +2109,8 @@ static void file_util_write_metadata_details_dialog(UtilityData *ud, FileData *f
 
 
 		label = gtk_label_new(title_f);
-		gtk_misc_set_alignment(GTK_MISC(label), 1.0, 0.0);
+		gtk_label_set_xalign(GTK_LABEL(label), 1.0);
+		gtk_label_set_yalign(GTK_LABEL(label), 0.0);
 		pref_label_bold(label, TRUE, FALSE);
 		gtk_table_attach(GTK_TABLE(table), label,
 				 0, 1, i, i + 1,
@@ -2115,7 +2120,8 @@ static void file_util_write_metadata_details_dialog(UtilityData *ud, FileData *f
 
 		label = gtk_label_new(value);
 
-		gtk_misc_set_alignment(GTK_MISC(label), 0.0, 0.0);
+		gtk_label_set_xalign(GTK_LABEL(label), 0.0);
+		gtk_label_set_yalign(GTK_LABEL(label), 0.0);
 		gtk_label_set_line_wrap(GTK_LABEL(label), TRUE);
 		gtk_table_attach(GTK_TABLE(table), label,
 				 1, 2, i, i + 1,

--- a/src/window.c
+++ b/src/window.c
@@ -377,10 +377,12 @@ void help_search_window_show()
 				  help_search_window_ok_cb, TRUE);
 
 	label1 = pref_label_new(GENERIC_DIALOG(gd)->vbox, _("Search engine:"));
-	gtk_misc_set_alignment(GTK_MISC(label1), 0.0, 0.5);
+	gtk_label_set_xalign(GTK_LABEL(label1), 0.0);
+	gtk_label_set_yalign(GTK_LABEL(label1), 0.5);
 
 	label2 = pref_label_new(GENERIC_DIALOG(gd)->vbox, options->help_search_engine);
-	gtk_misc_set_alignment(GTK_MISC(label2), 0.0, 0.5);
+	gtk_label_set_xalign(GTK_LABEL(label2), 0.0);
+	gtk_label_set_yalign(GTK_LABEL(label2), 0.5);
 	pref_spacer(GENERIC_DIALOG(gd)->vbox, 0);
 
 	table = pref_table_new(gd->vbox, 3, 1, FALSE, TRUE);


### PR DESCRIPTION
Fixes some of the warnings during build. There's still one gtk_misc_set_alignment used for a GtkImage left where another method need to be used. 