### PR TITLE
Don't use too new *_DEFAULT/*_NONE defines

### DIFF
--- a/src/cellrenderericon.cc
+++ b/src/cellrenderericon.cc
@@ -109,7 +109,7 @@ gqv_cell_renderer_icon_get_type(void)
 
 		cell_icon_type = g_type_register_static(GTK_TYPE_CELL_RENDERER,
 							"GQvCellRendererIcon",
-							&cell_icon_info, G_TYPE_FLAG_NONE);
+							&cell_icon_info, GTypeFlags(0));
 		}
 
 	return cell_icon_type;

--- a/src/filedata.cc
+++ b/src/filedata.cc
@@ -1895,7 +1895,7 @@ GList *file_data_filter_marks_list(GList *list, guint filter)
 
 gboolean file_data_filter_file_filter(FileData *fd, GRegex *filter)
 {
-	return g_regex_match(filter, fd->name, G_REGEX_MATCH_DEFAULT, NULL);
+	return g_regex_match(filter, fd->name, (GRegexMatchFlags)0, NULL);
 }
 
 GList *file_data_filter_file_filter_list(GList *list, GRegex *filter)

--- a/src/image-load.cc
+++ b/src/image-load.cc
@@ -88,7 +88,7 @@ GType image_loader_get_type(void)
 			(GInstanceInitFunc)image_loader_init, /* instance_init */
 			NULL	/* value_table */
 			};
-		type = g_type_register_static(G_TYPE_OBJECT, "ImageLoaderType", &info, G_TYPE_FLAG_NONE);
+		type = g_type_register_static(G_TYPE_OBJECT, "ImageLoaderType", &info, GTypeFlags(0));
 		}
 	return type;
 }

--- a/src/image.cc
+++ b/src/image.cc
@@ -877,7 +877,7 @@ static void image_load_done_cb(ImageLoader *UNUSED(il), gpointer data)
 
 	if (options->image.enable_read_ahead && imd->image_fd && !imd->image_fd->pixbuf && image_loader_get_pixbuf(imd->il))
 		{
-		imd->image_fd->pixbuf = g_object_ref(image_loader_get_pixbuf(imd->il));
+		imd->image_fd->pixbuf = (GdkPixbuf*)g_object_ref(image_loader_get_pixbuf(imd->il));
 		image_cache_set(imd, imd->image_fd);
 		}
 	/* call the callback triggered by image_state after fd->pixbuf is set */

--- a/src/pan-view/pan-view-filter.cc
+++ b/src/pan-view/pan-view-filter.cc
@@ -308,7 +308,7 @@ static gboolean pan_view_list_contains_kw_pattern(GList *haystack, PanViewFilter
 			{
 			gchar *keyword = static_cast<gchar *>(work->data);
 			work = work->next;
-			if (g_regex_match(filter->kw_regex, keyword, G_REGEX_MATCH_DEFAULT, NULL))
+			if (g_regex_match(filter->kw_regex, keyword, GRegexMatchFlags(0), NULL))
 				{
 				if (found_kw) *found_kw = keyword;
 				return TRUE;

--- a/src/pixbuf-renderer.cc
+++ b/src/pixbuf-renderer.cc
@@ -174,7 +174,7 @@ GType pixbuf_renderer_get_type(void)
 			};
 
 		pixbuf_renderer_type = g_type_register_static(GTK_TYPE_EVENT_BOX, "PixbufRenderer",
-							      &pixbuf_renderer_info, G_TYPE_FLAG_NONE);
+							      &pixbuf_renderer_info, GTypeFlags(0));
 		}
 
 	return pixbuf_renderer_type;

--- a/src/rcfile.cc
+++ b/src/rcfile.cc
@@ -1746,7 +1746,7 @@ gboolean load_config_from_buf(const gchar *buf, gsize size, gboolean startup)
 	parser_data->startup = startup;
 	options_parse_func_push(parser_data, options_parse_toplevel, NULL, NULL);
 
-	context = g_markup_parse_context_new(&parser, G_MARKUP_DEFAULT_FLAGS, parser_data, NULL);
+	context = g_markup_parse_context_new(&parser, GMarkupParseFlags(0), parser_data, NULL);
 
 	if (g_markup_parse_context_parse(context, buf, size, NULL) == FALSE)
 		{

--- a/src/search-and-run.cc
+++ b/src/search-and-run.cc
@@ -254,16 +254,16 @@ static gboolean match_func(GtkEntryCompletion *completion, const gchar *key, Gtk
 	reg_exp_str = g_string_new("\\b(\?=.*:)");
 	reg_exp_str = g_string_append(reg_exp_str, key);
 
-	reg_exp = g_regex_new(reg_exp_str->str, G_REGEX_CASELESS, G_REGEX_MATCH_DEFAULT, &error);
+	reg_exp = g_regex_new(reg_exp_str->str, G_REGEX_CASELESS, GRegexMatchFlags(0), &error);
 	if (error)
 		{
 		log_printf("Error: could not compile regular expression %s\n%s\n", reg_exp_str->str, error->message);
 		g_error_free(error);
 		error = NULL;
-		reg_exp = g_regex_new("", G_REGEX_DEFAULT, G_REGEX_MATCH_DEFAULT, NULL);
+		reg_exp = g_regex_new("", GRegexCompileFlags(0), GRegexMatchFlags(0), NULL);
 		}
 
-	ret = g_regex_match(reg_exp, normalized, G_REGEX_MATCH_DEFAULT, NULL);
+	ret = g_regex_match(reg_exp, normalized, GRegexMatchFlags(0), NULL);
 
 	if (sar->match_found == FALSE && ret == TRUE)
 		{

--- a/src/search.cc
+++ b/src/search.cc
@@ -1991,13 +1991,13 @@ static gboolean search_file_next(SearchData *sd)
 				}
 			if (sd->search_name_match_case)
 				{
-				match = g_regex_match(sd->search_name_regex, fd_name_or_path, G_REGEX_MATCH_DEFAULT, NULL);
+				match = g_regex_match(sd->search_name_regex, fd_name_or_path, GRegexMatchFlags(0), NULL);
 				}
 			else
 				{
 				/* sd->search_name is converted in search_start() */
 				gchar *haystack = g_utf8_strdown(fd_name_or_path, -1);
-				match = g_regex_match(sd->search_name_regex, haystack, G_REGEX_MATCH_DEFAULT, NULL);
+				match = g_regex_match(sd->search_name_regex, haystack, GRegexMatchFlags(0), NULL);
 				g_free(haystack);
 				}
 			}
@@ -2188,11 +2188,11 @@ static gboolean search_file_next(SearchData *sd)
 
 			if (sd->match_comment == SEARCH_MATCH_CONTAINS)
 				{
-				match = g_regex_match(sd->search_comment_regex, comment, G_REGEX_MATCH_DEFAULT, NULL);
+				match = g_regex_match(sd->search_comment_regex, comment, GRegexMatchFlags(0), NULL);
 				}
 			else if (sd->match_comment == SEARCH_MATCH_NONE)
 				{
-				match = !g_regex_match(sd->search_comment_regex, comment, G_REGEX_MATCH_DEFAULT, NULL);
+				match = !g_regex_match(sd->search_comment_regex, comment, GRegexMatchFlags(0), NULL);
 				}
 			g_free(comment);
 			}
