### PR TITLE
Replace gtk_widget_render_icon with gtk_icon_theme_load_icon

### DIFF
--- a/src/logwindow.cc
+++ b/src/logwindow.cc
@@ -498,7 +498,7 @@ static LogWindow *log_window_create(LayoutWindow *lw)
 	g_signal_connect(logwin->search_entry_box, "activate", G_CALLBACK(search_activate_event), logwin);
 
 	theme = gtk_icon_theme_get_default();
-	pixbuf = gtk_icon_theme_load_icon(theme, "pan-up-symbolic", 20, GTK_ICON_LOOKUP_GENERIC_FALLBACK, nullptr);
+	pixbuf = gtk_icon_theme_load_icon(theme, GQ_ICON_PAN_UP, 20, GTK_ICON_LOOKUP_GENERIC_FALLBACK, nullptr);
 	image = gtk_image_new_from_pixbuf(pixbuf);
 	backwards_button = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(backwards_button), GTK_WIDGET(image));
@@ -508,7 +508,7 @@ static LogWindow *log_window_create(LayoutWindow *lw)
 	g_signal_connect(backwards_button, "button_release_event", G_CALLBACK(backwards_keypress_event_cb), logwin);
 	g_object_unref(pixbuf);
 
-	pixbuf = gtk_icon_theme_load_icon(theme, "pan-down-symbolic", 20, GTK_ICON_LOOKUP_GENERIC_FALLBACK, nullptr);
+	pixbuf = gtk_icon_theme_load_icon(theme, GQ_ICON_PAN_DOWN, 20, GTK_ICON_LOOKUP_GENERIC_FALLBACK, nullptr);
 	image = gtk_image_new_from_pixbuf(pixbuf);
 	forwards_button = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(forwards_button), GTK_WIDGET(image));

--- a/src/main.h
+++ b/src/main.h
@@ -136,6 +136,7 @@
 #define GQ_ICON_ADD "list-add"
 #define GQ_ICON_REMOVE "list-remove"
 #define GQ_ICON_UNDO "edit-undo"
+#define GQ_ICON_REDO "edit-redo"
 #define GQ_ICON_OPEN "document-open"
 #define GQ_ICON_SAVE "document-save"
 #define GQ_ICON_SAVE_AS "document-save-as"

--- a/src/ui-misc.cc
+++ b/src/ui-misc.cc
@@ -1626,4 +1626,15 @@ gboolean defined_mouse_buttons(GtkWidget *, GdkEventButton *event, gpointer data
 	return ret;
 }
 
+GdkPixbuf *gq_gtk_icon_theme_load_icon_copy(GtkIconTheme *icon_theme, const gchar *icon_name, gint size, GtkIconLookupFlags flags)
+{
+	GError *error = nullptr;
+	GdkPixbuf *icon = gtk_icon_theme_load_icon(icon_theme, icon_name, size, flags, &error);
+	if (error) return nullptr;
+
+	GdkPixbuf *pixbuf = gdk_pixbuf_copy(icon);
+	g_object_unref(icon);
+	return pixbuf;
+}
+
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/ui-misc.h
+++ b/src/ui-misc.h
@@ -238,5 +238,8 @@ GList* get_action_items();
 void action_items_free(GList *list);
 
 gboolean defined_mouse_buttons(GtkWidget *widget, GdkEventButton *event, gpointer data);
+
+// Copy pixbuf returned by gtk_icon_theme_load_icon() to avoid GTK+ keeping the old icon theme loaded
+GdkPixbuf *gq_gtk_icon_theme_load_icon_copy(GtkIconTheme *icon_theme, const gchar *icon_name, gint size, GtkIconLookupFlags flags);
 #endif
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */


### PR DESCRIPTION
* Use icon size in pixels in gtk_icon_theme_load_icon
* Deduplicate folder icons creation
* Copy pixbuf returned by gtk_icon_theme_load_icon to avoid GTK+ keeping the old icon theme loaded
* Move static functions to anonymous namespace
* Replace some icon name string literals with GQ_ICON macros