### PR TITLE
Let image loader backend decide how to process image buffer

### DIFF
--- a/src/image-load-collection.cc
+++ b/src/image-load-collection.cc
@@ -35,6 +35,9 @@
 #include "options.h"
 #include "ui-fileops.h"
 
+namespace
+{
+
 struct ImageLoaderCOLLECTION {
 	ImageLoaderBackendCbAreaUpdated area_updated_cb;
 	ImageLoaderBackendCbSize size_cb;
@@ -46,7 +49,7 @@ struct ImageLoaderCOLLECTION {
 	gboolean abort;
 };
 
-static gboolean image_loader_collection_load(gpointer loader, const guchar *, gsize, GError **)
+gboolean image_loader_collection_write(gpointer loader, const guchar *, gsize &chunk_size, gsize count, GError **)
 {
 	auto ld = static_cast<ImageLoaderCOLLECTION *>(loader);
 	auto il = static_cast<ImageLoader *>(ld->data);
@@ -116,10 +119,11 @@ static gboolean image_loader_collection_load(gpointer loader, const guchar *, gs
 			g_string_free(file_names, TRUE);
 			}
 		}
+	chunk_size = count;
 	return ret;
 }
 
-static gpointer image_loader_collection_new(ImageLoaderBackendCbAreaUpdated area_updated_cb, ImageLoaderBackendCbSize size_cb, ImageLoaderBackendCbAreaPrepared area_prepared_cb, gpointer data)
+gpointer image_loader_collection_new(ImageLoaderBackendCbAreaUpdated area_updated_cb, ImageLoaderBackendCbSize size_cb, ImageLoaderBackendCbAreaPrepared area_prepared_cb, gpointer data)
 {
 	auto loader = g_new0(ImageLoaderCOLLECTION, 1);
 	loader->area_updated_cb = area_updated_cb;
@@ -129,53 +133,55 @@ static gpointer image_loader_collection_new(ImageLoaderBackendCbAreaUpdated area
 	return loader;
 }
 
-static void image_loader_collection_set_size(gpointer loader, int width, int height)
+void image_loader_collection_set_size(gpointer loader, int width, int height)
 {
 	auto ld = static_cast<ImageLoaderCOLLECTION *>(loader);
 	ld->requested_width = width;
 	ld->requested_height = height;
 }
 
-static GdkPixbuf* image_loader_collection_get_pixbuf(gpointer loader)
+GdkPixbuf* image_loader_collection_get_pixbuf(gpointer loader)
 {
 	auto ld = static_cast<ImageLoaderCOLLECTION *>(loader);
 	return ld->pixbuf;
 }
 
-static gchar* image_loader_collection_get_format_name(gpointer)
+gchar* image_loader_collection_get_format_name(gpointer)
 {
 	return g_strdup("collection");
 }
-static gchar** image_loader_collection_get_format_mime_types(gpointer)
+
+gchar** image_loader_collection_get_format_mime_types(gpointer)
 {
 	static const gchar *mime[] = {"image/png", nullptr};
 	return g_strdupv(const_cast<gchar **>(mime));
 }
 
-static gboolean image_loader_collection_close(gpointer, GError **)
+gboolean image_loader_collection_close(gpointer, GError **)
 {
 	return TRUE;
 }
 
-static void image_loader_collection_abort(gpointer loader)
+void image_loader_collection_abort(gpointer loader)
 {
 	auto ld = static_cast<ImageLoaderCOLLECTION *>(loader);
 	ld->abort = TRUE;
 }
 
-static void image_loader_collection_free(gpointer loader)
+void image_loader_collection_free(gpointer loader)
 {
 	auto ld = static_cast<ImageLoaderCOLLECTION *>(loader);
 	if (ld->pixbuf) g_object_unref(ld->pixbuf);
 	g_free(ld);
 }
 
+} // namespace
+
 void image_loader_backend_set_collection(ImageLoaderBackend *funcs)
 {
 	funcs->loader_new = image_loader_collection_new;
 	funcs->set_size = image_loader_collection_set_size;
-	funcs->load = image_loader_collection_load;
-	funcs->write = nullptr;
+	funcs->write = image_loader_collection_write;
 	funcs->get_pixbuf = image_loader_collection_get_pixbuf;
 	funcs->close = image_loader_collection_close;
 	funcs->abort = image_loader_collection_abort;

--- a/src/image-load-cr3.cc
+++ b/src/image-load-cr3.cc
@@ -36,7 +36,7 @@
 namespace
 {
 
-gboolean image_loader_cr3_load(gpointer loader, const guchar *buf, gsize count, GError **error)
+gboolean image_loader_cr3_write(gpointer loader, const guchar *buf, gsize &chunk_size, gsize count, GError **error)
 {
 	/** @FIXME Just start search at where full size jpeg should be,
 	 * then search through the file looking for a jpeg end-marker
@@ -78,7 +78,12 @@ gboolean image_loader_cr3_load(gpointer loader, const guchar *buf, gsize count, 
 		return FALSE;
 		}
 
-	return image_loader_jpeg_load(loader, buf + n + 12, i, error);
+	gboolean ret = image_loader_jpeg_write(loader, buf + n + 12, chunk_size, i, error);;
+	if (ret)
+		{
+		chunk_size = count;
+		}
+	return ret;
 }
 
 gchar* image_loader_cr3_get_format_name(gpointer)
@@ -98,7 +103,7 @@ void image_loader_backend_set_cr3(ImageLoaderBackend *funcs)
 {
 	image_loader_backend_set_jpeg(funcs);
 
-	funcs->load = image_loader_cr3_load;
+	funcs->write = image_loader_cr3_write;
 
 	funcs->get_format_name = image_loader_cr3_get_format_name;
 	funcs->get_format_mime_types = image_loader_cr3_get_format_mime_types;

--- a/src/image-load-dds.cc
+++ b/src/image-load-dds.cc
@@ -34,6 +34,9 @@
 
 #include "image-load.h"
 
+namespace
+{
+
 struct ImageLoaderDDS {
 	ImageLoaderBackendCbAreaUpdated area_updated_cb;
 	ImageLoaderBackendCbSize size_cb;
@@ -45,7 +48,7 @@ struct ImageLoaderDDS {
 	gboolean abort;
 };
 
-static void free_buffer(guchar *pixels, gpointer)
+void free_buffer(guchar *pixels, gpointer)
 {
 	g_free(pixels);
 }
@@ -113,22 +116,22 @@ enum {
 };
 
 // RGBA Masks
-static const uint A1R5G5B5_MASKS[] = { 0x7C00, 0x03E0, 0x001F, 0x8000 };
-static const uint X1R5G5B5_MASKS[] = { 0x7C00, 0x03E0, 0x001F, 0x0000 };
-static const uint A4R4G4B4_MASKS[] = { 0x0F00, 0x00F0, 0x000F, 0xF000 };
-static const uint X4R4G4B4_MASKS[] = { 0x0F00, 0x00F0, 0x000F, 0x0000 };
-static const uint R5G6B5_MASKS[] = { 0xF800, 0x07E0, 0x001F, 0x0000 };
-static const uint R8G8B8_MASKS[] = { 0xFF0000, 0x00FF00, 0x0000FF, 0x000000 };
-static const uint A8B8G8R8_MASKS[] = { 0x000000FF, 0x0000FF00, 0x00FF0000, 0xFF000000 };
-static const uint X8B8G8R8_MASKS[] = { 0x000000FF, 0x0000FF00, 0x00FF0000, 0x00000000 };
-static const uint A8R8G8B8_MASKS[] = { 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000 };
-static const uint X8R8G8B8_MASKS[] = { 0x00FF0000, 0x0000FF00, 0x000000FF, 0x00000000 };
+constexpr uint A1R5G5B5_MASKS[] = { 0x7C00, 0x03E0, 0x001F, 0x8000 };
+constexpr uint X1R5G5B5_MASKS[] = { 0x7C00, 0x03E0, 0x001F, 0x0000 };
+constexpr uint A4R4G4B4_MASKS[] = { 0x0F00, 0x00F0, 0x000F, 0xF000 };
+constexpr uint X4R4G4B4_MASKS[] = { 0x0F00, 0x00F0, 0x000F, 0x0000 };
+constexpr uint R5G6B5_MASKS[] = { 0xF800, 0x07E0, 0x001F, 0x0000 };
+constexpr uint R8G8B8_MASKS[] = { 0xFF0000, 0x00FF00, 0x0000FF, 0x000000 };
+constexpr uint A8B8G8R8_MASKS[] = { 0x000000FF, 0x0000FF00, 0x00FF0000, 0xFF000000 };
+constexpr uint X8B8G8R8_MASKS[] = { 0x000000FF, 0x0000FF00, 0x00FF0000, 0x00000000 };
+constexpr uint A8R8G8B8_MASKS[] = { 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000 };
+constexpr uint X8R8G8B8_MASKS[] = { 0x00FF0000, 0x0000FF00, 0x000000FF, 0x00000000 };
 
 // BIT4 = 17 * index;
-static const uint BIT5[] = { 0, 8, 16, 25, 33, 41, 49, 58, 66, 74, 82, 90, 99, 107, 115, 123, 132, 140, 148, 156, 165, 173, 181, 189, 197, 206, 214, 222, 230, 239, 247, 255 };
-static const uint BIT6[] = { 0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 45, 49, 53, 57, 61, 65, 69, 73, 77, 81, 85, 89, 93, 97, 101, 105, 109, 113, 117, 121, 125, 130, 134, 138, 142, 146, 150, 154, 158, 162, 166, 170, 174, 178, 182, 186, 190, 194, 198, 202, 206, 210, 215, 219, 223, 227, 231, 235, 239, 243, 247, 251, 255 };
+constexpr uint BIT5[] = { 0, 8, 16, 25, 33, 41, 49, 58, 66, 74, 82, 90, 99, 107, 115, 123, 132, 140, 148, 156, 165, 173, 181, 189, 197, 206, 214, 222, 230, 239, 247, 255 };
+constexpr uint BIT6[] = { 0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 45, 49, 53, 57, 61, 65, 69, 73, 77, 81, 85, 89, 93, 97, 101, 105, 109, 113, 117, 121, 125, 130, 134, 138, 142, 146, 150, 154, 158, 162, 166, 170, 174, 178, 182, 186, 190, 194, 198, 202, 206, 210, 215, 219, 223, 227, 231, 235, 239, 243, 247, 251, 255 };
 
-static uint ddsGetType(const unsigned char *buffer) {
+uint ddsGetType(const unsigned char *buffer) {
 	uint type = 0;
 	uint flags = ddsGetPixelFormatFlags(buffer);
 	if ((flags & 0x04) != 0) {
@@ -534,7 +537,7 @@ guchar *ddsReadX8R8G8B8(uint width, uint height, const unsigned char *buffer) {
 	return reinterpret_cast<guchar *>(pixels);
 }
 
-static gboolean image_loader_dds_load (gpointer loader, const guchar *buf, gsize, GError **)
+gboolean image_loader_dds_write (gpointer loader, const guchar *buf, gsize &chunk_size, gsize count, GError **)
 {
 	auto ld = static_cast<ImageLoaderDDS *>(loader);
 	uint width = ddsGetWidth(buf);
@@ -563,11 +566,12 @@ static gboolean image_loader_dds_load (gpointer loader, const guchar *buf, gsize
 		}
 		ld->pixbuf = gdk_pixbuf_new_from_data (pixels, GDK_COLORSPACE_RGB, TRUE, 8, width, height, rowstride, free_buffer, nullptr);
 		ld->area_updated_cb(loader, 0, 0, width, height, ld->data);
+		chunk_size = count;
 		return TRUE;
 	}
 }
 
-static gpointer image_loader_dds_new(ImageLoaderBackendCbAreaUpdated area_updated_cb, ImageLoaderBackendCbSize size_cb, ImageLoaderBackendCbAreaPrepared area_prepared_cb, gpointer data)
+gpointer image_loader_dds_new(ImageLoaderBackendCbAreaUpdated area_updated_cb, ImageLoaderBackendCbSize size_cb, ImageLoaderBackendCbAreaPrepared area_prepared_cb, gpointer data)
 {
 	auto loader = g_new0(ImageLoaderDDS, 1);
 	loader->area_updated_cb = area_updated_cb;
@@ -577,53 +581,55 @@ static gpointer image_loader_dds_new(ImageLoaderBackendCbAreaUpdated area_update
 	return loader;
 }
 
-static void image_loader_dds_set_size(gpointer loader, int width, int height)
+void image_loader_dds_set_size(gpointer loader, int width, int height)
 {
 	auto ld = static_cast<ImageLoaderDDS *>(loader);
 	ld->requested_width = width;
 	ld->requested_height = height;
 }
 
-static GdkPixbuf* image_loader_dds_get_pixbuf(gpointer loader)
+GdkPixbuf* image_loader_dds_get_pixbuf(gpointer loader)
 {
 	auto ld = static_cast<ImageLoaderDDS *>(loader);
 	return ld->pixbuf;
 }
 
-static gchar* image_loader_dds_get_format_name(gpointer)
+gchar* image_loader_dds_get_format_name(gpointer)
 {
 	return g_strdup("dds");
 }
-static gchar** image_loader_dds_get_format_mime_types(gpointer)
+
+gchar** image_loader_dds_get_format_mime_types(gpointer)
 {
 	static const gchar *mime[] = {"image/vnd-ms.dds", nullptr};
 	return g_strdupv(const_cast<gchar **>(mime));
 }
 
-static gboolean image_loader_dds_close(gpointer, GError **)
+gboolean image_loader_dds_close(gpointer, GError **)
 {
 	return TRUE;
 }
 
-static void image_loader_dds_abort(gpointer loader)
+void image_loader_dds_abort(gpointer loader)
 {
 	auto ld = static_cast<ImageLoaderDDS *>(loader);
 	ld->abort = TRUE;
 }
 
-static void image_loader_dds_free(gpointer loader)
+void image_loader_dds_free(gpointer loader)
 {
 	auto ld = static_cast<ImageLoaderDDS *>(loader);
 	if (ld->pixbuf) g_object_unref(ld->pixbuf);
 	g_free(ld);
 }
 
+} // namespace
+
 void image_loader_backend_set_dds(ImageLoaderBackend *funcs)
 {
 	funcs->loader_new = image_loader_dds_new;
 	funcs->set_size = image_loader_dds_set_size;
-	funcs->load = image_loader_dds_load;
-	funcs->write = nullptr;
+	funcs->write = image_loader_dds_write;
 	funcs->get_pixbuf = image_loader_dds_get_pixbuf;
 	funcs->close = image_loader_dds_close;
 	funcs->abort = image_loader_dds_abort;

--- a/src/image-load-jpeg.h
+++ b/src/image-load-jpeg.h
@@ -29,7 +29,7 @@
 
 struct ImageLoaderBackend;
 
-gboolean image_loader_jpeg_load(gpointer loader, const guchar *buf, gsize count, GError **error);
+gboolean image_loader_jpeg_write(gpointer loader, const guchar *buf, gsize &chunk_size, gsize count, GError **error);
 
 void image_loader_backend_set_jpeg(ImageLoaderBackend *funcs);
 #endif

--- a/src/image-load-svgz.cc
+++ b/src/image-load-svgz.cc
@@ -26,19 +26,22 @@
 
 #include "image-load.h"
 
+namespace
+{
 
-static gchar* image_loader_svgz_get_format_name(gpointer)
+gchar* image_loader_svgz_get_format_name(gpointer)
 {
 	return g_strdup("svg");
 
 }
-static gchar** image_loader_svgz_get_format_mime_types(gpointer)
+
+gchar** image_loader_svgz_get_format_mime_types(gpointer)
 {
 	static const gchar *mime[] = {"image/svg", nullptr};
 	return g_strdupv(const_cast<gchar **>(mime));
 }
 
-static gpointer image_loader_svgz_new(ImageLoaderBackendCbAreaUpdated area_updated_cb, ImageLoaderBackendCbSize size_cb, ImageLoaderBackendCbAreaPrepared area_prepared_cb, gpointer data)
+gpointer image_loader_svgz_new(ImageLoaderBackendCbAreaUpdated area_updated_cb, ImageLoaderBackendCbSize size_cb, ImageLoaderBackendCbAreaPrepared area_prepared_cb, gpointer data)
 {
 	GError *error = nullptr;
 
@@ -55,21 +58,27 @@ static gpointer image_loader_svgz_new(ImageLoaderBackendCbAreaUpdated area_updat
 	return loader;
 }
 
-static void image_loader_svgz_abort(gpointer)
+gboolean image_loader_svgz_write(gpointer loader, const guchar *buf, gsize &chunk_size, gsize, GError **error)
+{
+	return gdk_pixbuf_loader_write(GDK_PIXBUF_LOADER(loader), buf, chunk_size, error);
+}
+
+void image_loader_svgz_abort(gpointer)
 {
 }
 
-static void image_loader_svgz_free(gpointer loader)
+void image_loader_svgz_free(gpointer loader)
 {
 	g_object_unref(G_OBJECT(loader));
 }
+
+} // namespace
 
 void image_loader_backend_set_svgz(ImageLoaderBackend *funcs)
 {
 	funcs->loader_new = image_loader_svgz_new;
 	funcs->set_size = reinterpret_cast<ImageLoaderBackendFuncSetSize>(gdk_pixbuf_loader_set_size);
-	funcs->load = nullptr;
-	funcs->write = reinterpret_cast<ImageLoaderBackendFuncWrite>(gdk_pixbuf_loader_write);
+	funcs->write = image_loader_svgz_write;
 	funcs->get_pixbuf = reinterpret_cast<ImageLoaderBackendFuncGetPixbuf>(gdk_pixbuf_loader_get_pixbuf);
 	funcs->close = reinterpret_cast<ImageLoaderBackendFuncClose>(gdk_pixbuf_loader_close);
 	funcs->abort = image_loader_svgz_abort;
@@ -78,6 +87,5 @@ void image_loader_backend_set_svgz(ImageLoaderBackend *funcs)
 	funcs->get_format_name = image_loader_svgz_get_format_name;
 	funcs->get_format_mime_types = image_loader_svgz_get_format_mime_types;
 }
-
 
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/image-load.h
+++ b/src/image-load.h
@@ -36,8 +36,7 @@ using ImageLoaderBackendCbAreaUpdated = void (*)(gpointer, guint, guint, guint, 
 
 using ImageLoaderBackendFuncLoaderNew = gpointer (*)(ImageLoaderBackendCbAreaUpdated, ImageLoaderBackendCbSize, ImageLoaderBackendCbAreaPrepared, gpointer);
 using ImageLoaderBackendFuncSetSize = void (*)(gpointer, int, int);
-using ImageLoaderBackendFuncLoad = gboolean (*)(gpointer, const guchar *, gsize, GError **); /* optional, load whole image at once */
-using ImageLoaderBackendFuncWrite = gboolean (*)(gpointer, const guchar *, gsize, GError **);
+using ImageLoaderBackendFuncWrite = gboolean (*)(gpointer, const guchar *, gsize &, gsize, GError **);
 using ImageLoaderBackendFuncGetPixbuf = GdkPixbuf *(*)(gpointer);
 using ImageLoaderBackendFuncClose = gboolean (*)(gpointer, GError **);
 using ImageLoaderBackendFuncAbort = void (*)(gpointer);
@@ -51,7 +50,6 @@ struct ImageLoaderBackend
 {
 	ImageLoaderBackendFuncLoaderNew loader_new;
 	ImageLoaderBackendFuncSetSize set_size;
-	ImageLoaderBackendFuncLoad load;
 	ImageLoaderBackendFuncWrite write;
 	ImageLoaderBackendFuncGetPixbuf get_pixbuf;
 	ImageLoaderBackendFuncClose close;


### PR DESCRIPTION
Remove `ImageLoaderBackendFuncLoad`.
Also move static functions to anonymous namespace.