### PR TITLE
Bump Exiv2 minimum version requirement to 0.18

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -275,7 +275,7 @@ else
 endif
 
 exiv2_dep = []
-req_version = '>=0.11'
+req_version = '>=0.18'
 option = get_option('exiv2')
 if not option.disabled()
     exiv2_dep = dependency('exiv2', version : req_version, required : get_option('exiv2'))


### PR DESCRIPTION
Remove obsolete code.

According to [repology](https://repology.org/project/exiv2/versions) 0.18 is the oldest version in repos.