### PR TITLE
Various fixes of GList handling

### DIFF
--- a/src/bar-exif.cc
+++ b/src/bar-exif.cc
@@ -752,10 +752,11 @@ GList * bar_pane_exif_list()
 		ped = static_cast<PaneExifData *>(g_object_get_data(G_OBJECT(pane), "pane_data"));
 
 		list = gtk_container_get_children(GTK_CONTAINER(ped->vbox));
-		while (list)
+		GList *work = list;
+		while (work)
 			{
-			entry = static_cast<GtkWidget *>(list->data);
-			list = list->next;
+			entry = static_cast<GtkWidget *>(work->data);
+			work = work->next;
 			ee = static_cast<ExifEntry *>(g_object_get_data(G_OBJECT(entry), "entry_data"));
 			exif_list = g_list_append(exif_list, g_strdup(ee->title));
 			exif_list = g_list_append(exif_list, g_strdup(ee->key));

--- a/src/bar-gps.cc
+++ b/src/bar-gps.cc
@@ -122,7 +122,6 @@ static void bar_pane_gps_close_save_cb(GenericDialog *UNUSED(gd), gpointer data)
 			metadata_write_GPS_coord(fd, "Xmp.exif.GPSLongitude", pgd->dest_longitude);
 			}
 		}
-	g_list_free(work);
 	g_list_free(pgd->geocode_list);
 }
 
@@ -174,7 +173,7 @@ static void bar_pane_gps_close_save_cb(GenericDialog *UNUSED(gd), gpointer data)
 						}
 					}
 				}
-			g_list_free(work);
+			g_list_free(list);
 
 			if(count)
 				{

--- a/src/bar-keywords.cc
+++ b/src/bar-keywords.cc
@@ -164,7 +164,7 @@ static void bar_pane_keywords_write(PaneKeywordsData *pkd)
 
 	metadata_write_list(pkd->fd, KEYWORD_KEY, list);
 
-	string_list_free(list);
+	g_list_free_full(list, g_free);
 }
 
 gboolean bar_keyword_tree_expand_if_set_cb(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
@@ -208,7 +208,7 @@ static void bar_keyword_tree_sync(PaneKeywordsData *pkd)
 	keywords = keyword_list_pull(pkd->keyword_view);
 	keyword_show_set_in(GTK_TREE_STORE(keyword_tree), model, keywords);
 	if (pkd->hide_unchecked) keyword_hide_unset_in(GTK_TREE_STORE(keyword_tree), model, keywords);
-	string_list_free(keywords);
+	g_list_free_full(keywords, g_free);
 
 	gtk_tree_model_filter_refilter(GTK_TREE_MODEL_FILTER(model));
 
@@ -244,8 +244,8 @@ static void bar_pane_keywords_update(PaneKeywordsData *pkd)
 		bar_keyword_tree_sync(pkd);
 		g_signal_handlers_unblock_by_func(keyword_buffer, (gpointer)bar_pane_keywords_changed, pkd);
 		}
-	string_list_free(keywords);
-	string_list_free(orig_keywords);
+	g_list_free_full(keywords, g_free);
+	g_list_free_full(orig_keywords, g_free);
 }
 
 void bar_pane_keywords_set_fd(GtkWidget *pane, FileData *fd)
@@ -378,7 +378,7 @@ static void bar_pane_keywords_keyword_toggle(GtkCellRendererToggle *UNUSED(toggl
 
 	g_signal_handlers_block_by_func(keyword_buffer, (gpointer)bar_pane_keywords_changed, pkd);
 	keyword_list_push(pkd->keyword_view, list);
-	string_list_free(list);
+	g_list_free_full(list, g_free);
 	g_signal_handlers_unblock_by_func(keyword_buffer, (gpointer)bar_pane_keywords_changed, pkd);
 
 	/* call this just once in the end */
@@ -401,7 +401,7 @@ void bar_pane_keywords_filter_modify(GtkTreeModel *model, GtkTreeIter *iter, GVa
 			{
 			GList *keywords = keyword_list_pull(pkd->keyword_view);
 			gboolean set = keyword_tree_is_set(keyword_tree, &child_iter, keywords);
-			string_list_free(keywords);
+			g_list_free_full(keywords, g_free);
 
 			g_value_init(value, G_TYPE_BOOLEAN);
 			g_value_set_boolean(value, set);
@@ -454,7 +454,7 @@ static void bar_pane_keywords_set_selection(PaneKeywordsData *pkd, gboolean appe
 		}
 
 	filelist_free(list);
-	string_list_free(keywords);
+	g_list_free_full(keywords, g_free);
 }
 
 static void bar_pane_keywords_sel_add_cb(GtkWidget *UNUSED(button), gpointer data)
@@ -676,7 +676,7 @@ static void bar_pane_keywords_dnd_receive(GtkWidget *tree_view, GdkDragContext *
 			{
 			auto path = static_cast<GList *>(*reinterpret_cast<const gpointer *>(gtk_selection_data_get_data(selection_data)));
 			src_valid = keyword_tree_get_iter(keyword_tree, &src_kw_iter, path);
-			string_list_free(path);
+			g_list_free_full(path, g_free);
 			break;
 			}
 		default:
@@ -771,7 +771,7 @@ static void bar_pane_keywords_dnd_receive(GtkWidget *tree_view, GdkDragContext *
 			new_kw_iter = add;
 			}
 		}
-	string_list_free(new_keywords);
+	g_list_free_full(new_keywords, g_free);
 	bar_keyword_tree_sync(pkd);
 }
 
@@ -893,7 +893,7 @@ static void bar_pane_keywords_edit_ok_cb(GenericDialog *UNUSED(gd), gpointer dat
 			work = work->next;
 			}
 		}
-	string_list_free(keywords);
+	g_list_free_full(keywords, g_free);
 }
 
 static void bar_pane_keywords_conf_set_helper(GtkWidget *UNUSED(widget), gpointer data)
