### PR TITLE
Fix #ifdef for JPEG XL support

### DIFF
--- a/src/filefilter.cc
+++ b/src/filefilter.cc
@@ -190,7 +190,7 @@ void filter_add_defaults()
 #ifdef HAVE_DJVU
 	filter_add_if_missing("djvu", "DjVu Format", ".djvu;.djv", FORMAT_CLASS_DOCUMENT, FALSE, FALSE, TRUE);
 #endif
-#ifdef HAVE_JXL
+#ifdef HAVE_JPEGXL
 	filter_add_if_missing("jxl", "JXL", ".jxl", FORMAT_CLASS_IMAGE, FALSE, TRUE, TRUE);
 #endif
 #ifdef HAVE_J2K


### PR DESCRIPTION
It's `HAVE_JPEGXL` everywhere else, but `HAVE_JXL` here...