### PR TITLE
Update links from http: to https: where possible

### DIFF
--- a/CODING.md
+++ b/CODING.md
@@ -77,7 +77,7 @@ If referencing a Geeqie GitHub issue, include the issue number in the summary li
 
 Use whole sentences beginning with Capital letter. For each modification use a new line. Or you can write the theme, colon and then every change on new line, begin with "- ".
 
-See also [A Note About Git Commit Messages](http://www.tpope.net/node/106)
+See also [A Note About Git Commit Messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ open an issue on [Geeqie at GitHub](https://github.com/BestImageViewer/geeqie/is
 
 Subscribe to the mailing list [here](https://www.freelists.org/list/geeqie).
 
-The project website is <http://www.geeqie.org/> and you will find the latest sources in the
+The project website is <https://www.geeqie.org/> and you will find the latest sources in the
 [Geeqie repository](http://geeqie.org/cgi-bin/gitweb.cgi?p=geeqie.git).
 
 # README contents:
@@ -99,7 +99,7 @@ Geeqie is a graphics file viewer. Basic features:
 * Geeqie includes a 'find duplicates' tool which can compare images using a variety of criteria (filename, file size, visual similarity, dimensions, image content), either within a single folder or between two folders. Finding duplicates ignoring the rotation of images is also supported.
 * Images may be given a rating value (also known as a "star rating").
 
-* Maps from [OpenStreetMap](http://www.openstreetmap.org) may be displayed in a side panel. If an image has GPS coordinates embedded, its position will be displayed on the map - if Image Direction is encoded, that will be displayed also. If an image does not have embedded GPS coordinates, it may be dragged-and-dropped onto the map to encode its position.
+* Maps from [OpenStreetMap](https://www.openstreetmap.org) may be displayed in a side panel. If an image has GPS coordinates embedded, its position will be displayed on the map - if Image Direction is encoded, that will be displayed also. If an image does not have embedded GPS coordinates, it may be dragged-and-dropped onto the map to encode its position.
 
 * Speed of operation can be increased by caching thumbnails and similarity data of images. When Geeqie is run as a stand-alone command line program (`geeqie --cache-maintenance <path>`) these data will be recursively created from the defined start point. This program can be called from `cron` or `anacron` so that cache updating is automatically done at specified intervals.
 
@@ -131,9 +131,7 @@ To get the script, from the command line type:<br/><br/>
 
 If you wish to compile the sources yourself you may download the latest version (if you have installed git) from here:
 
-Either: `git clone git://www.geeqie.org/geeqie.git`
-
-Or: `git clone http://www.geeqie.org/git/geeqie.git`
+`git clone git://www.geeqie.org/geeqie.git`
 
 ## Manual Installation
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.  -*- Autoconf
  -*-
 
-dnl This file is a part of Geeqie project (http://www.geeqie.org/).
+dnl This file is a part of Geeqie project (https://www.geeqie.org/).
 dnl Copyright (C) 2008 - 2018 The Geeqie Team
 dnl
 dnl This program is free software; you can redistribute it and/or modify
@@ -15,7 +15,7 @@ dnl MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 dnl GNU General Public License for more details.
 
 AC_PREREQ(2.57)
-AC_INIT([geeqie], m4_translit(m4_esyscmd([if [ $(git tag --list 'v[1-9]*' --points-at HEAD | wc -c) -gt 0 ]; then git tag --list v[1-9]* --points-at HEAD | tail -n 1 | tr -d 'v' ; else git tag --list v[1-9]* | tail -n 1 | tr -d 'v' && echo "+git" && git log --max-count=1 --date=format:"%Y%m%d" --format="%ad" && echo "-" && git rev-parse --quiet --verify --short HEAD; fi ]), m4_newline), [geeqie@freelists.org], [], [http://www.geeqie.org/])
+AC_INIT([geeqie], m4_translit(m4_esyscmd([if [ $(git tag --list 'v[1-9]*' --points-at HEAD | wc -c) -gt 0 ]; then git tag --list v[1-9]* --points-at HEAD | tail -n 1 | tr -d 'v' ; else git tag --list v[1-9]* | tail -n 1 | tr -d 'v' && echo "+git" && git log --max-count=1 --date=format:"%Y%m%d" --format="%ad" && echo "-" && git rev-parse --quiet --verify --short HEAD; fi ]), m4_newline), [geeqie@freelists.org], [], [https://www.geeqie.org/])
 
 # Add -Werror to the default CFLAGS
 CFLAGS+=" -Werror -Wno-error=deprecated-declarations -Wno-error=sign-compare -Wno-error=return-type"
@@ -789,7 +789,7 @@ AH_TOP([
  */
 
 /*
- *  This file is a part of Geeqie project (http://www.geeqie.org/).
+ *  This file is a part of Geeqie project (https://www.geeqie.org/).
  *  Copyright (C) 2008 - 2016 The Geeqie Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/doc/docbook/GuideIndex.xml
+++ b/doc/docbook/GuideIndex.xml
@@ -55,7 +55,7 @@
       </para>
       <para>
         Website:
-        <ulink url="http://geeqie.org">geeqie.org</ulink>
+        <ulink url="https://geeqie.org/">geeqie.org</ulink>
       </para>
     </legalnotice>
   </bookinfo>

--- a/doc/docbook/GuideReferenceLIRC.xml
+++ b/doc/docbook/GuideReferenceLIRC.xml
@@ -6,7 +6,7 @@
   <para>If you are using a pre-compiled distribution, availability depends on the package maintainer.</para>
   <para>
     The website
-    <ulink url="http://www.lirc.org">Linux Infrared Remote Control</ulink>
+    <ulink url="https://www.lirc.org">Linux Infrared Remote Control</ulink>
     has detailed information on this subject.
   </para>
   <para>

--- a/doc/docbook/GuideReferenceStandards.xml
+++ b/doc/docbook/GuideReferenceStandards.xml
@@ -7,7 +7,7 @@
   </para>
   <para>
     Desktop files:
-    <ulink url="http://standards.freedesktop.org/desktop-entry-spec/">http://standards.freedesktop.org/desktop-entry-spec/</ulink>
+    <ulink url="https://standards.freedesktop.org/desktop-entry-spec/">https://standards.freedesktop.org/desktop-entry-spec/</ulink>
   </para>
   <para>
     XMP:

--- a/geeqie.spec.in
+++ b/geeqie.spec.in
@@ -34,7 +34,7 @@ License:        GNU General Public License version 2 or later (GPL v2 or later)
 Group:          Productivity/Graphics/Viewers
 Source:         geeqie-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-URL:            http://www.geeqie.org/
+URL:            https://www.geeqie.org/
 #
 # these are requirements of the plugins
 Requires: exiv2 exiftran ImageMagick ufraw

--- a/org.geeqie.Geeqie.appdata.xml.in
+++ b/org.geeqie.Geeqie.appdata.xml.in
@@ -16,10 +16,10 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image>http://cclark.uk/geeqie/screenshots/Screenshot_2017-08-13_12-02-32_rescaled.png</image>
+      <image>https://cclark.uk/geeqie/screenshots/Screenshot_2017-08-13_12-02-32_rescaled.png</image>
     </screenshot>
     <screenshot>
-      <image>http://cclark.uk/geeqie/screenshots/Screenshot_2017-08-13_12-29-44_rescaled.png</image>
+      <image>https://cclark.uk/geeqie/screenshots/Screenshot_2017-08-13_12-29-44_rescaled.png</image>
     </screenshot>
   </screenshots>
   <releases>
@@ -31,7 +31,7 @@
     <keyword>fast</keyword>
     <keyword>graphics</keyword>
   </keywords>
-  <url type="homepage">http://geeqie.org</url>
+  <url type="homepage">https://geeqie.org</url>
   <update_contact>geeqie@freelists.org</update_contact>
   <translation type="gettext">geeqie</translation>
 </component>

--- a/plugins/geocode-parameters/geocode-parameters.awk
+++ b/plugins/geocode-parameters/geocode-parameters.awk
@@ -40,13 +40,13 @@ function check_parameters(latitude, longitude)
 #
 # Search the input string for known formats.
 {
-if (index($0, "http://www.geonames.org/maps/google_"))
+if (index($0, "https://www.geonames.org/maps/google_"))
     {
     # This is a drag-and-drop or copy-paste from a geonames.org search
     # in the format e.g.
-    # http://www.geonames.org/maps/google_51.513_-0.092.html
+    # https://www.geonames.org/maps/google_51.513_-0.092.html
 
-    gsub(/http:\/\/www.geonames.org\/maps\/google_/, "")
+    gsub(/https:\/\/www.geonames.org\/maps\/google_/, "")
     gsub(/.html/, "")
     gsub(/_/, " ")
     print check_parameters($1, $2)

--- a/scripts/zonedetect/create_timezone_database
+++ b/scripts/zonedetect/create_timezone_database
@@ -71,7 +71,7 @@ cd ..
 
 mkdir geeqie_org
 cd geeqie_org
-wget http://www.geeqie.org/downloads/timezone21.bin
+wget https://www.geeqie.org/downloads/timezone21.bin
 if [ "$?" -ne 0 ]
 then
 	zenity --error --text="Download of timezone database from geeqie.org failed" --title="Generate Geeqie timezone database" --width=300 --window-icon="$current_dir/../../geeqie.png"

--- a/src/exif.c
+++ b/src/exif.c
@@ -316,7 +316,7 @@ static ExifTextList ExifSubjectRangeList[] = {
 };
 
 /*
-Tag names should match to exiv2 keys, http://www.exiv2.org/metadata.html
+Tag names should match to exiv2 keys, https://www.exiv2.org/metadata.html
 Tags that don't match are not supported by exiv2 and should not be used anywhere in the code
 */
 

--- a/src/image-load.c
+++ b/src/image-load.c
@@ -581,8 +581,8 @@ static void image_loader_area_prepared_cb(gpointer loader, gpointer data)
 	size_t h, rs;
 
 	/* a workaround for
-	   http://bugzilla.gnome.org/show_bug.cgi?id=547669
-	   http://bugzilla.gnome.org/show_bug.cgi?id=589334
+	   https://bugzilla.gnome.org/show_bug.cgi?id=547669
+	   https://bugzilla.gnome.org/show_bug.cgi?id=589334
 	*/
 	gchar *format = il->backend.get_format_name(loader);
 	if (strcmp(format, "svg") == 0 ||

--- a/src/main.h
+++ b/src/main.h
@@ -77,7 +77,7 @@
 
 #define GQ_APPNAME "Geeqie"
 #define GQ_APPNAME_LC "geeqie"
-#define GQ_WEBSITE "http://www.geeqie.org/"
+#define GQ_WEBSITE "https://www.geeqie.org/"
 #define GQ_EMAIL_ADDRESS "geeqie@freelists.org"
 
 #define GQ_RC_DIR		"." GQ_APPNAME_LC

--- a/src/pixbuf-renderer.c
+++ b/src/pixbuf-renderer.c
@@ -2041,7 +2041,7 @@ static gboolean pr_mouse_motion_cb(GtkWidget *widget, GdkEventMotion *event, gpo
 #endif
 
 	/* This is a hack, but work far the best, at least for single pointer systems.
-	 * See http://bugzilla.gnome.org/show_bug.cgi?id=587714 for more. */
+	 * See https://bugzilla.gnome.org/show_bug.cgi?id=587714 for more. */
 	gint x, y;
 #if GTK_CHECK_VERSION(3,0,0)
 	device_manager = gdk_display_get_device_manager(gdk_window_get_display(event->window));
@@ -2098,7 +2098,7 @@ static gboolean pr_mouse_motion_cb(GtkWidget *widget, GdkEventMotion *event, gpo
 
 	/* This is recommended by the GTK+ documentation, but does not work properly.
 	 * Use deprecated way until GTK+ gets a solution for correct motion hint handling:
-	 * http://bugzilla.gnome.org/show_bug.cgi?id=587714
+	 * https://bugzilla.gnome.org/show_bug.cgi?id=587714
 	 */
 	/* gdk_event_request_motions (event); */
 	return FALSE;

--- a/src/window.c
+++ b/src/window.c
@@ -251,11 +251,11 @@ void help_window_show(const gchar *key)
 			{
 			if (g_strcmp0(key, "index.html") == 0)
 				{
-				path = g_build_filename("http://geeqie.org/help/", "GuideIndex.html", NULL);
+				path = g_build_filename("https://geeqie.org/help/", "GuideIndex.html", NULL);
 				}
 			else
 				{
-				path = g_build_filename("http://geeqie.org/help/", key, NULL);
+				path = g_build_filename("https://geeqie.org/help/", key, NULL);
 				}
 			}
 		help_browser_run(path);

--- a/web/help/GuideIndex-info.html
+++ b/web/help/GuideIndex-info.html
@@ -478,7 +478,7 @@ dd.answer div.label { float: left; }
       </p>
       <p class="para block">
         Website:
-        <a class="ulink" href="http://geeqie.org" title="http://geeqie.org">geeqie.org</a>
+        <a class="ulink" href="https://geeqie.org" title="https://geeqie.org">geeqie.org</a>
       </p>
     </div>
 <div class="division revhistory">

--- a/web/help/GuideReferenceStandards.html
+++ b/web/help/GuideReferenceStandards.html
@@ -466,11 +466,11 @@ dd.answer div.label { float: left; }
   </p>
 <p class="para block">
     Desktop files:
-    <a class="ulink" href="http://standards.freedesktop.org/desktop-entry-spec/" title="http://standards.freedesktop.org/desktop-entry-spec/">http://standards.freedesktop.org/desktop-entry-spec/</a>
+    <a class="ulink" href="https://standards.freedesktop.org/desktop-entry-spec/" title="https://standards.freedesktop.org/desktop-entry-spec/">https://standards.freedesktop.org/desktop-entry-spec/</a>
   </p>
 <p class="para block">
     XMP:
-    <a class="ulink" href="http://www.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMPSpecificationPart3.pdf" title="http://www.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMPSpecificationPart3.pdf">http://www.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMPSpecificationPart3.pdf</a>
+    <a class="ulink" href="https://www.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMPSpecificationPart3.pdf" title="https://www.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMPSpecificationPart3.pdf">https://www.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMPSpecificationPart3.pdf</a>
   </p>
 <p class="para block">
     IPTC4XMP:

--- a/web/index.html
+++ b/web/index.html
@@ -88,7 +88,7 @@
         <a href="/cgi-bin/gitweb.cgi?p=geeqie.git">Geeqie repository.</a></p>Geeqie is stable, there
         are frequent updates, and compiling is a quick and painless task. The instructions for <a href=
         "installing.html">downloading and installing</a> are easy to follow.
-        <p>For Ubuntu and other Debian-based systems, <a href="http://www.geeqie.org/web/geeqie-install-debian.sh"> this script</a> will download Geeqie sources, all dependencies, and compile and install Geeqie. You may also select which optional libraries to install.</p>
+        <p>For Ubuntu and other Debian-based systems, <a href="https://www.geeqie.org/web/geeqie-install-debian.sh"> this script</a> will download Geeqie sources, all dependencies, and compile and install Geeqie. You may also select which optional libraries to install.</p>
         <h4>Support</h4>
 	<p>If you need help or have questions about Geeqie, just <a href="mailto:geeqie@freelists.org">send a message</a> to the <a href="https://www.freelists.org/list/geeqie">mailing list</a>.
 	<form action="https://www.freelists.org/cgi-bin/subscription.cgi" method="post">

--- a/web/installing.html
+++ b/web/installing.html
@@ -10,16 +10,11 @@
       <p>Geeqie is available as a package with some distributions.</p>
       <p>
         The source tar of the latest formal release may be downloaded:
-        <a href="http://geeqie.org/geeqie-1.3.tar.xz">http://geeqie.org/geeqie-1.3.tar.xz</a>
+        <a href="https://github.com/BestImageViewer/geeqie/releases/latest">https://github.com/BestImageViewer/geeqie/releases/latest</a>
       </p>
       <p>However Geeqie is stable, and you may download the latest version (if you have installed git) from here:</p>
       <p>
-        Either:
         <code>git clone git://www.geeqie.org/geeqie.git</code>
-      </p>
-      <p>
-        Or:
-        <code>git clone http://www.geeqie.org/git/geeqie.git</code>
       </p>
       <h2>Installation</h2>
       <p>


### PR DESCRIPTION
A number of links are bit-rotted and no longer work; only a few of these
are updated here. Generated links are also not touched.