@@ -1109,7 +1109,7 @@ static void bar_pane_keywords_show_all_cb(GtkWidget *UNUSED(menu_widget), gpoint
 
 	GtkTreeModel *keyword_tree;
 
-	string_list_free(pkd->expanded_rows);
+	g_list_free_full(pkd->expanded_rows, g_free);
 	pkd->expanded_rows = nullptr;
 	gtk_tree_view_map_expanded_rows(GTK_TREE_VIEW(pkd->keyword_treeview),
 								(bar_keyword_tree_get_expanded_cb), &pkd->expanded_rows);
@@ -1160,7 +1160,7 @@ static void bar_pane_keywords_collapse_all_cb(GtkWidget *UNUSED(menu_widget), gp
 {
 	auto pkd = static_cast<PaneKeywordsData *>(data);
 
-	string_list_free(pkd->expanded_rows);
+	g_list_free_full(pkd->expanded_rows, g_free);
 	pkd->expanded_rows = nullptr;
 	gtk_tree_view_map_expanded_rows(GTK_TREE_VIEW(pkd->keyword_treeview),
 								(bar_keyword_tree_get_expanded_cb), &pkd->expanded_rows);
@@ -1206,7 +1206,7 @@ static void bar_pane_keywords_hide_unchecked_cb(GtkWidget *UNUSED(menu_widget), 
 
 	keywords = keyword_list_pull(pkd->keyword_view);
 	keyword_hide_unset_in(GTK_TREE_STORE(keyword_tree), model, keywords);
-	string_list_free(keywords);
+	g_list_free_full(keywords, g_free);
 	bar_keyword_tree_sync(pkd);
 }
 
@@ -1268,7 +1268,7 @@ static void bar_pane_keywords_add_to_selected_cb(GtkWidget *UNUSED(menu_widget),
 	keyword_tree_set(keyword_tree, &child_iter, &list);
 
 	keyword_list_push(pkd->keyword_view, list); /* Set the left keyword view */
-	string_list_free(list);
+	g_list_free_full(list, g_free);
 
 	bar_pane_keywords_changed(keyword_buffer, pkd); /* Get list of all keywords in the hierarchy */
 
@@ -1284,7 +1284,7 @@ static void bar_pane_keywords_add_to_selected_cb(GtkWidget *UNUSED(menu_widget),
 		metadata_append_list(fd, KEYWORD_KEY, keywords);
 		}
 	filelist_free(list);
-	string_list_free(keywords);
+	g_list_free_full(keywords, g_free);
 }
 
 static void bar_pane_keywords_menu_popup(GtkWidget *UNUSED(widget), PaneKeywordsData *pkd, gint x, gint y)
@@ -1441,7 +1441,7 @@ static void bar_pane_keywords_destroy(GtkWidget *UNUSED(widget), gpointer data)
 	path = g_build_filename(get_rc_dir(), "keywords", NULL);
 	autocomplete_keywords_list_save(path);
 
-	string_list_free(pkd->expanded_rows);
+	g_list_free_full(pkd->expanded_rows, g_free);
 	if (pkd->click_tpath) gtk_tree_path_free(pkd->click_tpath);
 	if (pkd->idle_id) g_source_remove(pkd->idle_id);
 	file_data_unregister_notify_func(bar_pane_keywords_notify_cb, pkd);

--- a/src/bar-keywords.cc
+++ b/src/bar-keywords.cc
@@ -314,14 +314,13 @@ static void bar_pane_keywords_write_config(GtkWidget *pane, GString *outstr, gin
 	gtk_tree_view_map_expanded_rows(GTK_TREE_VIEW(pkd->keyword_treeview),
 								(bar_keyword_tree_get_expanded_cb), &path_expanded);
 
-	g_list_first(path_expanded);
-	while (path_expanded)
+	GList *work = g_list_first(path_expanded);
+	while (work)
 		{
-		bar_pane_keywords_entry_write_config(static_cast<gchar *>(path_expanded->data), outstr, indent);
-		g_free(path_expanded->data);
-		path_expanded = path_expanded->next;
+		bar_pane_keywords_entry_write_config(static_cast<gchar *>(work->data), outstr, indent);
+		work = work->next;
 		}
-	g_list_free(path_expanded);
+	g_list_free_full(path_expanded, g_free);
 
 	indent--;
 	WRITE_NL();

--- a/src/bar-sort.cc
+++ b/src/bar-sort.cc
@@ -166,13 +166,13 @@ static void bar_sort_mode_cb(GtkWidget *combo, gpointer data)
 /* this takes control of src_list */
 static void bar_sort_undo_set(SortData *sd, GList *src_list, const gchar *dest)
 {
-	string_list_free(sd->undo_src_list);
+	g_list_free_full(sd->undo_src_list, g_free);
 	sd->undo_src_list = filelist_to_path_list(src_list);
 
 	if (src_list)
 		{
 		/* we should create the undo_dest_list to use it later... */
-		string_list_free(sd->undo_dest_list);
+		g_list_free_full(sd->undo_dest_list, g_free);
 		sd->undo_dest_list=nullptr;
 
 		GList *work = sd->undo_src_list;
@@ -616,8 +616,8 @@ static void bar_sort_destroy(GtkWidget *UNUSED(widget), gpointer data)
 	bar_sort_add_close(sd);
 
 	g_free(sd->filter_key);
-	string_list_free(sd->undo_src_list);
-	string_list_free(sd->undo_dest_list);
+	g_list_free_full(sd->undo_src_list, g_free);
+	g_list_free_full(sd->undo_dest_list, g_free);
 	g_free(sd->undo_collection);
 	g_free(sd);
 }

--- a/src/bar.cc
+++ b/src/bar.cc
@@ -564,21 +564,14 @@ GtkWidget *bar_find_pane_by_id(GtkWidget *bar, PaneType type, const gchar *id)
 void bar_clear(GtkWidget *bar)
 {
 	BarData *bd;
-	GList *list, *work;
+	GList *list;
 
 	bd = static_cast<BarData *>(g_object_get_data(G_OBJECT(bar), "bar_data"));
 	if (!bd) return;
 
 	list = gtk_container_get_children(GTK_CONTAINER(bd->vbox));
 
-	work = list;
-	while (work)
-		{
-		auto widget = static_cast<GtkWidget *>(work->data);
-		gtk_widget_destroy(widget);
-		work = work->next;
-		}
-	g_list_free(list);
+	g_list_free_full(list, reinterpret_cast<GDestroyNotify>(gtk_widget_destroy));
 }
 
 void bar_write_config(GtkWidget *bar, GString *outstr, gint indent)

--- a/src/collect-io.cc
+++ b/src/collect-io.cc
@@ -92,7 +92,7 @@ static gboolean collection_load_private(CollectionData *cd, const gchar *path, C
 
 		if (!append)
 			{
-			collection_list_free(cd->list);
+			g_list_free_full(cd->list, reinterpret_cast<GDestroyNotify>(collection_info_free));
 			cd->list = nullptr;
 			}
 		}

--- a/src/collect-io.cc
+++ b/src/collect-io.cc
@@ -542,19 +542,7 @@ static void collect_manager_action_unref(CollectManagerAction *action)
 
 static void collect_manager_entry_free_data(CollectManagerEntry *entry)
 {
-	GList *work;
-
-	work = entry->add_list;
-	while (work)
-		{
-		CollectManagerAction *action;
-
-		action = static_cast<CollectManagerAction *>(work->data);
-		work = work->next;
-
-		collect_manager_action_unref(action);
-		}
-	g_list_free(entry->add_list);
+	g_list_free_full(entry->add_list, reinterpret_cast<GDestroyNotify>(collect_manager_action_unref));
 	if (g_hash_table_size(entry->oldpath_hash) > 0)
 		g_hash_table_destroy(entry->oldpath_hash);
 	else

--- a/src/collect.cc
+++ b/src/collect.cc
@@ -652,7 +652,7 @@ gchar *collection_info_list_to_dnd_data(CollectionData *cd, GList *list, gint *l
 
 	ptr[0] = '\0';
 
-	string_list_free(temp);
+	g_list_free_full(temp, g_free);
 
 	return uri_text;
 }

--- a/src/collect.cc
+++ b/src/collect.cc
@@ -125,18 +125,6 @@ gboolean collection_info_load_thumb_unused(CollectInfo *ci)
 }
 #pragma GCC diagnostic pop
 
-void collection_list_free(GList *list)
-{
-	GList *work;
-	work = list;
-	while (work)
-		{
-		collection_info_free(static_cast<CollectInfo *>(work->data));
-		work = work->next;
-		}
-	g_list_free(list);
-}
-
 /* an ugly static var, well what ya gonna do ? */
 static SortType collection_list_sort_method = SORT_NAME;
 
@@ -506,7 +494,7 @@ void collection_free(CollectionData *cd)
 	DEBUG_1("collection \"%s\" freed", cd->name);
 
 	collection_load_stop(cd);
-	collection_list_free(cd->list);
+	g_list_free_full(cd->list, reinterpret_cast<GDestroyNotify>(collection_info_free));
 
 	file_data_unregister_notify_func(collection_notify_cb, cd);
 

--- a/src/collect.h
+++ b/src/collect.h
@@ -30,8 +30,6 @@ void collection_info_free(CollectInfo *ci);
 
 void collection_info_set_thumb(CollectInfo *ci, GdkPixbuf *pixbuf);
 
-void collection_list_free(GList *list);
-
 GList *collection_list_sort(GList *list, SortType method);
 GList *collection_list_add(GList *list, CollectInfo *ci, SortType method);
 GList *collection_list_insert(GList *list, CollectInfo *ci, CollectInfo *insert_ci, SortType method);

--- a/src/dupe.cc
+++ b/src/dupe.cc
@@ -847,8 +847,7 @@ static GList *dupe_listview_get_selection(DupeWindow *UNUSED(dw), GtkWidget *lis
 			}
 		work = work->next;
 		}
-	g_list_foreach(slist, static_cast<GFunc>(tree_path_free_wrapper), nullptr);
-	g_list_free(slist);
+	g_list_free_full(slist, reinterpret_cast<GDestroyNotify>(gtk_tree_path_free));
 
 	return g_list_reverse(list);
 }
@@ -875,8 +874,7 @@ static gboolean dupe_listview_item_is_selected(DupeWindow *UNUSED(dw), DupeItem 
 		if (di_n == di) found = TRUE;
 		work = work->next;
 		}
-	g_list_foreach(slist, static_cast<GFunc>(tree_path_free_wrapper), nullptr);
-	g_list_free(slist);
+	g_list_free_full(slist, reinterpret_cast<GDestroyNotify>(gtk_tree_path_free));
 
 	return found;
 }
@@ -3254,8 +3252,7 @@ static void dupe_window_remove_selection(DupeWindow *dw, GtkWidget *listview)
 		if (di) list = g_list_prepend(list, di);
 		work = work->next;
 		}
-	g_list_foreach(slist, static_cast<GFunc>(tree_path_free_wrapper), nullptr);
-	g_list_free(slist);
+	g_list_free_full(slist, reinterpret_cast<GDestroyNotify>(gtk_tree_path_free));
 
 	dw->color_frozen = TRUE;
 	work = list;
@@ -4224,8 +4221,7 @@ static gboolean dupe_window_keypress_cb(GtkWidget *widget, GdkEventKey *event, g
 		gtk_tree_model_get_iter(store, &iter, tpath);
 		gtk_tree_model_get(store, &iter, DUPE_COLUMN_POINTER, &di, -1);
 		}
-	g_list_foreach(slist, static_cast<GFunc>(tree_path_free_wrapper), nullptr);
-	g_list_free(slist);
+	g_list_free_full(slist, reinterpret_cast<GDestroyNotify>(gtk_tree_path_free));
 
 	if (event->state & GDK_CONTROL_MASK)
 		{

--- a/src/dupe.cc
+++ b/src/dupe.cc
@@ -1004,20 +1004,21 @@ static void dupe_match_unlink(DupeItem *a, DupeItem *b)
  */
 static void dupe_match_link_clear(DupeItem *parent, gboolean unlink_children)
 {
-	GList *work;
-
-	work = parent->group;
-	while (work)
+	if (unlink_children)
 		{
-		auto dm = static_cast<DupeMatch *>(work->data);
-		work = work->next;
+		GList *work;
 
-		if (unlink_children) dupe_match_unlink_child(parent, dm->di);
+		work = parent->group;
+		while (work)
+			{
+			auto dm = static_cast<DupeMatch *>(work->data);
+			work = work->next;
 
-		g_free(dm);
+			dupe_match_unlink_child(parent, dm->di);
+			}
 		}
 
-	g_list_free(parent->group);
+	g_list_free_full(parent->group, g_free);
 	parent->group = nullptr;
 	parent->group_rank = 0.0;
 }

--- a/src/dupe.cc
+++ b/src/dupe.cc
@@ -466,18 +466,6 @@ static void dupe_item_free(DupeItem *di)
 	g_free(di);
 }
 
-static void dupe_list_free(GList *list)
-{
-	GList *work = list;
-	while (work)
-		{
-		auto di = static_cast<DupeItem *>(work->data);
-		work = work->next;
-		dupe_item_free(di);
-		}
-	g_list_free(list);
-}
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 static DupeItem *dupe_item_find_fd_by_list_unused(FileData *fd, GList *work)
@@ -3778,7 +3766,7 @@ static void dupe_second_clear(DupeWindow *dw)
 	g_list_free(dw->dupes);
 	dw->dupes = nullptr;
 
-	dupe_list_free(dw->second_list);
+	g_list_free_full(dw->second_list, reinterpret_cast<GDestroyNotify>(dupe_item_free));
 	dw->second_list = nullptr;
 
 	dupe_match_reset_list(dw->list);
@@ -4381,7 +4369,7 @@ void dupe_window_clear(DupeWindow *dw)
 	g_list_free(dw->dupes);
 	dw->dupes = nullptr;
 
-	dupe_list_free(dw->list);
+	g_list_free_full(dw->list, reinterpret_cast<GDestroyNotify>(dupe_item_free));
 	dw->list = nullptr;
 	dw->set_count = 0;
 
@@ -4416,9 +4404,9 @@ void dupe_window_close(DupeWindow *dw)
 	gtk_widget_destroy(dw->window);
 
 	g_list_free(dw->dupes);
-	dupe_list_free(dw->list);
+	g_list_free_full(dw->list, reinterpret_cast<GDestroyNotify>(dupe_item_free));
 
-	dupe_list_free(dw->second_list);
+	g_list_free_full(dw->second_list, reinterpret_cast<GDestroyNotify>(dupe_item_free));
 
 	file_data_unregister_notify_func(dupe_notify_cb, dw);
 

--- a/src/editors.cc
+++ b/src/editors.cc
@@ -90,7 +90,7 @@ void editor_description_free(EditorDescription *editor)
 	g_free(editor->menu_path);
 	g_free(editor->hotkey);
 	g_free(editor->comment);
-	string_list_free(editor->ext_list);
+	g_list_free_full(editor->ext_list, g_free);
 	g_free(editor->file);
 	g_free(editor);
 }

