### PR TITLE
Remove -r from geeqie command

### DIFF
--- a/geeqie.desktop.in
+++ b/geeqie.desktop.in
@@ -2,7 +2,7 @@
 _Name=Geeqie
 _GenericName=Image Viewer
 _Comment=View and manage images
-Exec=geeqie -r %F
+Exec=geeqie %F
 Icon=geeqie
 Type=Application
 Terminal=false


### PR DESCRIPTION
This -r option makes it impossible for me to simply double click an image in Thunar (or caja), and have it open in geeqie, even though it is the default program for image files.

It works just fine to open images with geeqie in other ways - from the command line or otherwise, but by double-clicking on the file which I would suspect it to open fine in geeqie, it doesn't.

Removing '-r' fixes this for me, and makes it work like I expect it to.

There might be better solutions, but this solves my problem.