### PR TITLE
Add ExifData as extra argument to exif_item_get_data_as_text()

### DIFF
--- a/src/advanced-exif.cc
+++ b/src/advanced-exif.cc
@@ -120,7 +120,7 @@ static void advanced_exif_update(ExifWin *ew)
 		tag = g_strdup_printf("0x%04x", exif_item_get_tag_id(item));
 		tag_name = exif_item_get_tag_name(item);
 		format = exif_item_get_format_name(item, TRUE);
-		text = exif_item_get_data_as_text(item);
+		text = exif_item_get_data_as_text(item, exif);
 		utf8_text = utf8_validate_or_convert(text);
 		g_free(text);
 		elements = g_strdup_printf("%d", exif_item_get_elements(item));

--- a/src/exif-common.cc
+++ b/src/exif-common.cc
@@ -994,7 +994,7 @@ gchar *exif_get_data_as_text(ExifData *exif, const gchar *key)
 	if (key_valid) return text;
 
 	item = exif_get_item(exif, key);
-	if (item) return exif_item_get_data_as_text(item);
+	if (item) return exif_item_get_data_as_text(item, exif);
 
 	return nullptr;
 }

--- a/src/exif.cc
+++ b/src/exif.cc
@@ -1454,7 +1454,7 @@ gchar *exif_item_get_string(ExifItem *item, gint UNUSED(idx))
 	return exif_item_get_data_as_text_full(item, METADATA_PLAIN);
 }
 
-gchar *exif_item_get_data_as_text(ExifItem *item)
+gchar *exif_item_get_data_as_text(ExifItem *item, ExifData *exif)
 {
 	return exif_item_get_data_as_text_full(item, METADATA_FORMATTED);
 }
@@ -1527,11 +1527,11 @@ gchar *exif_get_tag_description_by_key(const gchar *key)
 	return NULL;
 }
 
-static void exif_write_item(FILE *f, ExifItem *item)
+static void exif_write_item(FILE *f, ExifItem *item, ExifData *exif)
 {
 	gchar *text;
 
-	text = exif_item_get_data_as_text(item);
+	text = exif_item_get_data_as_text(item, exif);
 	if (text)
 		{
 		gchar *tag = exif_item_get_tag_name(item);
@@ -1578,7 +1578,7 @@ void exif_write_data_list(ExifData *exif, FILE *f, gint human_readable_list)
 			item = (ExifItem*)(work->data);
 			work = work->next;
 
-			exif_write_item(f, item);
+			exif_write_item(f, item, exif);
 			}
 		}
 	g_fprintf(f, "----------------------------------------------------\n");

--- a/src/exif.h
+++ b/src/exif.h
@@ -136,7 +136,7 @@ gchar *exif_item_get_data(ExifItem *item, guint *data_len);
 gchar *exif_item_get_description(ExifItem *item);
 guint exif_item_get_format_id(ExifItem *item);
 const gchar *exif_item_get_format_name(ExifItem *item, gboolean brief);
-gchar *exif_item_get_data_as_text(ExifItem *item);
+gchar *exif_item_get_data_as_text(ExifItem *item, ExifData *exif);
 gint exif_item_get_integer(ExifItem *item, gint *value);
 ExifRational *exif_item_get_rational(ExifItem *item, gint *sign, guint n);
 

--- a/src/exiv2.cc
+++ b/src/exiv2.cc
@@ -778,13 +778,13 @@ const char *exif_item_get_format_name(ExifItem *item, gboolean UNUSED(brief))
 }
 
 
-gchar *exif_item_get_data_as_text(ExifItem *item)
+gchar *exif_item_get_data_as_text(ExifItem *item, ExifData *exif)
 {
 	try {
 		if (!item) return nullptr;
 		auto metadatum = reinterpret_cast<Exiv2::Metadatum *>(item);
 #if EXIV2_TEST_VERSION(0,17,0)
-		return utf8_validate_or_convert(metadatum->print().c_str());
+		return utf8_validate_or_convert(metadatum->print(&exif->exifData()).c_str());
 #else
 		std::stringstream str;
 		Exiv2::Exifdatum *exifdatum;


### PR DESCRIPTION
I think this should fix the issue that was reported to Exiv2: https://github.com/Exiv2/exiv2/issues/2638
[`Metadatum::print`](https://github.com/Exiv2/exiv2/blob/931a40a746f5678dcc4625b06a2eb25fa4f00b34/src/metadatum.cpp#L10) needs to be given a pointer to the `ExifData`.