### PR TITLE
meson: distribute changelog when running `meson dist`, and install it

### DIFF
--- a/gen_changelog.sh
+++ b/gen_changelog.sh
@@ -38,4 +38,14 @@ echo "</html>" >> "$builddir/ChangeLog.$$.new.html"
 rm "$builddir/ChangeLog.$$.old.html"
 mv -f "$builddir/ChangeLog.$$.new.html" "$builddir/ChangeLog.html"
 
+# Meson: distribute in tarballs. The first variable is more reliable, but requires Meson 0.58.
+# Fallback to the older one if necessary
+for distdir in "$MESON_PROJECT_DIST_ROOT" "$MESON_DIST_ROOT"; do
+    if [ -n "$distdir" ]; then
+        cp -f "$builddir/ChangeLog.html" "$distdir/ChangeLog.html"
+        cp -f "$builddir/ChangeLog" "$distdir/ChangeLog"
+        break
+    fi
+done
+
 exit 0

--- a/meson.build
+++ b/meson.build
@@ -493,14 +493,19 @@ subdir('doc')
 
 # Install other project files
 if running_from_git
+    cmd = [find_program('gen_changelog.sh'), meson.current_source_dir(), meson.current_build_dir()]
     custom_target(
         'ChangeLog',
         input: 'ChangeLog.gqview',
         output: ['ChangeLog', 'ChangeLog.html'],
-        command: [find_program('gen_changelog.sh'), meson.current_source_dir(), meson.current_build_dir()],
+        command: cmd,
         install: true,
         install_dir: helpdir)
+    meson.add_dist_script(cmd)
     summary({'ChangeLog' : ['ChangeLog, ChangeLog.html created:', true]}, section : 'Documentation', bool_yn : true)
+elif fs.exists('ChangeLog.html')
+    install_data('ChangeLog', 'ChangeLog.html', install_dir: helpdir)
+    summary({'ChangeLog' : ['ChangeLog, ChangeLog.html installed from dist:', true]}, section : 'Documentation', bool_yn : true)
 else
     summary({'ChangeLog' : ['ChangeLog, ChangeLog.html created:', false]}, section : 'Documentation', bool_yn : true)
 endif


### PR DESCRIPTION
Installing without a changelog is still supported, if building without git *and* without an official dist tarball.

Fixes #1044