### PR TITLE
Add missing #ifdef for DEBUG_FILEDATA

### DIFF
--- a/src/filedata.cc
+++ b/src/filedata.cc
@@ -697,6 +697,7 @@ FileData *file_data_ref(FileData *fd)
  */
 void file_data_dump()
 {
+#ifdef DEBUG_FILEDATA
 	FileData *fd;
 	GList *list;
 
@@ -716,6 +717,7 @@ void file_data_dump()
 
 		g_list_free(list);
 		}
+#endif
 }
 
 static void file_data_free(FileData *fd)


### PR DESCRIPTION
It looks like one ifdef is missing in DEBUG_FILEDATA code making it impossible to build Geeqie on my system.
```
../src/filedata.cc: In function ‘void file_data_dump()’:
../src/filedata.cc:707:34: error: ‘global_file_data_count’ was not declared in this scope
  707 |                 log_printf("%d", global_file_data_count);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~
```

Simple fix adds ifdefs around body of `file_data_dump()` function which is used only for debugging anyway. Maybe more code should be ifdefed like `log_print_file_data_dump()` in `debug.cc`. Also not sure how/if DEBUG_FILEDATA was supposed to differ from DEBUG_FD. I didn't study the code that carefully ;)

Amends commit cd72fa8.