### PR TITLE
Add keywords to desktop file

### DIFF
--- a/org.geeqie.Geeqie.desktop.in
+++ b/org.geeqie.Geeqie.desktop.in
@@ -12,3 +12,4 @@ Terminal=false
 NotShowIn=X-Geeqie;
 Categories=Graphics;Viewer;
 MimeType=application/x-navi-animation;image/bmp;image/x-bmp;image/x-MS-bmp;image/gif;image/x-icon;image/jpeg;image/png;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-portable-pixmap;image/x-tga;image/tiff;image/x-xbitmap;image/x-xpixmap;image/svg;image/svg+xml;image/x-png;image/xpm;image/x-ico;
+Keywords=Picture;Slideshow;Graphics;


### PR DESCRIPTION
Add Keywords to the desktop file - I've got a warning of the debian package analyser tool lintian, this commit fixes this, full lintian output here:

```
I: geeqie: desktop-entry-lacks-keywords-entry [usr/share/applications/org.geeqie.Geeqie.desktop]
N: 
N:   This .desktop file is either missing a Keywords entry, or it does not contain keywords above and beyond those already present in the Name or
N:   GenericName entries.
N:   
N:   The Keywords field is intended to show keywords relevant for a .desktop file.
N:   
N:   Desktop files are organized in key-value pairs and are similar to INI files.
N:   
N:   The desktop-file-validate tool in the desktop-file-utils package may be useful when checking the syntax of desktop entries.
N: 
N:   Please refer to https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html, Bug#693918, and
N:   https://wiki.gnome.org/Initiatives/GnomeGoals/DesktopFileKeywords for details.
N: 
N:   Visibility: info
N:   Show-Always: no
N:   Check: menu-format
N: 
```