--- a/src/exif.cc
+++ b/src/exif.cc
@@ -1200,19 +1200,9 @@ ExifData *exif_get_original(ExifData *processed)
 
 void exif_free(ExifData *exif)
 {
-	GList *work;
-
 	if (!exif) return;
 
-	work = exif->items;
-	while (work)
-		{
-		auto item = static_cast<ExifItem *>(work->data);
-		work = work->next;
-		exif_item_free(item);
-		}
-
-	g_list_free(exif->items);
+	g_list_free_full(exif->items, reinterpret_cast<GDestroyNotify>(exif_item_free));
 	g_free(exif->path);
 	g_free(exif);
 }

--- a/src/filedata.cc
+++ b/src/filedata.cc
@@ -791,15 +791,7 @@ static void file_data_consider_free(FileData *fd)
 	DEBUG_2("file_data_consider_free: deleting '%s', parent '%s'",
 		fd->path, fd->parent ? parent->path : "-");
 
-	work = parent->sidecar_files;
-	while (work)
-		{
-		auto sfd = static_cast<FileData *>(work->data);
-		file_data_free(sfd);
-		work = work->next;
-		}
-
-	g_list_free(parent->sidecar_files);
+	g_list_free_full(parent->sidecar_files, reinterpret_cast<GDestroyNotify>(file_data_free));
 	parent->sidecar_files = nullptr;
 
 	file_data_free(parent);

