### PR TITLE
Limit definition of XOPEN_SOURCE to Linux, where it's needed.

### DIFF
--- a/src/exif-common.cc
+++ b/src/exif-common.cc
@@ -19,7 +19,9 @@
 
 #include <config.h>
 
+#ifdef __linux__
 #define _XOPEN_SOURCE
+#endif
 
 #include <cmath>
 #include <cstdlib>


### PR DESCRIPTION
The definition breaks the build on NetBSD where it hides symbols (to match what the standard says).

Fixes #1230.