### PR TITLE
Stop relying on implicit conversion from TRUE to COLLECTION_LOAD_APPEND.

### DIFF
--- a/src/collect-dlg.c
+++ b/src/collect-dlg.c
@@ -156,7 +156,7 @@ static void real_collection_button_pressed(FileDialog *fd, gpointer data, gint a
 
 	if (append)
 		{
-		collection_load(cd, fd->dest_path, TRUE);
+		collection_load(cd, fd->dest_path, COLLECTION_LOAD_APPEND);
 		collection_unref(cd);
 		}
 	else


### PR DESCRIPTION
This is one of the fixes that was necessary for C++ compatibility.