--- a/src/filedata.cc
+++ b/src/filedata.cc
@@ -711,11 +711,12 @@ void file_data_dump()
 		log_printf("%d", global_file_data_count);
 		log_printf("%d", g_list_length(list));
 
-		while (list)
+		GList *work = list;
+		while (work)
 			{
-			fd = static_cast<FileData *>(list->data);
+			fd = static_cast<FileData *>(work->data);
 			log_printf("%-4d %s", fd->ref, fd->path);
-			list = list->next;
+			work = work->next;
 			}
 
 		g_list_free(list);
@@ -1603,20 +1604,18 @@ GList *filelist_filter(GList *list, gboolean is_dir_list)
 		{
 		auto fd = static_cast<FileData *>(work->data);
 		const gchar *name = fd->name;
+		GList *link = work;
+		work = work->next;
 
 		if ((!options->file_filter.show_hidden_files && is_hidden_file(name)) ||
 		    (!is_dir_list && !filter_name_exists(name)) ||
 		    (is_dir_list && name[0] == '.' && (strcmp(name, GQ_CACHE_LOCAL_THUMB) == 0 ||
 						       strcmp(name, GQ_CACHE_LOCAL_METADATA) == 0)) )
 			{
-			GList *link = work;
-
 			list = g_list_remove_link(list, link);
 			file_data_unref(fd);
 			g_list_free(link);
 			}
-
-		work = work->next;
 		}
 
 	return list;

--- a/src/filefilter.cc
+++ b/src/filefilter.cc
@@ -377,18 +377,18 @@ void filter_rebuild()
 	GList *work;
 	guint i;
 
-	string_list_free(extension_list);
+	g_list_free_full(extension_list, g_free);
 	extension_list = nullptr;
 
-	string_list_free(file_writable_list);
+	g_list_free_full(file_writable_list, g_free);
 	file_writable_list = nullptr;
 
-	string_list_free(file_sidecar_list);
+	g_list_free_full(file_sidecar_list, g_free);
 	file_sidecar_list = nullptr;
 
 	for (i = 0; i < FILE_FORMAT_CLASSES; i++)
 		{
-		string_list_free(file_class_extension_list[i]);
+		g_list_free_full(file_class_extension_list[i], g_free);
 		file_class_extension_list[i] = nullptr;
 		}
 

--- a/src/filefilter.cc
+++ b/src/filefilter.cc
@@ -160,17 +160,7 @@ static void filter_add_if_missing(const gchar *key, const gchar *description, co
 
 void filter_reset()
 {
-	GList *work;
-
-	work = filter_list;
-	while (work)
-		{
-		auto fe = static_cast<FilterEntry *>(work->data);
-		work = work->next;
-		filter_entry_free(fe);
-		}
-
-	g_list_free(filter_list);
+	g_list_free_full(filter_list, reinterpret_cast<GDestroyNotify>(filter_entry_free));
 	filter_list = nullptr;
 }
 
@@ -580,16 +570,7 @@ GList *sidecar_ext_get_list()
 
 static void sidecar_ext_free_list()
 {
-	GList *work;
-
-	work = sidecar_ext_list;
-	while (work)
-		{
-		auto ext = static_cast<gchar *>(work->data);
-		work = work->next;
-		g_free(ext);
-		}
-	g_list_free(sidecar_ext_list);
+	g_list_free_full(sidecar_ext_list, g_free);
 	sidecar_ext_list = nullptr;
 }
 

--- a/src/fullscreen.cc
+++ b/src/fullscreen.cc
@@ -454,21 +454,12 @@ GList *fullscreen_prefs_list()
 	return list;
 }
 
-void fullscreen_prefs_list_free(GList *list)
+void screen_data_free(ScreenData *sd)
 {
-	GList *work;
+	if (!sd) return;
 
-	work = list;
-	while (work)
-		{
-		auto sd = static_cast<ScreenData *>(work->data);
-		work = work->next;
-
-		g_free(sd->description);
-		g_free(sd);
-		}
-
-	g_list_free(list);
+	g_free(sd->description);
+	g_free(sd);
 }
 
 ScreenData *fullscreen_prefs_list_find(GList *list, gint screen)
@@ -585,7 +576,7 @@ void fullscreen_prefs_get_geometry(gint screen, GtkWidget *widget, gint *x, gint
 		if (same_region) *same_region = TRUE;
 		}
 
-	fullscreen_prefs_list_free(list);
+	g_list_free_full(list, reinterpret_cast<GDestroyNotify>(screen_data_free));
 }
 
 #pragma GCC diagnostic push
@@ -692,7 +683,7 @@ GtkWidget *fullscreen_prefs_selection_new(const gchar *text, gint *screen_value,
 		work = work->next;
 		n++;
 		}
-	fullscreen_prefs_list_free(list);
+	g_list_free_full(list, reinterpret_cast<GDestroyNotify>(screen_data_free));
 
 	gtk_combo_box_set_active(GTK_COMBO_BOX(combo), current);
 

--- a/src/fullscreen.h
+++ b/src/fullscreen.h
@@ -49,7 +49,7 @@ struct ScreenData {
 
 
 GList *fullscreen_prefs_list();
-void fullscreen_prefs_list_free(GList *list);
+void screen_data_free(ScreenData *sd);
 
 ScreenData *fullscreen_prefs_list_find(GList *list, gint screen);
 

--- a/src/image-load.cc
+++ b/src/image-load.cc
@@ -1158,9 +1158,8 @@ void image_loader_delay_area_ready(ImageLoader *il, gboolean enable)
 			work = work->next;
 
 			g_signal_emit(il, signals[SIGNAL_AREA_READY], 0, par->x, par->y, par->w, par->h);
-			g_free(par);
 			}
-		g_list_free(list);
+		g_list_free_full(list, g_free);
 		}
 	else
 		{

--- a/src/layout-util.cc
+++ b/src/layout-util.cc
@@ -3195,13 +3195,13 @@ static void layout_actions_setup_editors(LayoutWindow *lw)
 		path = layout_actions_editor_menu_path(editor);
 		layout_actions_editor_add(desc, path, old_path);
 
-		string_list_free(old_path);
+		g_list_free_full(old_path, g_free);
 		old_path = path;
 		work = work->next;
 		}
 
 	layout_actions_editor_add(desc, nullptr, old_path);
-	string_list_free(old_path);
+	g_list_free_full(old_path, g_free);
 
 	g_string_append(desc,   "  </menubar>"
 				"</ui>" );
@@ -3341,7 +3341,7 @@ void layout_editors_reload_start()
 	if (layout_editors_reload_idle_id != -1)
 		{
 		g_source_remove(layout_editors_reload_idle_id);
-		string_list_free(layout_editors_desktop_files);
+		g_list_free_full(layout_editors_desktop_files, g_free);
 		}
 
 	editor_table_clear();
