### PR TITLE
Add meson option to allow disabling doxygen detection.

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -26,6 +26,8 @@ endif
 
 install_subdir(destdir, install_dir : helpdir, exclude_directories : 'lua-api/latex')
 
+option = get_option('doxygen')
+if not option.disabled()
 doxygen = find_program('doxygen', required : false)
 if doxygen.found() and running_from_git
     srcdir = join_paths(meson.source_root())
@@ -36,4 +38,5 @@ if doxygen.found() and running_from_git
     summary({'lua-api' : ['lua-api help file created:', true]}, section : 'Documentation', bool_yn : true)
 else
     summary({'lua-api' : ['doxygen not found - lua-api help file created:', false]}, section : 'Documentation', bool_yn : true)
+endif
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -25,6 +25,7 @@ option('gq_localedir', type : 'string', value : '', description : 'Location wher
 
 option('archive', type : 'feature', value : 'auto', description : 'archive files e.g. zip, gz')
 option('cms', type : 'feature', value : 'auto', description : 'color management system')
+option('doxygen', type : 'feature', value : 'auto', description : 'doxygen')
 option('djvu', type : 'feature', value : 'auto', description : 'djvu')
 option('exiv2', type : 'feature', value : 'auto', description : 'exiv2')
 option('videothumbnailer', type : 'feature', value : 'auto', description : 'video thumbnailer')


### PR DESCRIPTION
This is needed for packaging systems that check the installed files but can't assume what is available on the build system.