### PR TITLE
Use sigsetjmp instead of setjmp where appropriate

### DIFF
--- a/src/image-load-cr3.cc
+++ b/src/image-load-cr3.cc
@@ -353,7 +353,7 @@ static gboolean image_loader_cr3_load (gpointer loader, const guchar *buf, gsize
         jerr.error = error;
 
 
-	if (setjmp(jerr.setjmp_buffer))
+	if (sigsetjmp(jerr.setjmp_buffer, 0))
 		{
 		/* If we get here, the JPEG code has signaled an error.
 		 * We need to clean up the JPEG object, close the input file, and return.

--- a/src/image-load-jpeg.cc
+++ b/src/image-load-jpeg.cc
@@ -313,7 +313,7 @@ static gboolean image_loader_jpeg_load (gpointer loader, const guchar *buf, gsiz
         jerr.error = error;
 
 
-	if (setjmp(jerr.setjmp_buffer))
+	if (sigsetjmp(jerr.setjmp_buffer, 0))
 		{
 		/* If we get here, the JPEG code has signaled an error.
 		 * We need to clean up the JPEG object, close the input file, and return.


### PR DESCRIPTION
At least on FreeBSD, `setjmp`/`longjmp` and `sigsetjmp`/`siglongjmp` are different families of functions and cannot be mixed together, as these use different state structures (`jmp_buf` and `sigjmp_buf` respectively). Since `sigjmp_buf` is used in the Geeqie code, use corresponding `sigsetjmp` for it.