@@ -3429,7 +3429,7 @@ void layout_toolbar_clear(LayoutWindow *lw, ToolbarType type)
 		gtk_ui_manager_remove_ui(lw->ui_manager, lw->toolbar_merge_id[type]);
 		gtk_ui_manager_ensure_update(lw->ui_manager);
 		}
-	string_list_free(lw->toolbar_actions[type]);
+	g_list_free_full(lw->toolbar_actions[type], g_free);
 	lw->toolbar_actions[type] = nullptr;
 
 	lw->toolbar_merge_id[type] = gtk_ui_manager_new_merge_id(lw->ui_manager);

--- a/src/main.cc
+++ b/src/main.cc
@@ -656,7 +656,7 @@ static void parse_command_line(gint argc, gchar *argv[])
 		}
 	else
 		{
-		string_list_free(list);
+		g_list_free_full(list, g_free);
 		command_line->cmd_list = nullptr;
 		}
 
@@ -668,7 +668,7 @@ static void parse_command_line(gint argc, gchar *argv[])
 		command_line->file = nullptr;
 		filelist_free(command_line->cmd_list);
 		command_line->cmd_list = nullptr;
-		string_list_free(command_line->collection_list);
+		g_list_free_full(command_line->collection_list, g_free);
 		command_line->collection_list = nullptr;
 		}
 }

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -490,7 +490,7 @@ void pop_menu_collections(GList *selection_list, gpointer data)
 		name = collection_path(collection_name);
 		cw = collection_window_new(name);
 		g_free(name);
-		string_list_free(collection_list);
+		g_list_free_full(collection_list, g_free);
 		}
 	else
 		{

--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -162,18 +162,13 @@ static void metadata_cache_remove(FileData *fd, const gchar *key)
 
 void metadata_cache_free(FileData *fd)
 {
-	GList *work;
 	if (fd->cached_metadata) DEBUG_1("freed %s\n", fd->path);
 
-	work = fd->cached_metadata;
-	while (work)
+	g_list_free_full(fd->cached_metadata, [](gpointer data)
 		{
-		auto entry = static_cast<GList *>(work->data);
+		auto entry = static_cast<GList *>(data);
 		g_list_free_full(entry, g_free);
-
-		work = work->next;
-		}
-	g_list_free(fd->cached_metadata);
+		});
 	fd->cached_metadata = nullptr;
 }
 

--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -100,7 +100,7 @@ static void metadata_cache_update(FileData *fd, const gchar *key, const GList *v
 			GList *old_values = entry->next;
 			entry->next = nullptr;
 			old_values->prev = nullptr;
-			string_list_free(old_values);
+			g_list_free_full(old_values, g_free);
 			work->data = g_list_append(entry, string_list_copy(values));
 			DEBUG_1("updated %s %s\n", key, fd->path);
 			return;
@@ -150,7 +150,7 @@ static void metadata_cache_remove(FileData *fd, const gchar *key)
 		if (strcmp(entry_key, key) == 0)
 			{
 			/* key found */
-			string_list_free(entry);
+			g_list_free_full(entry, g_free);
 			fd->cached_metadata = g_list_delete_link(fd->cached_metadata, work);
 			DEBUG_1("removed %s %s\n", key, fd->path);
 			return;
@@ -169,7 +169,7 @@ void metadata_cache_free(FileData *fd)
 	while (work)
 		{
 		auto entry = static_cast<GList *>(work->data);
-		string_list_free(entry);
+		g_list_free_full(entry, g_free);
 
 		work = work->next;
 		}
@@ -420,7 +420,7 @@ gboolean metadata_write_string(FileData *fd, const gchar *key, const char *value
 {
 	GList *list = g_list_append(nullptr, g_strdup(value));
 	gboolean ret = metadata_write_list(fd, key, list);
-	string_list_free(list);
+	g_list_free_full(list, g_free);
 	return ret;
 }
 
@@ -497,7 +497,7 @@ static gboolean metadata_legacy_write(FileData *fd)
 
 	g_free(metadata_pathl);
 	g_free(orig_comment);
-	string_list_free(orig_keywords);
+	g_list_free_full(orig_keywords, g_free);
 
 	return success;
 }
@@ -567,7 +567,7 @@ static gboolean metadata_file_read(gchar *path, GList **keywords, gchar **commen
 		}
 	else
 		{
-		string_list_free(list);
+		g_list_free_full(list, g_free);
 		}
 
 	if (comment_build)
@@ -745,7 +745,7 @@ gchar *metadata_read_string(FileData *fd, const gchar *key, MetadataFormat forma
 		{
 		auto str = static_cast<gchar *>(string_list->data);
 		string_list->data = nullptr;
-		string_list_free(string_list);
+		g_list_free_full(string_list, g_free);
 		return str;
 		}
 	return nullptr;
@@ -928,7 +928,7 @@ gboolean metadata_append_list(FileData *fd, const gchar *key, const GList *value
 		list = remove_duplicate_strings_from_list(list);
 
 		ret = metadata_write_list(fd, key, list);
-		string_list_free(list);
+		g_list_free_full(list, g_free);
 		return ret;
 		}
 }
@@ -1091,7 +1091,7 @@ gboolean meta_data_set_keyword_mark(FileData *fd, gint UNUSED(n), gboolean value
 		metadata_write_list(fd, KEYWORD_KEY, keywords);
 		}
 
-	string_list_free(keywords);
+	g_list_free_full(keywords, g_free);
 	return TRUE;
 }
 
@@ -1476,7 +1476,7 @@ gboolean keyword_tree_is_set(GtkTreeModel *keyword_tree, GtkTreeIter *iter, GLis
 
 		ret = keyword_tree_is_set_casefold(keyword_tree, *iter, casefold_list);
 
-		string_list_free(casefold_list);
+		g_list_free_full(casefold_list, g_free);
 		}
 
 	return ret;

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -383,11 +383,6 @@ gint get_cpu_cores()
     return sysconf(_SC_NPROCESSORS_ONLN);
 }
 
-void tree_path_free_wrapper(void *data, void *UNUSED(useradata))
-{
-	gtk_tree_path_free(static_cast<GtkTreePath *>(data));
-}
-
 /* Copied from the libarchive .repo. examples */
 
 #ifndef HAVE_ARCHIVE

--- a/src/misc.h
+++ b/src/misc.h
@@ -32,7 +32,6 @@ gchar *date_get_abbreviated_day_name(gint day);
 gchar *convert_rating_to_stars(gint rating);
 gchar *get_symbolic_link(const gchar *path_utf8);
 gint get_cpu_cores();
-void tree_path_free_wrapper(void *data, void *useradata);
 gchar *open_archive(FileData *fd);
 #endif /* MISC_H */
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/osd.cc
+++ b/src/osd.cc
@@ -228,7 +228,7 @@ static gchar *keywords_to_string(FileData *fd)
 
 			g_string_append(kwstr, kw);
 			}
-		string_list_free(keywords);
+		g_list_free_full(keywords, g_free);
 		}
 
 	if (kwstr)

