### PR TITLE
No longer attempts to run yelp-build from the docs build if it wasn't found previously.

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -19,8 +19,11 @@ iconsdir = join_paths(meson.current_source_dir(), 'icons/')
 guideindex_html = join_paths(destdir, 'GuideIndex.html')
 guideindex_ln = join_paths(destdir, 'index.html')
 
-run_command(gnome_doc_tool, 'html', '-o', destdir, '-p', iconsdir, guideindex_xml, check : false)
-run_command(find_program('ln'), '-s', '-f', guideindex_html, guideindex_ln, check : false)
+# Not-found notification already handled by ../meson.build
+if gnome_doc_tool.found()
+    run_command(gnome_doc_tool, 'html', '-o', destdir, '-p', iconsdir, guideindex_xml, check : false)
+    run_command(find_program('ln'), '-s', '-f', guideindex_html, guideindex_ln, check : false)
+endif
 
 install_subdir(destdir, install_dir : helpdir, exclude_directories : 'lua-api/latex')
 


### PR DESCRIPTION
This was the sole fix from #1007 that wasn't already handled in https://github.com/BestImageViewer/geeqie/commit/db95a09715494db519f47315e970cf602cb97a88