### PR TITLE
Fix building whereami on Hurd/kFreeBSD

### DIFF
--- a/src/whereami.c
+++ b/src/whereami.c
@@ -3,6 +3,10 @@
 //   by Gregory Pakosz (@gpakosz)
 // https://github.com/gpakosz/whereami
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 // in case you want to #include "whereami.c" in a larger compilation unit
 #if !defined(WHEREAMI_H)
 #include <whereami.h>
@@ -160,7 +164,7 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
   return length;
 }
 
-#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun) || defined(WAI_USE_PROC_SELF_EXE)
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun) || defined(__GNU__) || defined(WAI_USE_PROC_SELF_EXE)
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -181,6 +185,10 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 #else
 #define WAI_PROC_SELF_EXE "/proc/self/exe"
 #endif
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
 #endif
 
 WAI_FUNCSPEC


### PR DESCRIPTION
Fixes building geeqie and it's embedded whereami on Hurd (and also kFreeBSD) - One option would be to not embed it in geeqie, but use distros provided packages, where this patch is already applied - at least in Debian it is available:

https://packages.debian.org/sid/libwhereami0

https://salsa.debian.org/yangfl-guest/whereami/-/blob/master/debian/patches/0001-added-support-for-kFreeBSD-and-GNU-Hurd.patch

