### PR TITLE
Fix join command on meson 0.56

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -540,5 +540,5 @@ i18n.merge_file(
 
 configure_file(input: 'geeqie.spec.in', output: 'geeqie.spec', configuration: conf_data)
 
-user_message = ''.join('Configuration Summary -\n\n', user_options_message, '\n', user_documentation_message, '\n', user_thumbnailer_message)
+user_message = ''.join(['Configuration Summary -\n\n', user_options_message, '\n', user_documentation_message, '\n', user_thumbnailer_message])
 message(user_message)


### PR DESCRIPTION
This fixes buildng on meson 0.56 - the join command errors out otherwise:

```
Program create-doxygen-lua-api.sh found: YES (/home/gusnan/kod/geeqie/git/geeqie/doc/create-doxygen-lua-api.sh)
Program gen_changelog.sh found: YES (/home/gusnan/kod/geeqie/git/geeqie/gen_changelog.sh)
Program pandoc found: YES (/usr/bin/pandoc)
Program gen_readme.sh found: YES (/home/gusnan/kod/geeqie/git/geeqie/gen_readme.sh)
Program evince found: YES (/usr/bin/evince)
Configuring geeqie.spec using configuration

meson.build:543:0: ERROR: Join() takes exactly one argument.

A full log can be found at /home/gusnan/kod/geeqie/git/geeqie/build/meson-logs/meson-log.txt
```

