### PR TITLE
Add content to the generic dialogs window

### DIFF
--- a/src/ui_utildlg.c
+++ b/src/ui_utildlg.c
@@ -467,6 +467,7 @@ static void generic_dialog_setup(GenericDialog *gd,
 	gtk_widget_show(scrolled);
 #else
 	vbox = gtk_vbox_new(FALSE, PREF_PAD_BUTTON_SPACE);
+	gtk_container_add(GTK_CONTAINER(gd->dialog), vbox);
 #endif
 	gtk_widget_show(vbox);
 


### PR DESCRIPTION
In case an older GTK version is used the function generic_dialog_setup()
did not add it's content to the dialog window.