### PR TITLE
Do more casting to avoid build errors

### DIFF
--- a/src/format-canon.cc
+++ b/src/format-canon.cc
@@ -516,13 +516,13 @@ gboolean format_canon_makernote(ExifData *exif, guchar *tiff, guint offset,
 	item = exif_get_item(exif, "MkN.Canon.Settings1");
 	if (item)
 		{
-		canon_mknote_parse_settings(exif, item->data, item->data_len, bo, CanonSet1);
+		canon_mknote_parse_settings(exif, (guint16*)item->data, item->data_len, bo, CanonSet1);
 		}
 
 	item = exif_get_item(exif, "MkN.Canon.Settings2");
 	if (item)
 		{
-		canon_mknote_parse_settings(exif, item->data, item->data_len, bo, CanonSet2);
+		canon_mknote_parse_settings(exif, (guint16*)item->data, item->data_len, bo, CanonSet2);
 		}
 
 	return TRUE;

--- a/src/format-nikon.cc
+++ b/src/format-nikon.cc
@@ -387,7 +387,7 @@ gboolean format_nikon_makernote(ExifData *exif, guchar *tiff, guint offset,
 		{
 		static ExifMarker marker = { 0x0088, EXIF_FORMAT_STRING, -1,
 					     "Nikon.AutoFocusPoint", "Auto focus point", NULL };
-		guchar *array = item->data;
+		guchar *array = (guchar*)item->data;
 		gchar *text;
 		gint l;
 

--- a/src/format-olympus.cc
+++ b/src/format-olympus.cc
@@ -321,7 +321,7 @@ gboolean format_olympus_makernote(ExifData *exif, guchar *tiff, guint offset,
 		{
 		static ExifMarker marker = { 0x0200, EXIF_FORMAT_STRING, -1,
 					     "Olympus.ShootingMode", "Shooting mode", NULL };
-		guint32 *array = item->data;
+		guint32 *array = (guint32 *)item->data;
 		gchar *mode;
 		gchar *pdir = NULL;
 		gchar *text;
@@ -352,7 +352,7 @@ gboolean format_olympus_makernote(ExifData *exif, guchar *tiff, guint offset,
 		{
 		static ExifMarker marker = { 0x1015, EXIF_FORMAT_STRING, -1,
 					     "Olympus.WhiteBalance", "White balance", NULL };
-		guint16 *array = item->data;
+		guint16 *array = (guint16 *)item->data;
 		gchar *mode;
 		gchar *color = NULL;
 		gchar *text;

--- a/src/format-raw.cc
+++ b/src/format-raw.cc
@@ -66,7 +66,7 @@ static FormatRawEntry format_raw_list[] = {
 	FORMAT_RAW_OLYMPUS,
 	FORMAT_RAW_PENTAX,
 	FORMAT_RAW_SAMSUNG,
-	{ NULL, 0, 0, NULL, 0, 0, NULL, NULL, NULL }
+	{ NULL, (FormatRawMatchType)0, 0, NULL, 0, (FormatRawExifType)0, NULL, NULL, NULL }
 };
 
 
@@ -84,7 +84,7 @@ static FormatExifEntry format_exif_list[] = {
 	FORMAT_EXIF_FUJI,
 	FORMAT_EXIF_NIKON,
 	FORMAT_EXIF_OLYMPUS,
-	{ 0, NULL, 0, NULL, NULL }
+	{ (FormatExifMatchType)0, NULL, 0, NULL, NULL }
 };
 
 
@@ -283,11 +283,11 @@ FormatRawExifType format_raw_exif_offset(guchar *data, const guint len, guint *e
 {
 	FormatRawEntry *entry;
 
-	if (!data || len < 1) return FALSE;
+	if (!data || len < 1) return (FormatRawExifType)FALSE;
 
 	entry = format_raw_find(data, len);
 
-	if (!entry || !entry->func_parse) return FALSE;
+	if (!entry || !entry->func_parse) return (FormatRawExifType)FALSE;
 
 	if (!format_raw_parse(entry, data, len, NULL, exif_offset)) return FORMAT_RAW_EXIF_NONE;
 
@@ -360,7 +360,7 @@ gboolean format_raw_img_exif_offsets_fd(gint fd, const gchar *path,
 		return FALSE;
 		}
 
-	success = format_raw_parse(entry, map_data, map_len, image_offset, exif_offset);
+	success = format_raw_parse(entry, (guchar*)map_data, map_len, image_offset, exif_offset);
 
 	if (munmap(map_data, map_len) == -1)
 		{


### PR DESCRIPTION
Now trying to build on Debian 12 - I still get build problems (Debian 11 - stable - is fine after my last pull request - thanks for that!)

Build log before my patch:

```
../src/exif.cc:484:49: warning: ISO C++ forbids converting a string constant to ‘gchar*’ {aka ‘char*’} [-Wwrite-strings]
  484 | { 0x0000, EXIF_FORMAT_RATIONAL, -1,             "unknown",      NULL, NULL },
      |                                                 ^~~~~~~~~
../src/exif.cc:485:49: warning: ISO C++ forbids converting a string constant to ‘gchar*’ {aka ‘char*’} [-Wwrite-strings]
  485 | { 0x0000, EXIF_FORMAT_FLOAT, -1,                "unknown",      NULL, NULL },
      |                                                 ^~~~~~~~~
../src/exif.cc:486:49: warning: ISO C++ forbids converting a string constant to ‘gchar*’ {aka ‘char*’} [-Wwrite-strings]
  486 | { 0x0000, EXIF_FORMAT_DOUBLE, -1,               "unknown",      NULL, NULL },
      |                                                 ^~~~~~~~~
../src/exif.cc: In function ‘gchar* exif_item_get_data(ExifItem*, guint*)’:
../src/exif.cc:587:24: warning: ‘void* g_memdup(gconstpointer, guint)’ is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]
  587 |         return g_memdup(item->data, item->data_len);
      |                ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/glib-2.0/glib.h:84,
                 from ../src/exif.cc:61:
/usr/include/glib-2.0/glib/gstrfuncs.h:259:23: note: declared here
  259 | gpointer              g_memdup         (gconstpointer mem,
      |                       ^~~~~~~~
../src/exif.cc:587:24: error: invalid conversion from ‘gpointer’ {aka ‘void*’} to ‘gchar*’ {aka ‘char*’} [-fpermissive]
  587 |         return g_memdup(item->data, item->data_len);
      |                ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                        |
      |                        gpointer {aka void*}
../src/exif.cc: In function ‘void rational_from_data(ExifRational*, gpointer, ExifByteOrder)’:
../src/exif.cc:749:38: error: invalid conversion from ‘gpointer’ {aka ‘void*’} to ‘guchar*’ {aka ‘unsigned char*’} [-fpermissive]
  749 |         r->num = exif_byte_get_int32(src, bo);
      |                                      ^~~
      |                                      |
      |                                      gpointer {aka void*}
../src/exif.cc:682:37: note:   initializing argument 1 of ‘guint32 exif_byte_get_int32(guchar*, ExifByteOrder)’
  682 | guint32 exif_byte_get_int32(guchar *f, ExifByteOrder bo)
      |                             ~~~~~~~~^
../src/exif.cc: In function ‘gint exif_parse_IFD_entry(ExifData*, guchar*, guint, guint, ExifByteOrder, gint, const ExifMarker*)’:
../src/exif.cc:935:68: error: invalid conversion from ‘guint’ {aka ‘unsigned int’} to ‘ExifFormatType’ [-fpermissive]
  935 |         exif_item_copy_data(item, tiff + data_offset, data_length, format, bo);
      |                                                                    ^~~~~~
      |                                                                    |
      |                                                                    guint {aka unsigned int}
../src/exif.cc:757:41: note:   initializing argument 4 of ‘void exif_item_copy_data(ExifItem*, gpointer, guint, ExifFormatType, ExifByteOrder)’
  757 |                          ExifFormatType src_format, ExifByteOrder bo)
      |                          ~~~~~~~~~~~~~~~^~~~~~~~~~
../src/exif.cc: At global scope:
../src/exif.cc:1054:76: warning: ISO C++ forbids converting a string constant to ‘gchar*’ {aka ‘char*’} [-Wwrite-strings]
 1054 | static ExifMarker jpeg_color_marker = { 0x8773, EXIF_FORMAT_UNDEFINED, -1, "Exif.Image.InterColorProfile", NULL, NULL };
      |                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/exif.cc: In function ‘ExifData* exif_read(gchar*, gchar*, GHashTable*)’:
../src/exif.cc:1248:52: error: invalid conversion from ‘gpointer’ {aka ‘void*’} to ‘guchar*’ {aka ‘unsigned char*’} [-fpermissive]
 1248 |                 exif_type = format_raw_exif_offset(f, size, &offset, &exif_parse_func);
      |                                                    ^
      |                                                    |
      |                                                    gpointer {aka void*}
In file included from ../src/exif.cc:70:
../src/format-raw.h:54:50: note:   initializing argument 1 of ‘FormatRawExifType format_raw_exif_offset(guchar*, guint, guint*, gboolean (**)(guchar*, guint, ExifData*))’
   54 | FormatRawExifType format_raw_exif_offset(guchar *data, const guint len, guint *exif_offset,
      |                                          ~~~~~~~~^~~~
../src/exif.cc: In function ‘ExifItem* exif_get_item(ExifData*, const gchar*)’:
../src/exif.cc:1302:30: error: invalid conversion from ‘gpointer’ {aka ‘void*’} to ‘ExifItem*’ {aka ‘_ExifItem*’} [-fpermissive]
 1302 |                 item = work->data;
      |                        ~~~~~~^~~~
      |                              |
      |                              gpointer {aka void*}
../src/exif.cc: In function ‘void exif_write_data_list(ExifData*, FILE*, gint)’:
../src/exif.cc:1574:38: error: invalid conversion from ‘gpointer’ {aka ‘void*’} to ‘ExifItem*’ {aka ‘_ExifItem*’} [-fpermissive]
 1574 |                         item = work->data;
      |                                ~~~~~~^~~~
      |                                      |
      |                                      gpointer {aka void*}
[83/182] Compiling C++ object src/geeqie.p/exif-common.cc.o
ninja: build stopped: subcommand failed.

```
This pull request makes it build here too. However - the function format_raw_exif_offset in format-raw.cc which returns a FormatRawExifType, does simply return FALSE - which I have made the easiest fix, which is just to cast to FormatRawExifType, but that seems a bit wrong to me (FALSE is simply 0).

It does also change a g_memdup to g_memdup2. (Which is available from GLib 2.68)


