### PR TITLE
Remove deprecated orientation-specific widgets

### DIFF
--- a/src/desktop-file.cc
+++ b/src/desktop-file.cc
@@ -212,7 +212,7 @@ static void editor_window_new(const gchar *src_path, const gchar *desktop_name)
 	gtk_widget_show(ew->entry);
 	g_signal_connect(G_OBJECT(ew->entry), "changed", G_CALLBACK(editor_window_entry_changed_cb), ew);
 
-	button_hbox = gtk_hbutton_box_new();
+	button_hbox = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
 	gtk_button_box_set_layout(GTK_BUTTON_BOX(button_hbox), GTK_BUTTONBOX_END);
 	gtk_box_set_spacing(GTK_BOX(button_hbox), PREF_PAD_BUTTON_GAP);
 	gtk_box_pack_end(GTK_BOX(hbox), button_hbox, FALSE, FALSE, 0);
@@ -553,7 +553,7 @@ static void editor_list_window_create()
 	gtk_container_add(GTK_CONTAINER(ewl->window), win_vbox);
 	gtk_widget_show(win_vbox);
 
-	hbox = gtk_hbutton_box_new();
+	hbox = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
 	gtk_button_box_set_layout(GTK_BUTTON_BOX(hbox), GTK_BUTTONBOX_END);
 	gtk_box_set_spacing(GTK_BOX(hbox), PREF_PAD_BUTTON_GAP);
 	gtk_box_pack_end(GTK_BOX(win_vbox), hbox, FALSE, FALSE, 0);

--- a/src/dupe.cc
+++ b/src/dupe.cc
@@ -4778,7 +4778,7 @@ DupeWindow *dupe_window_new()
 	gtk_box_pack_start(GTK_BOX(vbox), button_box, FALSE, FALSE, 0);
 	gtk_widget_show(button_box);
 
-	hbox = gtk_hbutton_box_new();
+	hbox = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
 	gtk_button_box_set_layout(GTK_BUTTON_BOX(hbox), GTK_BUTTONBOX_END);
 	gtk_box_set_spacing(GTK_BOX(hbox), PREF_PAD_SPACE);
 	gtk_box_pack_end(GTK_BOX(button_box), hbox, FALSE, FALSE, 0);

--- a/src/layout.cc
+++ b/src/layout.cc
@@ -2265,7 +2265,7 @@ void layout_show_config_window(LayoutWindow *lw)
 	gtk_container_add(GTK_CONTAINER(lc->configwindow), win_vbox);
 	gtk_widget_show(win_vbox);
 
-	hbox = gtk_hbutton_box_new();
+	hbox = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
 	gtk_button_box_set_layout(GTK_BUTTON_BOX(hbox), GTK_BUTTONBOX_END);
 	gtk_box_set_spacing(GTK_BOX(hbox), PREF_PAD_BUTTON_GAP);
 	gtk_box_pack_end(GTK_BOX(win_vbox), hbox, FALSE, FALSE, 0);

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -1904,14 +1904,14 @@ static void pan_window_new_real(FileData *dir_fd)
 
 	pan_image_set_buttons(pw, pw->imd);
 
-	pw->scrollbar_h = gtk_hscrollbar_new(nullptr);
+	pw->scrollbar_h = gtk_scrollbar_new(GTK_ORIENTATION_HORIZONTAL, nullptr);
 	g_signal_connect(G_OBJECT(pw->scrollbar_h), "value_changed",
 			 G_CALLBACK(pan_window_scrollbar_h_value_cb), pw);
 	gtk_table_attach(GTK_TABLE(table), pw->scrollbar_h, 0, 1, 1, 2,
 			 static_cast<GtkAttachOptions>(GTK_FILL | GTK_EXPAND), static_cast<GtkAttachOptions>(0), 0, 0);
 	gtk_widget_show(pw->scrollbar_h);
 
