### PR TITLE
Copy image to clipboard menu action

### DIFF
--- a/src/layout_image.c
+++ b/src/layout_image.c
@@ -583,6 +583,17 @@ static void li_pop_menu_copy_path_unquoted_cb(GtkWidget *widget, gpointer data)
 	file_util_copy_path_to_clipboard(layout_image_get_fd(lw), FALSE);
 }
 
+static void li_pop_menu_copy_image_cb(GtkWidget *widget, gpointer data)
+{
+	LayoutWindow *lw = data;
+	ImageWindow *imd = lw->image;
+
+	GdkPixbuf *pixbuf;
+	pixbuf = image_get_pixbuf(imd);
+	if (!pixbuf) return;
+	gtk_clipboard_set_image(gtk_clipboard_get(GDK_SELECTION_CLIPBOARD), pixbuf);
+}
+
 static void li_pop_menu_move_cb(GtkWidget *widget, gpointer data)
 {
 	LayoutWindow *lw = data;
@@ -773,6 +784,7 @@ static GtkWidget *layout_image_pop_menu(LayoutWindow *lw)
 	if (!path) gtk_widget_set_sensitive(item, FALSE);
 	item = menu_item_add(menu, _("_Copy path"), G_CALLBACK(li_pop_menu_copy_path_cb), lw);
 	item = menu_item_add(menu, _("_Copy path unquoted"), G_CALLBACK(li_pop_menu_copy_path_unquoted_cb), lw);
+	item = menu_item_add(menu, _("Copy _image"), G_CALLBACK(li_pop_menu_copy_image_cb), lw);
 	if (!path) gtk_widget_set_sensitive(item, FALSE);
 	menu_item_add_divider(menu);
 


### PR DESCRIPTION
Both chrome and firefox have a "Copy Image" pop-up menu item on images that copies image _content_ to clipboard. A surprising number of modern programs accepts image pastes, ranging from image editors like the Gimp to virtually all messaging UIs, including web-based ones. After getting used to that convenience, I miss the Copy Image feature in geeqie.

This PR uses GTK's [built-in functionality](https://developer.gnome.org/gtk3/stable/gtk3-Clipboards.html#gtk-clipboard-set-image) to implement the copy in very few LOCs (I was surprised with how simple it was).