### PR TITLE
Drop stale intltool references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,9 +34,6 @@ Makefile.in
 /depcomp
 /auxdir
 /stamp-h1
-/intltool-extract.in
-/intltool-update.in
-/intltool-merge.in
 
 # /po/
 /po/Makefile.in.in
@@ -47,7 +44,6 @@ Makefile.in
 /po/geeqie.pot
 /po/*.mo
 /po/stamp-it
-/po/.intltool-merge-cache
 
 # /src/
 /src/.deps

--- a/geeqie-install-debian.sh
+++ b/geeqie-install-debian.sh
@@ -29,7 +29,6 @@ Command line options are:
 essential_array="git
 build-essential
 libglib2.0-0
-intltool
 libtool
 meson
 yelp-tools

--- a/geeqie.spec.in
+++ b/geeqie.spec.in
@@ -1,6 +1,6 @@
 # norootforbuild
 
-BuildRequires:  libgtk-3-dev gcc-c++ intltool gnome-doc-utils libjpeg-devel libtiff-devel
+BuildRequires:  libgtk-3-dev gcc-c++ gnome-doc-utils libjpeg-devel libtiff-devel
 %if 0%{?suse_version}
 BuildRequires:  liblcms-devel update-desktop-files
 %define docname	%{name}


### PR DESCRIPTION
Moved to gettext when porting to meson.