### PR TITLE
Fix HAVE_FFMPEGTHUMBNAILER_METADATA to use mesondefine

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -57,7 +57,7 @@
 #mesondefine HAVE_FFMPEGTHUMBNAILER
 
 /* Define if ffmpegthumbnailer supports embedded metadata */
-#define HAVE_FFMPEGTHUMBNAILER_METADATA
+#mesondefine HAVE_FFMPEGTHUMBNAILER_METADATA
 
 /* Define if ffmpegthumbnailer supports raw RGB output */
 #mesondefine HAVE_FFMPEGTHUMBNAILER_RGB


### PR DESCRIPTION
Looks to me that also HAVE_FFMPEGTHUMBNAILER_METADATA should use #mesondefine - On older distros with ffmpeg < 2.2 the video_thumbnailer_struct doesn't include the prefer_embedded_metadata field, and this causes a build error.

(I'm on libffmpegthumbnailer4v5 2.1.1-0.2+b1 on Debian 11.4).
