### PR TITLE
Allows `meson setup` to finish successfully without champlain and without docs utils

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -19,8 +19,12 @@ iconsdir = join_paths(meson.project_source_root(), 'doc', 'icons/')
 guideindex_html = join_paths(destdir, 'GuideIndex.html')
 guideindex_ln = join_paths(destdir, 'index.html')
 
-run_command(gnome_doc_tool, 'html', '-o', destdir, '-p', iconsdir, guideindex_xml, check : false)
-run_command(find_program('ln'), '-s', '-f', guideindex_html, guideindex_ln, check : false)
+if gnome_doc_tool.found()
+    run_command(gnome_doc_tool, 'html', '-o', destdir, '-p', iconsdir, guideindex_xml, check : false)
+    run_command(find_program('ln'), '-s', '-f', guideindex_html, guideindex_ln, check : false)
+else
+    message('yelp-build not found. Help files not created.')
+endif
 
 install_subdir(destdir, install_dir : helpdir, install_tag : 'help')
 

--- a/meson.build
+++ b/meson.build
@@ -185,9 +185,9 @@ champlain_dep = []
 champlain_gtk_dep = []
 champlain_dep = dependency('champlain-0.12', version: '>=0.12', required : get_option('gps-map'))
 champlain_gtk_dep = dependency('champlain-gtk-0.12', version: '>=0.12', required : get_option('gps-map'))
+clutter_dep = []
+clutter_gtk_dep = []
 if champlain_dep.found() and champlain_gtk_dep.found()
-    clutter_dep = []
-    clutter_gtk_dep = []
     clutter_dep = dependency('clutter-1.0', required : true)
     clutter_gtk_dep = dependency('clutter-gtk-1.0', required : true)
     if clutter_dep.found() and clutter_gtk_dep.found()

--- a/meson.build
+++ b/meson.build
@@ -307,13 +307,15 @@ subdir('doc')
 # Install other project files
 run_command(find_program('gen_changelog.sh'), meson.project_source_root(), meson.project_build_root(), check : true)
 
-run_command(find_program('gen_readme.sh'), meson.project_source_root(), meson.project_build_root(), check : true)
-
-pandoc = find_program('pandoc')
+pandoc = find_program('pandoc', required : false)
 if pandoc.found()
+    # gen_readme.sh depends on pandoc.
+    run_command(find_program('gen_readme.sh'), meson.project_source_root(), meson.project_build_root(), check : true)
+
     install_data('README.md', 'COPYING', join_paths(meson.project_build_root(), 'ChangeLog'), 'TODO', 'AUTHORS', join_paths(meson.project_build_root(), 'README.html'), join_paths(meson.project_build_root(), 'ChangeLog.html'), install_dir : helpdir, install_tag : 'help')
 else
-    install_data('README.md', 'COPYING', join_paths(meson.project_build_root(), 'ChangeLog'), 'TODO', 'README.lirc', 'AUTHORS', install_dir : helpdir, install_tag : 'help')
+    message('pandoc not found. Skipping creation of README.html')
+    install_data('README.md', 'COPYING', join_paths(meson.project_build_root(), 'ChangeLog'), 'TODO', 'AUTHORS', join_paths(meson.project_build_root(), 'ChangeLog.html'), install_dir : helpdir, install_tag : 'help')
 endif
 
 install_data('geeqie.png', install_dir : icondir, install_tag : 'icons')


### PR DESCRIPTION
As originally written, the build would fail if libchamplain weren't found (with an unknown variable when `src/meson.build` tried to access `clutter_dep` or `clutter_gtk_dep`), or if `yelp-build` or `pandoc` weren't found.  These two changes allow the build system setup to complete in either of those cases.