### PR TITLE
Mark another string in the --help output as translatable

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -551,7 +551,7 @@ static void parse_command_line(gint argc, gchar *argv[])
 #endif
 
 				print_term(FALSE, "\n");
-				print_term(FALSE, "* Normally a single set of configuration files is used for all instances.\nHowever, the environment variables XDG_CONFIG_HOME, XDG_CACHE_HOME, XDG_DATA_HOME\ncan be used to modify this behavior on an individual basis e.g.\n\nXDG_CONFIG_HOME=/tmp/a XDG_CACHE_HOME=/tmp/b geeqie\n\n");
+				print_term(FALSE, _("* Normally a single set of configuration files is used for all instances.\nHowever, the environment variables XDG_CONFIG_HOME, XDG_CACHE_HOME, XDG_DATA_HOME\ncan be used to modify this behavior on an individual basis e.g.\n\nXDG_CONFIG_HOME=/tmp/a XDG_CACHE_HOME=/tmp/b geeqie\n\n"));
 
 				remote_help();
 


### PR DESCRIPTION
Just marking another string that should be translatable as such.