### PR TITLE
Deduplicate cr3 image loader

### DIFF
--- a/src/image-load-cr3.h
+++ b/src/image-load-cr3.h
@@ -23,12 +23,12 @@
 
 #include <config.h>
 
-#if HAVE_JPEG
+#if HAVE_JPEG && !HAVE_RAW
 struct ImageLoaderBackend;
 
 void image_loader_backend_set_cr3(ImageLoaderBackend *funcs);
 #endif
 
-#endif
+#endif // IMAGE_LOAD_CR3_H
 
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/image-load-jpeg.cc
+++ b/src/image-load-jpeg.cc
@@ -270,7 +270,7 @@ static void set_mem_src (j_decompress_ptr cinfo, void* buffer, long nbytes)
 }
 
 
-static gboolean image_loader_jpeg_load (gpointer loader, const guchar *buf, gsize count, GError **error)
+gboolean image_loader_jpeg_load (gpointer loader, const guchar *buf, gsize count, GError **error)
 {
 	auto lj = static_cast<ImageLoaderJpeg *>(loader);
 	struct jpeg_decompress_struct cinfo;

--- a/src/image-load-jpeg.h
+++ b/src/image-load-jpeg.h
@@ -25,7 +25,11 @@
 #include <config.h>
 
 #if HAVE_JPEG
+#include <glib.h>
+
 struct ImageLoaderBackend;
+
+gboolean image_loader_jpeg_load(gpointer loader, const guchar *buf, gsize count, GError **error);
 
 void image_loader_backend_set_jpeg(ImageLoaderBackend *funcs);
 #endif


### PR DESCRIPTION
Make it wrapper of jpeg image loader.
Add `HAVE_RAW` define check to make consistent with usage in `image-load`.
Move static functions to anonymous namespace.