### PR TITLE
Fix permissions for geocode-parameters plugin

### DIFF
--- a/plugins/geocode-parameters/meson.build
+++ b/plugins/geocode-parameters/meson.build
@@ -11,4 +11,4 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #
 
-install_data('geocode-parameters.awk', install_dir : gq_bindir)
+install_data('geocode-parameters.awk', install_dir : gq_bindir, install_mode : 'rwxr-xr-x')


### PR DESCRIPTION
Again lintian warns me for stuff - this time the permissions on the geocode-parameters.awk plugin:

```
N:
W: geeqie-common: script-not-executable [usr/lib/geeqie/geocode-parameters.awk]
N: 
N:   This file starts with the #! sequence that marks interpreted scripts, but it is not executable.
N:   
N:   There has been some discussion to allow such files in paths other than /usr/bin but there was ultimately no broad support for it.
N: 
N:   Please refer to Bug#368792 for details.
N: 
N:   Visibility: warning
N:   Show-Always: no
N:   Check: scripts
N: 
```

This commit should fix this and make geocode-parameters.awk have the same permissions as the rest of the plugins in the /usr/lib/geeqie/ folder. And as the lintian warning I assume it should have the executable permission, since it has the #! shebang.

And I add a link to the bug mentioned in the lintian warning: https://bugs.debian.org/368792