### PR TITLE
Allow to use xxdi, lightweight alternative to vim's "xxd -i"

### DIFF
--- a/scripts/generate-ClayRGB1998-icc-h.sh
+++ b/scripts/generate-ClayRGB1998-icc-h.sh
@@ -12,9 +12,12 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
+# Allow standalone replacement for xxd
+command -v xxdi.pl >/dev/null 2>&1 && XXD="xxdi.pl" || XXD="xxd -i"
+
 # To generate the required code, xxd has to run in the same folder as the source
 build_dir="$PWD"
 
 cd "$(dirname "$1")" || return 1
 
-xxd -i "$(basename "$1")" "$build_dir/$2"
+${XXD} "$(basename "$1")" "$build_dir/$2"


### PR DESCRIPTION
xxdi [0] is a lightweight script that can replace "xxd -i", which is now needed to build geeqie. This is helpful on systems not running vim. This checks for its availability on the system and falls back to existing vim mode if not installed.

[0] https://github.com/gregkh/xxdi