### PR TITLE
Replace deprecated *-gdk properties

### DIFF
--- a/src/cellrenderericon.cc
+++ b/src/cellrenderericon.cc
@@ -169,7 +169,7 @@ gqv_cell_renderer_icon_class_init(GQvCellRendererIconClass *icon_class)
 
 	g_object_class_install_property(object_class,
 					PROP_BACKGROUND_GDK,
-					g_param_spec_boxed("background_gdk",
+					g_param_spec_boxed("background_rgba",
 							"Background color",
 							"Background color as a GdkRGBA",
 							GDK_TYPE_RGBA,
@@ -177,7 +177,7 @@ gqv_cell_renderer_icon_class_init(GQvCellRendererIconClass *icon_class)
 
 	g_object_class_install_property(object_class,
 					PROP_FOREGROUND_GDK,
-					g_param_spec_boxed("foreground_gdk",
+					g_param_spec_boxed("foreground_rgba",
 							"Foreground color",
 							"Foreground color as a GdkRGBA",
 							GDK_TYPE_RGBA,

--- a/src/collect-table.cc
+++ b/src/collect-table.cc
@@ -2570,9 +2570,9 @@ static void collection_table_cell_data_cb(GtkTreeViewColumn *, GtkCellRenderer *
 			{
 			g_object_set(cell,	"pixbuf", info->pixbuf,
 						"text",  display_text,
-						"cell-background-gdk", &color_bg,
+						"cell-background-rgba", &color_bg,
 						"cell-background-set", TRUE,
-						"foreground-gdk", &color_fg,
+						"foreground-rgba", &color_fg,
 						"foreground-set", TRUE,
 						"has-focus", (ct->focus_info == info), NULL);
 			}

--- a/src/dupe.cc
+++ b/src/dupe.cc
@@ -4023,7 +4023,7 @@ static void dupe_listview_color_cb(GtkTreeViewColumn *, GtkCellRenderer *cell,
 
 	gtk_tree_model_get(tree_model, iter, DUPE_COLUMN_COLOR, &set, -1);
 	g_object_set(G_OBJECT(cell),
-		     "cell-background-gdk", dupe_listview_color_shifted(dw->listview),
+		     "cell-background-rgba", dupe_listview_color_shifted(dw->listview),
 		     "cell-background-set", set, NULL);
 }
 

--- a/src/view-dir.cc
+++ b/src/view-dir.cc
@@ -25,8 +25,8 @@
 #include "dupe.h"
 #include "editors.h"
 #include "filedata.h"
+#include "layout.h"
 #include "layout-image.h"
-#include "layout-util.h"
 #include "menu.h"
 #include "ui-fileops.h"
 #include "ui-tree-edit.h"
@@ -1200,7 +1200,7 @@ void vd_color_cb(GtkTreeViewColumn *, GtkCellRenderer *cell, GtkTreeModel *tree_
 
 	gtk_tree_model_get(tree_model, iter, DIR_COLUMN_COLOR, &set, -1);
 	g_object_set(G_OBJECT(cell),
-		     "cell-background-gdk", vd_color_shifted(vd->view),
+		     "cell-background-rgba", vd_color_shifted(vd->view),
 		     "cell-background-set", set, NULL);
 }
 

--- a/src/view-file/view-file-icon.cc
+++ b/src/view-file/view-file-icon.cc
@@ -2150,7 +2150,7 @@ static void vficon_cell_data_cb(GtkTreeViewColumn *, GtkCellRenderer *cell,
 					"show_marks", vf->marks_enabled,
 					"cell-background-rgba", &color_bg,
 					"cell-background-set", TRUE,
-					"foreground-gdk", &color_fg,
+					"foreground-rgba", &color_fg,
 					"foreground-set", TRUE,
 					"has-focus", (VFICON(vf)->focus_fd == fd), NULL);
 		g_free(name_sidecars);

--- a/src/view-file/view-file-list.cc
+++ b/src/view-file/view-file-list.cc
@@ -1981,7 +1981,7 @@ static void vflist_listview_color_cb(GtkTreeViewColumn *, GtkCellRenderer *cell,
 
 	gtk_tree_model_get(tree_model, iter, FILE_COLUMN_COLOR, &set, -1);
 	g_object_set(G_OBJECT(cell),
-		     "cell-background-gdk", vflist_listview_color_shifted(vf->listview),
+		     "cell-background-rgba", vflist_listview_color_shifted(vf->listview),
 		     "cell-background-set", set, NULL);
 }
 


### PR DESCRIPTION
Use *-rgba counterparts, rename related GQvCellRendererIcon properties