### PR TITLE
Please don't hardcode lua version in lua package name

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -368,12 +368,12 @@ lua_dep = []
 req_version = '>=5.3'
 option = get_option('lua')
 if not option.disabled()
-    lua_dep = dependency('lua5.3',  version : req_version, required : get_option('lua'))
+    lua_dep = dependency('lua',  version : req_version, required : get_option('lua'))
     if lua_dep.found()
         conf_data.set('HAVE_LUA', 1)
         summary({'lua' : ['lua supported:', true]}, section : 'Configuration', bool_yn : true)
     else
-        summary({'lua' : ['lua5.3 ' + req_version + ' not found - lua supported:', false]}, section : 'Configuration', bool_yn : true)
+        summary({'lua' : ['lua ' + req_version + ' not found - lua supported:', false]}, section : 'Configuration', bool_yn : true)
     endif
 else
     summary({'lua' : ['disabled - lua supported:', false]}, section : 'Configuration', bool_yn : true)


### PR DESCRIPTION
This fails on Fedora Linux, since our Lua 5.4 package is just called `lua`, not `lua53`. (It wouldn't work for our compat package for older versions either, because pkg-config for that is installed as e.g. `lua-5.1`.)

This _should_ work since `req_version` is still there checking the actual version.

If it is necessary to search for the package by this name for some distros, please at least make that a special-case check in addition to the "nameversion" one. Thanks!