### PR TITLE
Fix comparison in version.sh

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -22,7 +22,7 @@ if [ -d .git ]
 then
 	branch=$(git rev-parse --abbrev-ref HEAD)
 
-	if [ "$branch" == "master" ]
+	if [ "$branch" = "master" ]
 	then
 		IFS=$'.'
 # shellcheck disable=SC2046


### PR DESCRIPTION
Though some `test` implementations do support `==` for compatibility, standard primary is `=`