@@ -2583,13 +2583,13 @@ static void search_start(SearchData *sd)
 		g_regex_unref(sd->search_name_regex);
 		}
 
-	sd->search_name_regex = g_regex_new(sd->search_name, G_REGEX_DEFAULT, G_REGEX_MATCH_DEFAULT, &error);
+	sd->search_name_regex = g_regex_new(sd->search_name, GRegexCompileFlags(0), GRegexMatchFlags(0), &error);
 	if (error)
 		{
 		log_printf("Error: could not compile regular expression %s\n%s\n", sd->search_name, error->message);
 		g_error_free(error);
 		error = NULL;
-		sd->search_name_regex = g_regex_new("", G_REGEX_DEFAULT, G_REGEX_MATCH_DEFAULT, NULL);
+		sd->search_name_regex = g_regex_new("", GRegexCompileFlags(0), GRegexMatchFlags(0), NULL);
 		}
 
 	if (!sd->search_comment_match_case)
@@ -2605,13 +2605,13 @@ static void search_start(SearchData *sd)
 		g_regex_unref(sd->search_comment_regex);
 		}
 
-	sd->search_comment_regex = g_regex_new(sd->search_comment,G_REGEX_DEFAULT, G_REGEX_MATCH_DEFAULT, &error);
+	sd->search_comment_regex = g_regex_new(sd->search_comment, GRegexCompileFlags(0), GRegexMatchFlags(0), &error);
 	if (error)
 		{
 		log_printf("Error: could not compile regular expression %s\n%s\n", sd->search_comment, error->message);
 		g_error_free(error);
 		error = NULL;
-		sd->search_comment_regex = g_regex_new("", G_REGEX_DEFAULT, G_REGEX_MATCH_DEFAULT, NULL);
+		sd->search_comment_regex = g_regex_new("", GRegexCompileFlags(0), GRegexMatchFlags(0), NULL);
 		}
 
 	sd->search_count = 0;

--- a/src/view-file/view-file.cc
+++ b/src/view-file/view-file.cc
@@ -1639,26 +1639,26 @@ GRegex *vf_file_filter_get_filter(ViewFile *vf)
 
 	if (!gtk_widget_get_visible(vf->file_filter.combo))
 		{
-		return g_regex_new("", G_REGEX_DEFAULT, G_REGEX_MATCH_DEFAULT, NULL);
+		return g_regex_new("", GRegexCompileFlags(0), GRegexMatchFlags(0), NULL);
 		}
 
 	file_filter_text = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(vf->file_filter.combo));
 
 	if (file_filter_text[0] != '\0')
 		{
-		ret = g_regex_new(file_filter_text, vf->file_filter.case_sensitive ? G_REGEX_DEFAULT : G_REGEX_CASELESS, G_REGEX_MATCH_DEFAULT, &error);
+		ret = g_regex_new(file_filter_text, vf->file_filter.case_sensitive ? GRegexCompileFlags(0) : G_REGEX_CASELESS, GRegexMatchFlags(0), &error);
 		if (error)
 			{
 			log_printf("Error: could not compile regular expression %s\n%s\n", file_filter_text, error->message);
 			g_error_free(error);
 			error = NULL;
-			ret = g_regex_new("", G_REGEX_DEFAULT, G_REGEX_MATCH_DEFAULT, NULL);
+			ret = g_regex_new("", GRegexCompileFlags(0), GRegexMatchFlags(0), NULL);
 			}
 		g_free(file_filter_text);
 		}
 	else
 		{
-		ret = g_regex_new("", G_REGEX_DEFAULT, G_REGEX_MATCH_DEFAULT, NULL);
+		ret = g_regex_new("", GRegexCompileFlags(0), GRegexMatchFlags(0), NULL);
 		}
 
 	return ret;


### PR DESCRIPTION
To build on current Debian stable, I have to remove using these new glib G_TYPE_ and G_REGEX_ default/none-defines and instead use 0 cast to the proper type. This makes it build with older glib (Debian Bullseye have glib  2.66.8). The defines that are currently used are from Glib 2.74).

For example see here: https://docs.gtk.org/glib/flags.RegexCompileFlags.html

for the G_REGEX_DEFAULT.