### PR TITLE
Fix iterating through lua dependency variants when lua is required

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -411,8 +411,9 @@ lua_dep = []
 req_version = '>=5.3'
 option = get_option('lua')
 if not option.disabled()
-    foreach name : ['lua', 'lua5.3', 'lua-5.3', 'lua53']
-        lua_dep = dependency(name, version: req_version, required: get_option('lua'))
+    lua_names = ['lua5.3', 'lua-5.3', 'lua53', 'lua']
+    foreach name : lua_names
+        lua_dep = dependency(name, version: req_version, required: name == lua_names[-1] ? get_option('lua') : false)
         if lua_dep.found()
             break
         endif


### PR DESCRIPTION
When lua is required and the build fails to find the first lua dependency variant from the list, build fails right away without trying other variants. Fix this by treating only the last variant as required. Also, move unversioned lua variant to the end to prefer versioned ones, which lessens chance to pick different version than expected 5.3 and provides more generic error message when lua is not found.
