### PR TITLE
Drop unconditional Xlib dependency

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -66,11 +66,6 @@
 #include <clutter-gtk/clutter-gtk.h>
 #endif
 
-#ifdef HAVE_GTHREAD
-/** @FIXME see below */
-#include <X11/Xlib.h>
-#endif
-
 gboolean thumb_format_changed = FALSE;
 static RemoteConnection *remote_connection = NULL;
 


### PR DESCRIPTION
It was introduced 4eb2f5880956c8259d0b5e2084baf61a27ee82ad, to support XInitThreads, but XInitThreads was dropped later. Nothing else in this file needs this header, but it fails to compile on X11-less systems