-	pw->scrollbar_v = gtk_vscrollbar_new(nullptr);
+	pw->scrollbar_v = gtk_scrollbar_new(GTK_ORIENTATION_VERTICAL, nullptr);
 	g_signal_connect(G_OBJECT(pw->scrollbar_v), "value_changed",
 			 G_CALLBACK(pan_window_scrollbar_v_value_cb), pw);
 	gtk_table_attach(GTK_TABLE(table), pw->scrollbar_v, 1, 2, 0, 1,

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -4050,7 +4050,7 @@ static void config_window_create(LayoutWindow *lw)
 
 	gtk_notebook_set_current_page(GTK_NOTEBOOK(notebook), lw->options.preferences_window.page_number);
 
-	hbox = gtk_hbutton_box_new();
+	hbox = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
 	gtk_button_box_set_layout(GTK_BUTTON_BOX(hbox), GTK_BUTTONBOX_END);
 	gtk_box_set_spacing(GTK_BOX(hbox), PREF_PAD_BUTTON_GAP);
 	gtk_box_pack_end(GTK_BOX(win_vbox), hbox, FALSE, FALSE, 0);

--- a/src/ui-help.cc
+++ b/src/ui-help.cc
@@ -237,7 +237,7 @@ GtkWidget *help_window_new(const gchar *title,
 	gtk_text_buffer_create_tag(buffer, "monospace",
 				   "family", "monospace", NULL);
 
-	hbox = gtk_hbutton_box_new();
+	hbox = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
 	gtk_container_set_border_width(GTK_CONTAINER(hbox), PREF_PAD_BORDER);
 	gtk_button_box_set_layout(GTK_BUTTON_BOX(hbox), GTK_BUTTONBOX_END);
 	gtk_box_pack_end(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);

--- a/src/ui-misc.cc
+++ b/src/ui-misc.cc
@@ -169,15 +169,7 @@ GtkWidget *pref_line(GtkWidget *parent_box, gboolean padding)
 {
 	GtkWidget *spacer;
 
-	if (GTK_IS_HBOX(parent_box))
-		{
-		spacer = gtk_vseparator_new();
-		}
-	else
-		{
-		spacer = gtk_hseparator_new();
-		}
-
+	spacer = gtk_separator_new(GTK_IS_HBOX(parent_box) ? GTK_ORIENTATION_VERTICAL : GTK_ORIENTATION_HORIZONTAL);
 	gtk_box_pack_start(GTK_BOX(parent_box), spacer, FALSE, FALSE, padding / 2);
 	gtk_widget_show(spacer);
 

--- a/src/ui-utildlg.cc
+++ b/src/ui-utildlg.cc
@@ -445,7 +445,7 @@ static void generic_dialog_setup(GenericDialog *gd,
 	gtk_box_pack_start(GTK_BOX(vbox), gd->vbox, TRUE, TRUE, 0);
 	gtk_widget_show(gd->vbox);
 
-	gd->hbox = gtk_hbutton_box_new();
+	gd->hbox = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
 	gtk_button_box_set_layout(GTK_BUTTON_BOX(gd->hbox), GTK_BUTTONBOX_END);
 	gtk_box_set_spacing(GTK_BOX(gd->hbox), PREF_PAD_BUTTON_GAP);
 	gtk_box_pack_start(GTK_BOX(vbox), gd->hbox, FALSE, FALSE, 0);

--- a/src/utilops.cc
+++ b/src/utilops.cc
@@ -90,7 +90,7 @@ static void generic_dialog_add_image(GenericDialog *gd, GtkWidget *box,
 
 		gtk_box_pack_start(GTK_BOX(preview_box), vbox, FALSE, TRUE, 0);
 
-		sep = gtk_hseparator_new();
+		sep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
 		gtk_box_pack_start(GTK_BOX(preview_box), sep, FALSE, FALSE, 0);
 		gtk_widget_show(sep);
 		}


### PR DESCRIPTION
- Replace GtkHButtonBox with GtkButtonBox.
- Replace GtkHScrollbar, GtkVScrollbar with GtkScrollbar.
- Remove GtkHSeparator, GtkVSeparator with GtkSeparator.