### PR TITLE
Fix appstream validation

### DIFF
--- a/org.geeqie.Geeqie.appdata.xml.in
+++ b/org.geeqie.Geeqie.appdata.xml.in
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <component>
-  <id type="desktop">geeqie.desktop</id>
+  <id>org.geeqie.Geeqie</id>
   <metadata_license>CC-BY-SA-4.0</metadata_license>
   <content_rating type="oars-1.1" />
   <project_license>GPL-3.0+</project_license>
-  <_name>Geeqie</_name>
-  <_summary>A lightweight image viewer</_summary>
+  <name>Geeqie</name>
+  <summary>A lightweight image viewer</summary>
   <description>
     <p>
           Geeqie is a lightweight image viewer for Linux, BSDs and compatibles.


### PR DESCRIPTION
This fixes more validation problems in the appstream file - before appstream reported:

```
I: geeqie.desktop:10: description-first-para-too-short
     Geeqie is a lightweight image viewer for Linux, BSDs and compatibles.
I: geeqie.desktop:3: id-tag-has-type geeqie.desktop
I: geeqie.desktop:7: unknown-tag _name
E: geeqie.desktop:~: component-name-missing
I: geeqie.desktop:22: screenshot-media-url-not-secure
     http://cclark.uk/geeqie/screenshots/Screenshot_2017-08-13_12-29-44_rescaled.png
I: geeqie.desktop:34: url-not-secure http://geeqie.org
E: geeqie.desktop:~: component-summary-missing
I: geeqie.desktop:8: unknown-tag _summary
W: geeqie.desktop:3: cid-desktopapp-is-not-rdns geeqie.desktop
I: geeqie.desktop:19: screenshot-media-url-not-secure
     http://cclark.uk/geeqie/screenshots/Screenshot_2017-08-13_12-02-32_rescaled.png

Validation failed: errors: 2, warnings: 1, infos: 7, pedantic: 2
```
And after these changes:
```
I: org.geeqie.Geeqie:22: screenshot-media-url-not-secure
     http://cclark.uk/geeqie/screenshots/Screenshot_2017-08-13_12-29-44_rescaled.png
I: org.geeqie.Geeqie:34: url-not-secure http://geeqie.org
I: org.geeqie.Geeqie:19: screenshot-media-url-not-secure
     http://cclark.uk/geeqie/screenshots/Screenshot_2017-08-13_12-02-32_rescaled.png
I: org.geeqie.Geeqie:10: description-first-para-too-short
     Geeqie is a lightweight image viewer for Linux, BSDs and compatibles.

Valideringen lyckades: info: 4, pedantiska: 3

```