--- a/src/pan-view/pan-folder.cc
+++ b/src/pan-view/pan-folder.cc
@@ -327,18 +327,7 @@ static FlowerGroup *pan_flower_group(PanWindow *pw, FileData *dir_fd, gint x, gi
 
 	if (!f && !group->children)
 		{
-		work = group->items;
-		while (work)
-			{
-			PanItem *pi;
-
-			pi = static_cast<PanItem *>(work->data);
-			work = work->next;
-
-			pan_item_free(pi);
-			}
-
-		g_list_free(group->items);
+		g_list_free_full(group->items, reinterpret_cast<GDestroyNotify>(pan_item_free));
 		g_free(group);
 		group = nullptr;
 		}

--- a/src/pan-view/pan-view-filter.cc
+++ b/src/pan-view/pan-view-filter.cc
@@ -398,7 +398,7 @@ gboolean pan_filter_fd_list(GList **fd_list, GList *filter_elements, gint filter
 						break;
 					}
 				}
-			string_list_free(img_keywords);
+			g_list_free_full(img_keywords, g_free);
 			if (!should_reject && group_kw != nullptr) g_hash_table_add(seen_kw_table, group_kw);
 			group_kw = nullptr;  // group_kw references an item from img_keywords.
 			}

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -569,22 +569,13 @@ GList *pan_cache_sort(GList *list, SortType method, gboolean ascend)
 
 static void pan_cache_free(PanWindow *pw)
 {
-	GList *work;
-
-	work = pw->cache_list;
-	while (work)
+	g_list_free_full(pw->cache_list, [](gpointer data)
 		{
-		PanCacheData *pc;
-
-		pc = static_cast<PanCacheData *>(work->data);
-		work = work->next;
-
+		auto pc = static_cast<PanCacheData *>(data);
 		cache_sim_data_free(pc->cd);
 		file_data_unref(pc->fd);
 		g_free(pc);
-		}
-
-	g_list_free(pw->cache_list);
+		});
 	pw->cache_list = nullptr;
 
 	filelist_free(pw->cache_todo);
@@ -711,21 +702,12 @@ void pan_cache_sync_date(PanWindow *pw, GList *list)
 
 static void pan_grid_clear(PanWindow *pw)
 {
-	GList *work;
-
-	work = pw->list_grid;
-	while (work)
+	g_list_free_full(pw->list_grid, [](gpointer data)
 		{
-		PanGrid *pg;
-
-		pg = static_cast<PanGrid *>(work->data);
-		work = work->next;
-
+		auto pg = static_cast<PanGrid *>(data);
 		g_list_free(pg->list);
 		g_free(pg);
-		}
-
-	g_list_free(pw->list_grid);
+		});
 	pw->list_grid = nullptr;
 
 	pw->list = g_list_concat(pw->list, pw->list_static);
@@ -830,20 +812,9 @@ static void pan_grid_build(PanWindow *pw, gint width, gint height, gint grid_siz
 
 static void pan_window_items_free(PanWindow *pw)
 {
-	GList *work;
-
 	pan_grid_clear(pw);
 
-	work = pw->list;
-	while (work)
-		{
-		auto pi = static_cast<PanItem *>(work->data);
-		work = work->next;
-
-		pan_item_free(pi);
-		}
-
-	g_list_free(pw->list);
+	g_list_free_full(pw->list, reinterpret_cast<GDestroyNotify>(pan_item_free));
 	pw->list = nullptr;
 
 	g_list_free(pw->queue);

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -1405,7 +1405,7 @@ static void pan_info_add_exif(PanTextAlignment *ta, FileData *fd)
 		g_free(text);
 		}
 
-	string_list_free(exif_list);
+	g_list_free_full(exif_list, g_free);
 }
 
 

--- a/src/pixbuf-renderer.cc
+++ b/src/pixbuf-renderer.cc
@@ -959,20 +959,7 @@ static void pr_source_tile_free(SourceTile *st)
 
 static void pr_source_tile_free_all(PixbufRenderer *pr)
 {
-	GList *work;
-
-	work = pr->source_tiles;
-	while (work)
-		{
-		SourceTile *st;
-
-		st = static_cast<SourceTile *>(work->data);
-		work = work->next;
-
-		pr_source_tile_free(st);
-		}
-
-	g_list_free(pr->source_tiles);
+	g_list_free_full(pr->source_tiles, reinterpret_cast<GDestroyNotify>(pr_source_tile_free));
 	pr->source_tiles = nullptr;
 }
 

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -3073,7 +3073,7 @@ static gboolean keywords_find_file(gpointer data)
 
 		gtk_entry_set_text(GTK_ENTRY(kfd->progress), fd->path);
 		file_data_unref(fd);
-		string_list_free(keywords);
+		g_list_free_full(keywords, g_free);
 
 		return (G_SOURCE_CONTINUE);
 		}
@@ -3234,7 +3234,7 @@ static void config_tab_keywords_save()
 
 	keyword_list_set(kw_list);
 
-	string_list_free(kw_list);
+	g_list_free_full(kw_list, g_free);
 	g_free(buffer_text);
 }
 
@@ -3911,7 +3911,7 @@ static void config_tab_advanced(GtkWidget *notebook)
 	gtk_widget_show(vbox);
 
 	g_slist_free(formats_list);
-	string_list_free(extensions_list);
+	g_list_free_full(extensions_list, g_free);
 	g_string_free(types_string, TRUE);
 
 	pref_spacer(group, PREF_PAD_GROUP);

--- a/src/remote.cc
+++ b/src/remote.cc
@@ -1155,7 +1155,7 @@ static void gr_collection_list(const gchar *UNUSED(text), GIOChannel *channel, g
 	g_io_channel_write_chars(channel, out_string->str, -1, nullptr, nullptr);
 	g_io_channel_write_chars(channel, "<gq_end_of_command>", -1, nullptr, nullptr);
 
-	string_list_free(collection_list);
+	g_list_free_full(collection_list, g_free);
 	g_string_free(out_string, TRUE);
 }
 

--- a/src/renderer-tiles.cc
+++ b/src/renderer-tiles.cc
@@ -305,20 +305,7 @@ static void rt_tile_free(ImageTile *it)
 
 static void rt_tile_free_all(RendererTiles *rt)
 {
-	GList *work;
-
-	work = rt->tiles;
-	while (work)
-		{
-		ImageTile *it;
-
-		it = static_cast<ImageTile *>(work->data);
-		work = work->next;
-
-		rt_tile_free(it);
-		}
-
-	g_list_free(rt->tiles);
+	g_list_free_full(rt->tiles, reinterpret_cast<GDestroyNotify>(rt_tile_free));
 	rt->tiles = nullptr;
 	rt->tile_cache_size = 0;
 }

--- a/src/search.cc
+++ b/src/search.cc
@@ -2153,7 +2153,7 @@ static gboolean search_file_next(SearchData *sd)
 
 				match = !found;
 				}
-			string_list_free(list);
+			g_list_free_full(list, g_free);
 			}
 		else
 			{
@@ -2713,7 +2713,7 @@ static void search_start_cb(GtkWidget *UNUSED(widget), gpointer data)
 			}
 		}
 
-	string_list_free(sd->search_keyword_list);
+	g_list_free_full(sd->search_keyword_list, g_free);
 	sd->search_keyword_list = keyword_list_pull(sd->entry_keywords);
 
 	date_selection_get(sd->date_sel, &sd->search_date_d, &sd->search_date_m, &sd->search_date_y);
