### PR TITLE
Add a doc option to build system

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -19,21 +19,16 @@ iconsdir = join_paths(meson.current_source_dir(), 'icons/')
 guideindex_ln = join_paths(destdir, 'index.html')
 
 # Not-found notification already handled by ../meson.build
-if gnome_doc_tool.found()
+if not get_option('doc').disabled() and gnome_doc_tool.found()
     run_command(gnome_doc_tool, 'html', '-o', destdir, '-p', iconsdir, guideindex_xml, check : false)
     run_command(find_program('ln'), '-s', '-f', 'GuideIndex.html', guideindex_ln, check : false)
 endif
 
 install_subdir(destdir, install_dir : helpdir, exclude_directories : 'lua-api/latex')
 
-doxygen = find_program('doxygen', required : false)
-if doxygen.found()
+if not get_option('doc').disabled() and doxygen.found()
     srcdir = join_paths(meson.source_root())
     destdir = join_paths(meson.build_root(), 'doc', 'html', 'lua-api')
 
     run_command(find_program('create-doxygen-lua-api.sh'), srcdir, destdir, check : false)
-
-    summary({'lua-api' : ['lua-api help file created:', true]}, section : 'Documentation', bool_yn : true)
-else
-    summary({'lua-api' : ['doxygen not found - lua-api help file created:', false]}, section : 'Documentation', bool_yn : true)
 endif

--- a/meson.build
+++ b/meson.build
@@ -70,12 +70,6 @@ configuration_inc = include_directories('.')
 # External programs
 gdk_pixbuf_csource = find_program('gdk-pixbuf-csource', required : true)
 glib_genmarshal = find_program('glib-genmarshal', required : true)
-gnome_doc_tool = find_program('yelp-build', required : false)
-if gnome_doc_tool.found()
-    summary({'help' : ['Help files created:', true]}, section : 'Documentation', bool_yn : true)
-else
-    summary({'help' : ['yelp-build not found - Help files created:', false]}, section : 'Documentation', bool_yn : true)
-endif
 
 debug = get_option('debug')
 
@@ -145,6 +139,26 @@ conf_data.set('DEBUG', debug)
 
 gtk_dep = dependency('gtk+-3.0', version : '>=3.22', required: true)
 glib_dep = dependency('glib-2.0', version : '>=2.52', required: true)
+
+#option = get_option('doc')
+if not get_option('doc').disabled()
+    gnome_doc_tool = find_program('yelp-build', required : false)
+    if gnome_doc_tool.found()
+        summary({'help' : ['Help files created:', true]}, section : 'Documentation', bool_yn : true)
+    else
+        summary({'help' : ['yelp-build not found - Help files created:', false]}, section : 'Documentation', bool_yn : true)
+    endif
+
+    doxygen = find_program('doxygen', required : false)
+    if doxygen.found()
+        summary({'lua-api' : ['lua-api help file created:', true]}, section : 'Documentation', bool_yn : true)
+    else
+        summary({'lua-api' : ['doxygen not found - lua-api help file created:', false]}, section : 'Documentation', bool_yn : true)
+    endif
+else
+    summary({'help' : ['disabled - Help files created:', false]}, section : 'Documentation', bool_yn : true)
+    summary({'lua-api' : ['disabled - lua-api help file created:', false]}, section : 'Documentation', bool_yn : true)
+endif
 
 libarchive_dep = []
 req_version = '>=3.4.0'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -26,6 +26,7 @@ option('gq_localedir', type : 'string', value : '', description : 'Location wher
 option('archive', type : 'feature', value : 'auto', description : 'archive files e.g. zip, gz')
 option('cms', type : 'feature', value : 'auto', description : 'color management system')
 option('djvu', type : 'feature', value : 'auto', description : 'djvu')
+option('doc', type : 'feature', value : 'auto', description : 'doc')
 option('exiv2', type : 'feature', value : 'auto', description : 'exiv2')
 option('videothumbnailer', type : 'feature', value : 'auto', description : 'video thumbnailer')
 option('gps-map', type : 'feature', value : 'auto', description : 'gps map')


### PR DESCRIPTION
Currently, HTML and lua API documentations are built automatically if relevant program (yelp-build or doxygen) is found. This adds a doc option to control whether such documentation should be built and installed.

This helps for packaging and reproducible builds.