### PR TITLE
Translation fixes

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -6,7 +6,6 @@ plugins/image-crop/org.geeqie.image-crop.desktop.in
 plugins/open-with/org.geeqie.open-with.desktop.in
 plugins/org.geeqie.template.desktop.in
 plugins/random-image/org.geeqie.random-image.desktop.in
-plugins/refresh-thumbnail/org.geeqie.refresh-thumbnail.desktop.in
 plugins/resize-image/org.geeqie.resize-image.desktop.in
 plugins/rotate/org.geeqie.rotate.desktop.in
 plugins/symlink/org.geeqie.symlink.desktop.in

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -2339,7 +2339,7 @@ static void config_tab_image(GtkWidget *notebook)
 	gtk_widget_set_tooltip_text(GTK_WIDGET(hbox), _("Enable this to allow Geeqie to increase the image size for images that are smaller than the current view area when the zoom is set to \"Fit image to window\". This value sets the maximum expansion permitted in percent i.e. 100% is full-size."));
 
 	hbox = pref_box_new(group, FALSE, GTK_ORIENTATION_HORIZONTAL, PREF_PAD_SPACE);
-	ct_button = pref_checkbox_new_int(hbox, _("Virtual window size (% of actual window):"),
+	ct_button = pref_checkbox_new_int(hbox, _("Virtual window size (%% of actual window):"),
 					  options->image.limit_autofit_size, &c_options->image.limit_autofit_size);
 	spin = pref_spin_new_int(hbox, nullptr, nullptr,
 				 10, 150, 1,


### PR DESCRIPTION
Commits should be self-explainatory - I have a bit of a hard time finding stuff regarding the refresh-thumbnail plugin though, but it does give a build error for when trying to update translations, as mentioned on the geeqie mailinglist.

The percent stuff is that c-format wrongly interprets single percent as formatting, when it really should be a percent, which requires the syntax in my commit.