@@ -3219,7 +3219,7 @@ static void search_window_destroy_cb(GtkWidget *UNUSED(widget), gpointer data)
 		g_regex_unref(sd->search_comment_regex);
 		}
 	g_free(sd->search_similarity_path);
-	string_list_free(sd->search_keyword_list);
+	g_list_free_full(sd->search_keyword_list, g_free);
 
 	file_data_unregister_notify_func(search_notify_cb, sd);
 

--- a/src/search.cc
+++ b/src/search.cc
@@ -491,8 +491,7 @@ static gboolean search_result_row_selected(SearchData *sd, FileData *fd)
 		if (mfd_n->fd == fd) found = TRUE;
 		work = work->next;
 		}
-	g_list_foreach(slist, static_cast<GFunc>(tree_path_free_wrapper), nullptr);
-	g_list_free(slist);
+	g_list_free_full(slist, reinterpret_cast<GDestroyNotify>(gtk_tree_path_free));
 
 	return found;
 }
@@ -530,8 +529,7 @@ static gint search_result_selection_util(SearchData *sd, gint64 *bytes, GList **
 
 		work = work->next;
 		}
-	g_list_foreach(slist, static_cast<GFunc>(tree_path_free_wrapper), nullptr);
-	g_list_free(slist);
+	g_list_free_full(slist, reinterpret_cast<GDestroyNotify>(gtk_tree_path_free));
 
 	if (bytes) *bytes = total;
 	if (list) *list = g_list_reverse(plist);
@@ -748,8 +746,7 @@ static void search_result_remove_selection(SearchData *sd)
 		flist = g_list_prepend(flist, mfd->fd);
 		work = work->next;
 		}
-	g_list_foreach(slist, static_cast<GFunc>(tree_path_free_wrapper), nullptr);
-	g_list_free(slist);
+	g_list_free_full(slist, reinterpret_cast<GDestroyNotify>(gtk_tree_path_free));
 
 	work = flist;
 	while (work)
@@ -1350,8 +1347,7 @@ static gboolean search_result_keypress_cb(GtkWidget *widget, GdkEventKey *event,
 		gtk_tree_model_get_iter(store, &iter, tpath);
 		gtk_tree_model_get(store, &iter, SEARCH_COLUMN_POINTER, &mfd, -1);
 		}
-	g_list_foreach(slist, static_cast<GFunc>(tree_path_free_wrapper), nullptr);
-	g_list_free(slist);
+	g_list_free_full(slist, reinterpret_cast<GDestroyNotify>(gtk_tree_path_free));
 
 	if (event->state & GDK_CONTROL_MASK)
 		{

--- a/src/ui-bookmark.cc
+++ b/src/ui-bookmark.cc
@@ -735,7 +735,7 @@ static void bookmark_dnd_get_data(GtkWidget *UNUSED(widget),
 		if(errors)
 			{
 			warning_dialog_dnd_uri_error(errors);
-			string_list_free(errors);
+			g_list_free_full(errors, g_free);
 			}
 		g_strfreev(uris);
 
@@ -768,7 +768,7 @@ static void bookmark_dnd_get_data(GtkWidget *UNUSED(widget),
 			g_free(real_path);
 			}
 
-		string_list_free(list);
+		g_list_free_full(list, g_free);
 
 		bookmark_populate_all(bm->key);
 		}

--- a/src/ui-fileops.cc
+++ b/src/ui-fileops.cc
@@ -724,15 +724,9 @@ gchar *get_current_dir()
 	return path8;
 }
 
-void list_free_wrapper(void *data, void *UNUSED(userdata))
-{
-	g_free(data);
-}
-
 void string_list_free(GList *list)
 {
-	g_list_foreach(list, static_cast<GFunc>(list_free_wrapper), nullptr);
-	g_list_free(list);
+	g_list_free_full(list, g_free);
 }
 
 GList *string_list_copy(const GList *list)

--- a/src/ui-pathsel.cc
+++ b/src/ui-pathsel.cc
@@ -237,7 +237,7 @@ static void dest_populate(Dest_Data *dd, const gchar *path)
 		list = list->next;
 		}
 
-	string_list_free(path_list);
+	g_list_free_full(path_list, g_free);
 
 
 	if (dd->f_view)
@@ -261,7 +261,7 @@ static void dest_populate(Dest_Data *dd, const gchar *path)
 			list = list->next;
 			}
 
-		string_list_free(file_list);
+		g_list_free_full(file_list, g_free);
 		}
 
 	g_free(dd->path);
@@ -348,7 +348,7 @@ static void dest_dnd_set_data(GtkWidget *view,
 		g_free(str);
 		}
 
-	string_list_free(list);
+	g_list_free_full(list, g_free);
 }
 
 static void dest_dnd_init(Dest_Data *dd)
