### PR TITLE
Replace deprecated g_memdup with g_memdup2

### DIFF
--- a/src/exif.cc
+++ b/src/exif.cc
@@ -584,7 +584,11 @@ gchar *exif_item_get_data(ExifItem *item, guint *data_len)
 {
 	if (data_len)
 		*data_len = item->data_len;
+#if GLIB_CHECK_VERSION(2,68,0)
 	return (gchar*)g_memdup2((gpointer)(item->data), item->data_len);
+#else
+	return (gchar*)g_memdup((gpointer)(item->data), item->data_len);
+#endif
 }
 
 guint exif_item_get_format_id(ExifItem *item)

--- a/src/exiv2.cc
+++ b/src/exiv2.cc
@@ -267,7 +267,11 @@ public:
 		if (cp_data_)
 		{
 			if (data_len) *data_len = cp_length_;
+#if GLIB_CHECK_VERSION(2,68,0)
+			return (unsigned char *) g_memdup2(cp_data_, cp_length_);
+#else
 			return (unsigned char *) g_memdup(cp_data_, cp_length_);
+#endif
 		}
 		return NULL;
 	}


### PR DESCRIPTION
`g_memdup` is declared as deprecated in current GLib, safer replacement `g_memdup2` is available since GLib-2.68. It's probably fairly minor thing, but gets rid of one of countless build warnings.

Code is protected by GLIB_CHECK_VERSION macro, so should build on older distros as well (e.g. Debian 11 or Ubuntu 20.04 LTS).

See https://docs.gtk.org/glib/func.memdup2.html