@@ -943,10 +943,10 @@ static void dest_filter_add(Dest_Data *dd, const gchar *filter, const gchar *des
 
 static void dest_filter_clear(Dest_Data *dd)
 {
-	string_list_free(dd->filter_list);
+	g_list_free_full(dd->filter_list, g_free);
 	dd->filter_list = nullptr;
 
-	string_list_free(dd->filter_text_list);
+	g_list_free_full(dd->filter_text_list, g_free);
 	dd->filter_text_list = nullptr;
 
 	dest_filter_add(dd, "*", _("All Files"), TRUE);

--- a/src/ui-spinner.cc
+++ b/src/ui-spinner.cc
@@ -93,19 +93,10 @@ static void spinner_set_timeout(SpinnerData *sp, gint interval)
 static void spinner_destroy_cb(GtkWidget *UNUSED(widget), gpointer data)
 {
 	auto sp = static_cast<SpinnerData *>(data);
-	GList *work;
 
 	spinner_set_timeout(sp, 0);
 
-	work = sp->list;
-	while (work)
-		{
-		auto pb = static_cast<GdkPixbuf *>(work->data);
-		work = work->next;
-
-		g_object_unref(pb);
-		}
-	g_list_free(sp->list);
+	g_list_free_full(sp->list, g_object_unref);
 	g_free(sp);
 }
 

--- a/src/ui-tabcomp.cc
+++ b/src/ui-tabcomp.cc
@@ -88,20 +88,10 @@ static gint tab_completion_do(TabCompData *td);
 
 static void tab_completion_free_list(TabCompData *td)
 {
-	GList *list;
-
 	g_free(td->dir_path);
 	td->dir_path = nullptr;
 
-	list = td->file_list;
-
-	while (list)
-		{
-		g_free(list->data);
-		list = list->next;
-		}
-
-	g_list_free(td->file_list);
+	g_list_free_full(td->file_list, g_free);
 	td->file_list = nullptr;
 }
 

--- a/src/uri-utils.cc
+++ b/src/uri-utils.cc
@@ -71,7 +71,7 @@ gchar **uris_from_filelist(GList *list)
 {
 	GList *path_list = filelist_to_path_list(list);
 	gchar **ret = uris_from_pathlist(path_list);
-	string_list_free(path_list);
+	g_list_free_full(path_list, g_free);
 	return ret;
 }
 
@@ -139,7 +139,7 @@ GList *uri_filelist_from_uris(gchar **uris, GList **uri_error_list)
 {
 	GList *path_list = uri_pathlist_from_uris(uris, uri_error_list);
 	GList *filelist = filelist_from_path_list(path_list);
-	string_list_free(path_list);
+	g_list_free_full(path_list, g_free);
 	return filelist;
 }
 
@@ -151,7 +151,7 @@ GList *uri_filelist_from_gtk_selection_data(GtkSelectionData *selection_data)
 	if(errors)
 		{
 		warning_dialog_dnd_uri_error(errors);
-		string_list_free(errors);
+		g_list_free_full(errors, g_free);
 		}
 	g_strfreev(uris);
 	return ret;

--- a/src/utilops.cc
+++ b/src/utilops.cc
@@ -3177,7 +3177,7 @@ static void clipboard_clear_func(GtkClipboard *UNUSED(clipboard), gpointer data)
 {
 	auto cbd = static_cast<ClipboardData *>(data);
 
-	string_list_free(cbd->path_list);
+	g_list_free_full(cbd->path_list, g_free);
 	g_free(cbd);
 }
 

--- a/src/view-dir-tree.cc
+++ b/src/view-dir-tree.cc
@@ -253,18 +253,12 @@ static GList *parts_list(const gchar *path)
 	return list;
 }
 
-static void parts_list_free(GList *list)
+static void path_data_free(PathData *pd)
 {
-	GList *work = list;
-	while (work)
-		{
-		auto pd = static_cast<PathData *>(work->data);
-		g_free(pd->name);
-		g_free(pd);
-		work = work->next;
-		}
+	if (!pd) return;
 
-	g_list_free(list);
+	g_free(pd->name);
+	g_free(pd);
 }
 
 static GList *parts_list_add_node_points(ViewDir *vd, GList *list)
@@ -646,7 +640,7 @@ FileData *vdtree_populate_path(ViewDir *vd, FileData *target_fd, gboolean expand
 				{
 				/* should not happen */
 				log_printf("vdtree warning, root node not found\n");
-				parts_list_free(list);
+				g_list_free_full(list, reinterpret_cast<GDestroyNotify>(path_data_free));
 				vdtree_busy_pop(vd);
 				return nullptr;
 				}
@@ -658,7 +652,7 @@ FileData *vdtree_populate_path(ViewDir *vd, FileData *target_fd, gboolean expand
 			    (nd = vdtree_find_iter_by_name(vd, &parent_iter, pd->name, &iter)) == nullptr)
 				{
 				log_printf("vdtree warning, aborted at %s\n", parent_pd->name);
-				parts_list_free(list);
+				g_list_free_full(list, reinterpret_cast<GDestroyNotify>(path_data_free));
 				vdtree_busy_pop(vd);
 				return nullptr;
 				}
@@ -695,7 +689,7 @@ FileData *vdtree_populate_path(ViewDir *vd, FileData *target_fd, gboolean expand
 		auto pd = static_cast<PathData *>(work->data);
 		fd = pd->node;
 		}
-	parts_list_free(list);
+	g_list_free_full(list, reinterpret_cast<GDestroyNotify>(path_data_free));
 
 	vdtree_busy_pop(vd);
 

--- a/src/view-file/view-file-icon.cc
+++ b/src/view-file/view-file-icon.cc
@@ -499,7 +499,7 @@ static void vficon_drag_data_received(GtkWidget *UNUSED(entry_widget), GdkDragCo
 			GList *kw_list = string_to_keywords_list(str);
 
 			metadata_append_list(fd, KEYWORD_KEY, kw_list);
-			string_list_free(kw_list);
+			g_list_free_full(kw_list, g_free);
 			g_free(str);
 		}
 	}

--- a/src/view-file/view-file-list.cc
+++ b/src/view-file/view-file-list.cc
@@ -1416,8 +1416,7 @@ static gboolean vflist_row_is_selected(ViewFile *vf, FileData *fd)
 		if (fd_n == fd) found = TRUE;
 		work = work->next;
 		}
-	g_list_foreach(slist, static_cast<GFunc>(tree_path_free_wrapper), nullptr);
-	g_list_free(slist);
+	g_list_free_full(slist, reinterpret_cast<GDestroyNotify>(gtk_tree_path_free));
 
 	return found;
 }
@@ -1466,8 +1465,7 @@ guint vflist_selection_count(ViewFile *vf, gint64 *bytes)
 		}
 
 	count = g_list_length(slist);
-	g_list_foreach(slist, static_cast<GFunc>(tree_path_free_wrapper), nullptr);
-	g_list_free(slist);
+	g_list_free_full(slist, reinterpret_cast<GDestroyNotify>(gtk_tree_path_free));
 
 	return count;
 }
@@ -1508,8 +1506,7 @@ GList *vflist_selection_get_list(ViewFile *vf)
 
 		work = work->next;
 		}
-	g_list_foreach(slist, static_cast<GFunc>(tree_path_free_wrapper), nullptr);
-	g_list_free(slist);
+	g_list_free_full(slist, reinterpret_cast<GDestroyNotify>(gtk_tree_path_free));
 
 	return g_list_reverse(list);
 }
@@ -1538,8 +1535,7 @@ GList *vflist_selection_get_list_by_index(ViewFile *vf)
 
 		work = work->next;
 		}
-	g_list_foreach(slist, static_cast<GFunc>(tree_path_free_wrapper), nullptr);
-	g_list_free(slist);
+	g_list_free_full(slist, reinterpret_cast<GDestroyNotify>(gtk_tree_path_free));
 
 	return g_list_reverse(list);
 }
@@ -1793,8 +1789,7 @@ void vflist_selection_to_mark(ViewFile *vf, gint mark, SelectionToMarkMode mode)
 
 		work = work->next;
 		}
-	g_list_foreach(slist, static_cast<GFunc>(tree_path_free_wrapper), nullptr);
-	g_list_free(slist);
+	g_list_free_full(slist, reinterpret_cast<GDestroyNotify>(gtk_tree_path_free));
 }
 
 /*

--- a/src/view-file/view-file-list.cc
+++ b/src/view-file/view-file-list.cc
@@ -281,7 +281,7 @@ static void vflist_drag_data_received(GtkWidget *UNUSED(entry_widget), GdkDragCo
 			GList *kw_list = string_to_keywords_list(str);
 
 			metadata_append_list(fd, KEYWORD_KEY, kw_list);
-			string_list_free(kw_list);
+			g_list_free_full(kw_list, g_free);
 			g_free(str);
 		}
 	}

--- a/src/view-file/view-file-list.cc
+++ b/src/view-file/view-file-list.cc
@@ -167,10 +167,11 @@ static void vflist_store_clear(ViewFile *vf, gboolean unlock_files)
 		{
 		// unlock locked files in this directory
 		filelist_read(vf->dir_fd, &files, nullptr);
-		while (files)
+		GList *work = files;
+		while (work)
 			{
-			auto fd = static_cast<FileData *>(files->data);
-			files = files->next;
+			auto fd = static_cast<FileData *>(work->data);
+			work = work->next;
 			file_data_unlock(fd);
 			file_data_unref(fd);  // undo the ref that got added in filelist_read
 			}


### PR DESCRIPTION
Mostly fixes are:
- Use `g_list_free_full` instead of `while`+`g_list_free` to avoid extra loop.
- Remove some wrappers, use `reinterpret_cast<GDestroyNotify>`.
- Use temporary variable as list iterator to save original list pointer.