### PR TITLE
Convert ImageLoaderBackend to interface and backends to implementations

### DIFF
--- a/src/image-load-collection.cc
+++ b/src/image-load-collection.cc
@@ -38,21 +38,27 @@
 namespace
 {
 
-struct ImageLoaderCOLLECTION {
-	ImageLoaderBackendCbAreaUpdated area_updated_cb;
-	ImageLoaderBackendCbSize size_cb;
-	ImageLoaderBackendCbAreaPrepared area_prepared_cb;
+struct ImageLoaderCOLLECTION : public ImageLoaderBackend
+{
+public:
+	~ImageLoaderCOLLECTION() override;
+
+	void init(AreaUpdatedCb area_updated_cb, SizePreparedCb size_prepared_cb, AreaPreparedCb area_prepared_cb, gpointer data) override;
+	gboolean write(const guchar *buf, gsize &chunk_size, gsize count, GError **error) override;
+	GdkPixbuf *get_pixbuf() override;
+	gchar *get_format_name() override;
+	gchar **get_format_mime_types() override;
+
+private:
+	AreaUpdatedCb area_updated_cb;
 	gpointer data;
+
 	GdkPixbuf *pixbuf;
-	guint requested_width;
-	guint requested_height;
-	gboolean abort;
 };
 
-gboolean image_loader_collection_write(gpointer loader, const guchar *, gsize &chunk_size, gsize count, GError **)
+gboolean ImageLoaderCOLLECTION::write(const guchar *, gsize &chunk_size, gsize count, GError **)
 {
-	auto ld = static_cast<ImageLoaderCOLLECTION *>(loader);
-	auto il = static_cast<ImageLoader *>(ld->data);
+	auto il = static_cast<ImageLoader *>(data);
 
 	#define LINE_LENGTH 1000
 
@@ -103,10 +109,10 @@ gboolean image_loader_collection_write(gpointer loader, const guchar *, gsize &c
 				cmd_line = g_strdup_printf("montage %s -geometry %dx%d+1+1 %s >/dev/null 2>&1", file_names->str, options->thumbnails.max_width, options->thumbnails.max_height, randname);
 
 				runcmd(cmd_line);
-				ld->pixbuf = gdk_pixbuf_new_from_file(randname, nullptr);
-				if (ld->pixbuf)
+				pixbuf = gdk_pixbuf_new_from_file(randname, nullptr);
+				if (pixbuf)
 					{
-					ld->area_updated_cb(loader, 0, 0, gdk_pixbuf_get_width(ld->pixbuf), gdk_pixbuf_get_height(ld->pixbuf), ld->data);
+					area_updated_cb(nullptr, 0, 0, gdk_pixbuf_get_width(pixbuf), gdk_pixbuf_get_height(pixbuf), data);
 					}
 
 				unlink(randname);
@@ -123,71 +129,38 @@ gboolean image_loader_collection_write(gpointer loader, const guchar *, gsize &c
 	return ret;
 }
 
-gpointer image_loader_collection_new(ImageLoaderBackendCbAreaUpdated area_updated_cb, ImageLoaderBackendCbSize size_cb, ImageLoaderBackendCbAreaPrepared area_prepared_cb, gpointer data)
+void ImageLoaderCOLLECTION::init(AreaUpdatedCb area_updated_cb, SizePreparedCb, AreaPreparedCb, gpointer data)
 {
-	auto loader = g_new0(ImageLoaderCOLLECTION, 1);
-	loader->area_updated_cb = area_updated_cb;
-	loader->size_cb = size_cb;
-	loader->area_prepared_cb = area_prepared_cb;
-	loader->data = data;
-	return loader;
+	this->area_updated_cb = area_updated_cb;
+	this->data = data;
 }
 
-void image_loader_collection_set_size(gpointer loader, int width, int height)
+GdkPixbuf *ImageLoaderCOLLECTION::get_pixbuf()
 {
-	auto ld = static_cast<ImageLoaderCOLLECTION *>(loader);
-	ld->requested_width = width;
-	ld->requested_height = height;
+	return pixbuf;
 }
 
-GdkPixbuf* image_loader_collection_get_pixbuf(gpointer loader)
-{
-	auto ld = static_cast<ImageLoaderCOLLECTION *>(loader);
-	return ld->pixbuf;
-}
-
-gchar* image_loader_collection_get_format_name(gpointer)
+gchar *ImageLoaderCOLLECTION::get_format_name()
 {
 	return g_strdup("collection");
 }
 
-gchar** image_loader_collection_get_format_mime_types(gpointer)
+gchar **ImageLoaderCOLLECTION::get_format_mime_types()
 {
 	static const gchar *mime[] = {"image/png", nullptr};
 	return g_strdupv(const_cast<gchar **>(mime));
 }
 
-gboolean image_loader_collection_close(gpointer, GError **)
+ImageLoaderCOLLECTION::~ImageLoaderCOLLECTION()
 {
-	return TRUE;
-}
-
-void image_loader_collection_abort(gpointer loader)
-{
-	auto ld = static_cast<ImageLoaderCOLLECTION *>(loader);
-	ld->abort = TRUE;
-}
-
-void image_loader_collection_free(gpointer loader)
-{
-	auto ld = static_cast<ImageLoaderCOLLECTION *>(loader);
-	if (ld->pixbuf) g_object_unref(ld->pixbuf);
-	g_free(ld);
+	if (pixbuf) g_object_unref(pixbuf);
 }
 
 } // namespace
 
-void image_loader_backend_set_collection(ImageLoaderBackend *funcs)
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_collection()
 {
-	funcs->loader_new = image_loader_collection_new;
-	funcs->set_size = image_loader_collection_set_size;
-	funcs->write = image_loader_collection_write;
-	funcs->get_pixbuf = image_loader_collection_get_pixbuf;
-	funcs->close = image_loader_collection_close;
-	funcs->abort = image_loader_collection_abort;
-	funcs->free = image_loader_collection_free;
-	funcs->get_format_name = image_loader_collection_get_format_name;
-	funcs->get_format_mime_types = image_loader_collection_get_format_mime_types;
+	return std::make_unique<ImageLoaderCOLLECTION>();
 }
 
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/image-load-collection.h
+++ b/src/image-load-collection.h
@@ -21,9 +21,11 @@
 #ifndef IMAGE_LOAD_COLLECTION_H
 #define IMAGE_LOAD_COLLECTION_H
 
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_collection(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_collection();
 
 #endif
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/image-load-cr3.h
+++ b/src/image-load-cr3.h
@@ -24,9 +24,11 @@
 #include <config.h>
 
 #if HAVE_JPEG && !HAVE_RAW
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_cr3(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_cr3();
 #endif
 
 #endif // IMAGE_LOAD_CR3_H

--- a/src/image-load-dds.h
+++ b/src/image-load-dds.h
@@ -21,9 +21,11 @@
 #ifndef IMAGE_LOAD_DDS_H
 #define IMAGE_LOAD_DDS_H
 
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_dds(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_dds();
 
 #endif
 

--- a/src/image-load-djvu.cc
+++ b/src/image-load-djvu.cc
@@ -35,15 +35,24 @@
 namespace
 {
 
-struct ImageLoaderDJVU {
-	ImageLoaderBackendCbAreaUpdated area_updated_cb;
-	ImageLoaderBackendCbSize size_cb;
-	ImageLoaderBackendCbAreaPrepared area_prepared_cb;
+struct ImageLoaderDJVU : public ImageLoaderBackend
+{
+public:
+	~ImageLoaderDJVU() override;
+
+	void init(AreaUpdatedCb area_updated_cb, SizePreparedCb size_prepared_cb, AreaPreparedCb area_prepared_cb, gpointer data) override;
+	gboolean write(const guchar *buf, gsize &chunk_size, gsize count, GError **error) override;
+	GdkPixbuf *get_pixbuf() override;
+	gchar *get_format_name() override;
+	gchar **get_format_mime_types() override;
+	void set_page_num(gint page_num) override;
+	gint get_page_total() override;
+
+private:
+	AreaUpdatedCb area_updated_cb;
 	gpointer data;
+
 	GdkPixbuf *pixbuf;
-	guint requested_width;
-	guint requested_height;
-	gboolean abort;
 	gint page_num;
 	gint page_total;
 };
@@ -53,9 +62,8 @@ void free_buffer(guchar *pixels, gpointer)
 	g_free (pixels);
 }
 
-gboolean image_loader_djvu_write(gpointer loader, const guchar *buf, gsize &chunk_size, gsize count, GError **)
+gboolean ImageLoaderDJVU::write(const guchar *buf, gsize &chunk_size, gsize count, GError **)
 {
-	auto ld = static_cast<ImageLoaderDJVU *>(loader);
 	ddjvu_context_t *ctx;
 	ddjvu_document_t *doc;
 	ddjvu_page_t *page;
@@ -76,9 +84,9 @@ gboolean image_loader_djvu_write(gpointer loader, const guchar *buf, gsize &chun
 	ddjvu_stream_write(doc, 0, reinterpret_cast<const char *>(buf), count );
 	while (!ddjvu_document_decoding_done(doc));
 
-	ld->page_total = ddjvu_document_get_pagenum(doc);
+	page_total = ddjvu_document_get_pagenum(doc);
 
-	page = ddjvu_page_create_by_pageno(doc, ld->page_num);
+	page = ddjvu_page_create_by_pageno(doc, page_num);
 	while (!ddjvu_page_decoding_done(page));
 
 	fmt = ddjvu_format_create(DDJVU_FORMAT_RGB24, 0, nullptr);
@@ -107,10 +115,9 @@ gboolean image_loader_djvu_write(gpointer loader, const guchar *buf, gsize &chun
 	tmp2 = gdk_pixbuf_flip(tmp1, TRUE);
 	g_object_unref(tmp1);
 
-	ld->pixbuf = gdk_pixbuf_rotate_simple(tmp2,GDK_PIXBUF_ROTATE_UPSIDEDOWN);
+	pixbuf = gdk_pixbuf_rotate_simple(tmp2, GDK_PIXBUF_ROTATE_UPSIDEDOWN);
 
-	ld->area_updated_cb(loader, 0, 0, width, height, ld->data);
-
+	area_updated_cb(nullptr, 0, 0, width, height, data);
 
 	cairo_surface_destroy(surface);
 	ddjvu_page_release(page);
@@ -121,87 +128,48 @@ gboolean image_loader_djvu_write(gpointer loader, const guchar *buf, gsize &chun
 	return TRUE;
 }
 
-gpointer image_loader_djvu_new(ImageLoaderBackendCbAreaUpdated area_updated_cb, ImageLoaderBackendCbSize size_cb, ImageLoaderBackendCbAreaPrepared area_prepared_cb, gpointer data)
+void ImageLoaderDJVU::init(AreaUpdatedCb area_updated_cb, SizePreparedCb, AreaPreparedCb, gpointer data)
 {
-	auto loader = g_new0(ImageLoaderDJVU, 1);
-	loader->area_updated_cb = area_updated_cb;
-	loader->size_cb = size_cb;
-	loader->area_prepared_cb = area_prepared_cb;
-	loader->data = data;
-	return loader;
+	this->area_updated_cb = area_updated_cb;
+	this->data = data;
 }
 
-void image_loader_djvu_set_size(gpointer loader, int width, int height)
+GdkPixbuf *ImageLoaderDJVU::get_pixbuf()
 {
-	auto ld = static_cast<ImageLoaderDJVU *>(loader);
-	ld->requested_width = width;
-	ld->requested_height = height;
+	return pixbuf;
 }
 
-GdkPixbuf* image_loader_djvu_get_pixbuf(gpointer loader)
-{
-	auto ld = static_cast<ImageLoaderDJVU *>(loader);
-	return ld->pixbuf;
-}
-
-gchar* image_loader_djvu_get_format_name(gpointer)
+gchar *ImageLoaderDJVU::get_format_name()
 {
 	return g_strdup("djvu");
 }
 
-gchar** image_loader_djvu_get_format_mime_types(gpointer)
+gchar **ImageLoaderDJVU::get_format_mime_types()
 {
 	static const gchar *mime[] = {"image/vnd.djvu", nullptr};
 	return g_strdupv(const_cast<gchar **>(mime));
 }
 
-void image_loader_djvu_set_page_num(gpointer loader, gint page_num)
+void ImageLoaderDJVU::set_page_num(gint page_num)
 {
-	auto ld = static_cast<ImageLoaderDJVU *>(loader);
-
-	ld->page_num = page_num;
+	this->page_num = page_num;
 }
 
-gint image_loader_djvu_get_page_total(gpointer loader)
+gint ImageLoaderDJVU::get_page_total()
 {
-	auto ld = static_cast<ImageLoaderDJVU *>(loader);
-
-	return ld->page_total;
+	return page_total;
 }
 
-gboolean image_loader_djvu_close(gpointer, GError **)
+ImageLoaderDJVU::~ImageLoaderDJVU()
 {
-	return TRUE;
-}
-
-void image_loader_djvu_abort(gpointer loader)
-{
-	auto ld = static_cast<ImageLoaderDJVU *>(loader);
-	ld->abort = TRUE;
-}
-
-void image_loader_djvu_free(gpointer loader)
-{
-	auto ld = static_cast<ImageLoaderDJVU *>(loader);
-	if (ld->pixbuf) g_object_unref(ld->pixbuf);
-	g_free(ld);
+	if (pixbuf) g_object_unref(pixbuf);
 }
 
 } // namespace
 
-void image_loader_backend_set_djvu(ImageLoaderBackend *funcs)
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_djvu()
 {
-	funcs->loader_new = image_loader_djvu_new;
-	funcs->set_size = image_loader_djvu_set_size;
-	funcs->write = image_loader_djvu_write;
-	funcs->get_pixbuf = image_loader_djvu_get_pixbuf;
-	funcs->close = image_loader_djvu_close;
-	funcs->abort = image_loader_djvu_abort;
-	funcs->free = image_loader_djvu_free;
-	funcs->get_format_name = image_loader_djvu_get_format_name;
-	funcs->get_format_mime_types = image_loader_djvu_get_format_mime_types;
-	funcs->set_page_num = image_loader_djvu_set_page_num;
-	funcs->get_page_total = image_loader_djvu_get_page_total;
+	return std::make_unique<ImageLoaderDJVU>();
 }
 
 #endif

--- a/src/image-load-djvu.h
+++ b/src/image-load-djvu.h
@@ -24,9 +24,11 @@
 #include <config.h>
 
 #if HAVE_DJVU
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_djvu(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_djvu();
 #endif
 
 #endif

--- a/src/image-load-external.cc
+++ b/src/image-load-external.cc
@@ -33,21 +33,27 @@
 namespace
 {
 
-struct ImageLoaderExternal {
-	ImageLoaderBackendCbAreaUpdated area_updated_cb;
-	ImageLoaderBackendCbSize size_cb;
-	ImageLoaderBackendCbAreaPrepared area_prepared_cb;
+struct ImageLoaderExternal : public ImageLoaderBackend
+{
+public:
+	~ImageLoaderExternal() override;
+
+	void init(AreaUpdatedCb area_updated_cb, SizePreparedCb size_prepared_cb, AreaPreparedCb area_prepared_cb, gpointer data) override;
+	gboolean write(const guchar *buf, gsize &chunk_size, gsize count, GError **error) override;
+	GdkPixbuf *get_pixbuf() override;
+	gchar *get_format_name() override;
+	gchar **get_format_mime_types() override;
+
+private:
+	AreaUpdatedCb area_updated_cb;
 	gpointer data;
+
 	GdkPixbuf *pixbuf;
-	guint requested_width;
-	guint requested_height;
-	gboolean abort;
 };
 
-gboolean image_loader_external_write(gpointer loader, const guchar *, gsize &chunk_size, gsize count, GError **)
+gboolean ImageLoaderExternal::write(const guchar *, gsize &chunk_size, gsize count, GError **)
 {
-	auto ld = static_cast<ImageLoaderExternal *>(loader);
-	auto il = static_cast<ImageLoader *>(ld->data);
+	auto il = static_cast<ImageLoader *>(data);
 	gchar *cmd_line;
 	gchar *randname;
 	gchar *tilde_filename;
@@ -61,9 +67,9 @@ gboolean image_loader_external_write(gpointer loader, const guchar *, gsize &chu
 
 	runcmd(cmd_line);
 
-	ld->pixbuf = gdk_pixbuf_new_from_file(randname, nullptr);
+	pixbuf = gdk_pixbuf_new_from_file(randname, nullptr);
 
-	ld->area_updated_cb(loader, 0, 0, gdk_pixbuf_get_width(ld->pixbuf), gdk_pixbuf_get_height(ld->pixbuf), ld->data);
+	area_updated_cb(nullptr, 0, 0, gdk_pixbuf_get_width(pixbuf), gdk_pixbuf_get_height(pixbuf), data);
 
 	g_free(cmd_line);
 	unlink_file(randname);
@@ -74,72 +80,38 @@ gboolean image_loader_external_write(gpointer loader, const guchar *, gsize &chu
 	return TRUE;
 }
 
-gpointer image_loader_external_new(ImageLoaderBackendCbAreaUpdated area_updated_cb, ImageLoaderBackendCbSize size_cb, ImageLoaderBackendCbAreaPrepared area_prepared_cb, gpointer data)
+void ImageLoaderExternal::init(AreaUpdatedCb area_updated_cb, SizePreparedCb, AreaPreparedCb, gpointer data)
 {
-	auto loader = g_new0(ImageLoaderExternal, 1);
-	loader->area_updated_cb = area_updated_cb;
-	loader->size_cb = size_cb;
-	loader->area_prepared_cb = area_prepared_cb;
-	loader->data = data;
-	return loader;
+	this->area_updated_cb = area_updated_cb;
+	this->data = data;
 }
 
-void image_loader_external_set_size(gpointer loader, int width, int height)
+GdkPixbuf *ImageLoaderExternal::get_pixbuf()
 {
-	auto ld = static_cast<ImageLoaderExternal *>(loader);
-	ld->requested_width = width;
-	ld->requested_height = height;
+	return pixbuf;
 }
 
-GdkPixbuf* image_loader_external_get_pixbuf(gpointer loader)
-{
-	auto ld = static_cast<ImageLoaderExternal *>(loader);
-	return ld->pixbuf;
-}
-
-gchar* image_loader_external_get_format_name(gpointer)
+gchar *ImageLoaderExternal::get_format_name()
 {
 	return g_strdup("external");
 }
 
-gchar** image_loader_external_get_format_mime_types(gpointer)
+gchar **ImageLoaderExternal::get_format_mime_types()
 {
 	static const gchar *mime[] = {"application/octet-stream", nullptr};
 	return g_strdupv(const_cast<gchar **>(mime));
 }
 
-gboolean image_loader_external_close(gpointer, GError **)
+ImageLoaderExternal::~ImageLoaderExternal()
 {
-	return TRUE;
-}
-
-void image_loader_external_abort(gpointer loader)
-{
-	auto ld = static_cast<ImageLoaderExternal *>(loader);
-	ld->abort = TRUE;
-}
-
-void image_loader_external_free(gpointer loader)
-{
-	auto ld = static_cast<ImageLoaderExternal *>(loader);
-	if (ld->pixbuf) g_object_unref(ld->pixbuf);
-	g_free(ld);
+	if (pixbuf) g_object_unref(pixbuf);
 }
 
 } // namespace
 
-void image_loader_backend_set_external(ImageLoaderBackend *funcs)
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_external()
 {
-	funcs->loader_new = image_loader_external_new;
-	funcs->set_size = image_loader_external_set_size;
-	funcs->write = image_loader_external_write;
-	funcs->get_pixbuf = image_loader_external_get_pixbuf;
-	funcs->close = image_loader_external_close;
-	funcs->abort = image_loader_external_abort;
-	funcs->free = image_loader_external_free;
-	funcs->get_format_name = image_loader_external_get_format_name;
-	funcs->get_format_mime_types = image_loader_external_get_format_mime_types;
+	return std::make_unique<ImageLoaderExternal>();
 }
-
 
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/image-load-external.h
+++ b/src/image-load-external.h
@@ -21,9 +21,11 @@
 #ifndef IMAGE_LOAD_EXTERNAL_H
 #define IMAGE_LOAD_EXTERNAL_H
 
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_external(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_external();
 
 #endif
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/image-load-ffmpegthumbnailer.h
+++ b/src/image-load-ffmpegthumbnailer.h
@@ -25,9 +25,11 @@
 #include <config.h>
 
 #if HAVE_FFMPEGTHUMBNAILER
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_ft(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_ft();
 #endif
 
 #endif

--- a/src/image-load-gdk.h
+++ b/src/image-load-gdk.h
@@ -22,9 +22,11 @@
 #ifndef IMAGE_LOAD_GDK_H
 #define IMAGE_LOAD_GDK_H
 
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_default(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_default();
 
 #endif
 

--- a/src/image-load-heif.cc
+++ b/src/image-load-heif.cc
@@ -36,15 +36,24 @@
 namespace
 {
 
-struct ImageLoaderHEIF {
-	ImageLoaderBackendCbAreaUpdated area_updated_cb;
-	ImageLoaderBackendCbSize size_cb;
-	ImageLoaderBackendCbAreaPrepared area_prepared_cb;
+struct ImageLoaderHEIF : public ImageLoaderBackend
+{
+public:
+	~ImageLoaderHEIF() override;
+
+	void init(AreaUpdatedCb area_updated_cb, SizePreparedCb size_prepared_cb, AreaPreparedCb area_prepared_cb, gpointer data) override;
+	gboolean write(const guchar *buf, gsize &chunk_size, gsize count, GError **error) override;
+	GdkPixbuf *get_pixbuf() override;
+	gchar *get_format_name() override;
+	gchar **get_format_mime_types() override;
+	void set_page_num(gint page_num) override;
+	gint get_page_total() override;
+
+private:
+	AreaUpdatedCb area_updated_cb;
 	gpointer data;
+
 	GdkPixbuf *pixbuf;
-	guint requested_width;
-	guint requested_height;
-	gboolean abort;
 	gint page_num;
 	gint page_total;
 };
@@ -54,19 +63,17 @@ void free_buffer(guchar *, gpointer data)
 	heif_image_release(static_cast<const struct heif_image*>(data));
 }
 
-gboolean image_loader_heif_write(gpointer loader, const guchar *buf, gsize &chunk_size, gsize count, GError **)
+gboolean ImageLoaderHEIF::write(const guchar *buf, gsize &chunk_size, gsize count, GError **)
 {
-	auto ld = static_cast<ImageLoaderHEIF *>(loader);
 	struct heif_context* ctx;
 	struct heif_image* img;
 	struct heif_error error_code;
 	struct heif_image_handle* handle;
-	guint8* data;
+	guint8* pixels;
 	gint width;
 	gint height;
 	gint stride;
 	gboolean alpha;
-	gint page_total;
 
 	ctx = heif_context_alloc();
 
@@ -79,17 +86,16 @@ gboolean image_loader_heif_write(gpointer loader, const guchar *buf, gsize &chun
 		}
 
 	page_total = heif_context_get_number_of_top_level_images(ctx);
-	ld->page_total = page_total;
 
 	std::vector<heif_item_id> IDs(page_total);
 
 	/* get list of all (top level) image IDs */
 	heif_context_get_list_of_top_level_image_IDs(ctx, IDs.data(), page_total);
 
-	error_code = heif_context_get_image_handle(ctx, IDs[ld->page_num], &handle);
+	error_code = heif_context_get_image_handle(ctx, IDs[page_num], &handle);
 	if (error_code.code)
 		{
-		log_printf("warning:  heif reader error: %s\n", error_code.message);
+		log_printf("warning: heif reader error: %s\n", error_code.message);
 		heif_context_free(ctx);
 		return FALSE;
 		}
@@ -103,16 +109,16 @@ gboolean image_loader_heif_write(gpointer loader, const guchar *buf, gsize &chun
 		return FALSE;
 		}
 
-	data = heif_image_get_plane(img, heif_channel_interleaved, &stride);
+	pixels = heif_image_get_plane(img, heif_channel_interleaved, &stride);
 
 	height = heif_image_get_height(img,heif_channel_interleaved);
 	width = heif_image_get_width(img,heif_channel_interleaved);
 	alpha = heif_image_handle_has_alpha_channel(handle);
 	heif_image_handle_release(handle);
 
-	ld->pixbuf = gdk_pixbuf_new_from_data(data, GDK_COLORSPACE_RGB, alpha, 8, width, height, stride, free_buffer, img);
+	pixbuf = gdk_pixbuf_new_from_data(pixels, GDK_COLORSPACE_RGB, alpha, 8, width, height, stride, free_buffer, img);
 
-	ld->area_updated_cb(loader, 0, 0, width, height, ld->data);
+	area_updated_cb(nullptr, 0, 0, width, height, data);
 
 	heif_context_free(ctx);
 
@@ -120,88 +126,49 @@ gboolean image_loader_heif_write(gpointer loader, const guchar *buf, gsize &chun
 	return TRUE;
 }
 
-gpointer image_loader_heif_new(ImageLoaderBackendCbAreaUpdated area_updated_cb, ImageLoaderBackendCbSize size_cb, ImageLoaderBackendCbAreaPrepared area_prepared_cb, gpointer data)
+void ImageLoaderHEIF::init(AreaUpdatedCb area_updated_cb, SizePreparedCb, AreaPreparedCb, gpointer data)
 {
-	auto loader = g_new0(ImageLoaderHEIF, 1);
-	loader->area_updated_cb = area_updated_cb;
-	loader->size_cb = size_cb;
-	loader->area_prepared_cb = area_prepared_cb;
-	loader->data = data;
-	loader->page_num = 0;
-	return loader;
+	this->area_updated_cb = area_updated_cb;
+	this->data = data;
+	page_num = 0;
 }
 
-void image_loader_heif_set_size(gpointer loader, int width, int height)
+GdkPixbuf *ImageLoaderHEIF::get_pixbuf()
 {
-	auto ld = static_cast<ImageLoaderHEIF *>(loader);
-	ld->requested_width = width;
-	ld->requested_height = height;
+	return pixbuf;
 }
 
-GdkPixbuf* image_loader_heif_get_pixbuf(gpointer loader)
-{
-	auto ld = static_cast<ImageLoaderHEIF *>(loader);
-	return ld->pixbuf;
-}
-
-gchar* image_loader_heif_get_format_name(gpointer)
+gchar *ImageLoaderHEIF::get_format_name()
 {
 	return g_strdup("heif");
 }
 
-gchar** image_loader_heif_get_format_mime_types(gpointer)
+gchar **ImageLoaderHEIF::get_format_mime_types()
 {
 	static const gchar *mime[] = {"image/heic", nullptr};
 	return g_strdupv(const_cast<gchar **>(mime));
 }
 
-void image_loader_heif_set_page_num(gpointer loader, gint page_num)
+void ImageLoaderHEIF::set_page_num(gint page_num)
 {
-	auto ld = static_cast<ImageLoaderHEIF *>(loader);
-
-	ld->page_num = page_num;
+	this->page_num = page_num;
 }
 
-gint image_loader_heif_get_page_total(gpointer loader)
+gint ImageLoaderHEIF::get_page_total()
 {
-	auto ld = static_cast<ImageLoaderHEIF *>(loader);
-
-	return ld->page_total;
+	return page_total;
 }
 
-gboolean image_loader_heif_close(gpointer, GError **)
+ImageLoaderHEIF::~ImageLoaderHEIF()
 {
-	return TRUE;
-}
-
-void image_loader_heif_abort(gpointer loader)
-{
-	auto ld = static_cast<ImageLoaderHEIF *>(loader);
-	ld->abort = TRUE;
-}
-
-void image_loader_heif_free(gpointer loader)
-{
-	auto ld = static_cast<ImageLoaderHEIF *>(loader);
-	if (ld->pixbuf) g_object_unref(ld->pixbuf);
-	g_free(ld);
+	if (pixbuf) g_object_unref(pixbuf);
 }
 
 } // namespace
 
-void image_loader_backend_set_heif(ImageLoaderBackend *funcs)
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_heif()
 {
-	funcs->loader_new = image_loader_heif_new;
-	funcs->set_size = image_loader_heif_set_size;
-	funcs->write = image_loader_heif_write;
-	funcs->get_pixbuf = image_loader_heif_get_pixbuf;
-	funcs->close = image_loader_heif_close;
-	funcs->abort = image_loader_heif_abort;
-	funcs->free = image_loader_heif_free;
-	funcs->get_format_name = image_loader_heif_get_format_name;
-	funcs->get_format_mime_types = image_loader_heif_get_format_mime_types;
-	funcs->set_page_num = image_loader_heif_set_page_num;
-	funcs->get_page_total = image_loader_heif_get_page_total;
+	return std::make_unique<ImageLoaderHEIF>();
 }
 
 #endif

--- a/src/image-load-heif.h
+++ b/src/image-load-heif.h
@@ -24,9 +24,11 @@
 #include <config.h>
 
 #if HAVE_HEIF
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_heif(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_heif();
 #endif
 
 #endif

--- a/src/image-load-j2k.h
+++ b/src/image-load-j2k.h
@@ -24,9 +24,11 @@
 #include <config.h>
 
 #if HAVE_J2K
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_j2k(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_j2k();
 #endif
 
 #endif

--- a/src/image-load-jpeg.h
+++ b/src/image-load-jpeg.h
@@ -25,13 +25,42 @@
 #include <config.h>
 
 #if HAVE_JPEG
+#include <memory>
+
+#include <gdk-pixbuf/gdk-pixbuf.h>
 #include <glib.h>
 
-struct ImageLoaderBackend;
+#include "image-load.h"
 
-gboolean image_loader_jpeg_write(gpointer loader, const guchar *buf, gsize &chunk_size, gsize count, GError **error);
+struct ImageLoaderJpeg : public ImageLoaderBackend
+{
+public:
+	~ImageLoaderJpeg() override;
 
-void image_loader_backend_set_jpeg(ImageLoaderBackend *funcs);
+	void init(AreaUpdatedCb area_updated_cb, SizePreparedCb size_prepared_cb, AreaPreparedCb area_prepared_cb, gpointer data) override;
+	void set_size(int width, int height) override;
+	gboolean write(const guchar *buf, gsize &chunk_size, gsize count, GError **error) override;
+	GdkPixbuf *get_pixbuf() override;
+	void abort() override;
+	gchar *get_format_name() override;
+	gchar **get_format_mime_types() override;
+
+private:
+	AreaUpdatedCb area_updated_cb;
+	SizePreparedCb size_prepared_cb;
+	AreaPreparedCb area_prepared_cb;
+
+	gpointer data;
+
+	GdkPixbuf *pixbuf;
+	guint requested_width;
+	guint requested_height;
+
+	gboolean aborted;
+	gboolean stereo;
+};
+
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_jpeg();
 #endif
 
 #endif

--- a/src/image-load-jpegxl.h
+++ b/src/image-load-jpegxl.h
@@ -24,9 +24,11 @@
 #include <config.h>
 
 #if HAVE_JPEGXL
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_jpegxl(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_jpegxl();
 #endif
 
 #endif

--- a/src/image-load-pdf.h
+++ b/src/image-load-pdf.h
@@ -24,9 +24,11 @@
 #include <config.h>
 
 #if HAVE_PDF
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_pdf(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_pdf();
 #endif
 
 #endif

--- a/src/image-load-psd.h
+++ b/src/image-load-psd.h
@@ -21,9 +21,11 @@
 #ifndef IMAGE_LOAD_PSD_H
 #define IMAGE_LOAD_PSD_H
 
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_psd(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_psd();
 
 #endif
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/image-load-svgz.h
+++ b/src/image-load-svgz.h
@@ -21,9 +21,11 @@
 #ifndef IMAGE_LOAD_SVGZ_H
 #define IMAGE_LOAD_SVGZ_H
 
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_svgz(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_svgz();
 
 #endif
 

--- a/src/image-load-tiff.h
+++ b/src/image-load-tiff.h
@@ -25,9 +25,11 @@
 #include <config.h>
 
 #if HAVE_TIFF
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_tiff(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_tiff();
 #endif
 
 #endif

--- a/src/image-load-webp.cc
+++ b/src/image-load-webp.cc
@@ -34,16 +34,22 @@
 namespace
 {
 
-using ImageLoaderWEBP = struct _ImageLoaderWEBP;
-struct _ImageLoaderWEBP {
-	ImageLoaderBackendCbAreaUpdated area_updated_cb;
-	ImageLoaderBackendCbSize size_cb;
-	ImageLoaderBackendCbAreaPrepared area_prepared_cb;
+struct ImageLoaderWEBP : public ImageLoaderBackend
+{
+public:
+	~ImageLoaderWEBP() override;
+
+	void init(AreaUpdatedCb area_updated_cb, SizePreparedCb size_prepared_cb, AreaPreparedCb area_prepared_cb, gpointer data) override;
+	gboolean write(const guchar *buf, gsize &chunk_size, gsize count, GError **error) override;
+	GdkPixbuf *get_pixbuf() override;
+	gchar *get_format_name() override;
+	gchar **get_format_mime_types() override;
+
+private:
+	AreaUpdatedCb area_updated_cb;
 	gpointer data;
+
 	GdkPixbuf *pixbuf;
-	guint requested_width;
-	guint requested_height;
-	gboolean abort;
 };
 
 void free_buffer(guchar *pixels, gpointer)
@@ -51,10 +57,9 @@ void free_buffer(guchar *pixels, gpointer)
 	g_free(pixels);
 }
 
-gboolean image_loader_webp_write(gpointer loader, const guchar *buf, gsize &chunk_size, gsize count, GError **)
+gboolean ImageLoaderWEBP::write(const guchar *buf, gsize &chunk_size, gsize count, GError **)
 {
-	auto *ld = (ImageLoaderWEBP *) loader;
-	guint8* data;
+	guint8* pixels;
 	gint width;
 	gint height;
 	gboolean res_info;
@@ -77,88 +82,55 @@ gboolean image_loader_webp_write(gpointer loader, const guchar *buf, gsize &chun
 
 	if (features.has_alpha)
 		{
-		data = WebPDecodeRGBA(buf, count, &width, &height);
+		pixels = WebPDecodeRGBA(buf, count, &width, &height);
 		}
 	else
 		{
-		data = WebPDecodeRGB(buf, count, &width, &height);
+		pixels = WebPDecodeRGB(buf, count, &width, &height);
 		}
 
-	ld->pixbuf = gdk_pixbuf_new_from_data(data, GDK_COLORSPACE_RGB, features.has_alpha, 8, width, height, width * (features.has_alpha ? 4 : 3), free_buffer, nullptr);
+	pixbuf = gdk_pixbuf_new_from_data(pixels, GDK_COLORSPACE_RGB, features.has_alpha, 8, width, height, width * (features.has_alpha ? 4 : 3), free_buffer, nullptr);
 
-	ld->area_updated_cb(loader, 0, 0, width, height, ld->data);
+	area_updated_cb(nullptr, 0, 0, width, height, data);
 
 	chunk_size = count;
 	return TRUE;
 }
 
-gpointer image_loader_webp_new(ImageLoaderBackendCbAreaUpdated area_updated_cb, ImageLoaderBackendCbSize size_cb, ImageLoaderBackendCbAreaPrepared area_prepared_cb, gpointer data)
+void ImageLoaderWEBP::init(AreaUpdatedCb area_updated_cb, SizePreparedCb, AreaPreparedCb, gpointer data)
 {
-	auto *loader = g_new0(ImageLoaderWEBP, 1);
-	loader->area_updated_cb = area_updated_cb;
-	loader->size_cb = size_cb;
-	loader->area_prepared_cb = area_prepared_cb;
-	loader->data = data;
-
-	return (gpointer) loader;
+	this->area_updated_cb = area_updated_cb;
+	this->data = data;
 }
 
-void image_loader_webp_set_size(gpointer loader, int width, int height)
+GdkPixbuf *ImageLoaderWEBP::get_pixbuf()
 {
-	auto *ld = (ImageLoaderWEBP *) loader;
-	ld->requested_width = width;
-	ld->requested_height = height;
+	return pixbuf;
 }
 
-GdkPixbuf* image_loader_webp_get_pixbuf(gpointer loader)
-{
-	auto *ld = (ImageLoaderWEBP *) loader;
-	return ld->pixbuf;
-}
-
-gchar* image_loader_webp_get_format_name(gpointer)
+gchar *ImageLoaderWEBP::get_format_name()
 {
 	return g_strdup("webp");
 }
 
-gchar** image_loader_webp_get_format_mime_types(gpointer)
+gchar **ImageLoaderWEBP::get_format_mime_types()
 {
 	static const gchar *mime[] = {"image/webp", nullptr};
 	return g_strdupv(const_cast<gchar **>(mime));
 }
 
-gboolean image_loader_webp_close(gpointer, GError **)
+ImageLoaderWEBP::~ImageLoaderWEBP()
 {
-	return TRUE;
-}
-
-void image_loader_webp_abort(gpointer loader)
-{
-	auto *ld = (ImageLoaderWEBP *) loader;
-	ld->abort = TRUE;
-}
-
-void image_loader_webp_free(gpointer loader)
-{
-	auto *ld = (ImageLoaderWEBP *) loader;
-	if (ld->pixbuf) g_object_unref(ld->pixbuf);
-	g_free(ld);
+	if (pixbuf) g_object_unref(pixbuf);
 }
 
 } // namespace
 
-void image_loader_backend_set_webp(ImageLoaderBackend *funcs)
+
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_webp()
 {
-DEBUG_0("        "     );
-	funcs->loader_new = image_loader_webp_new;
-	funcs->set_size = image_loader_webp_set_size;
-	funcs->write = image_loader_webp_write;
-	funcs->get_pixbuf = image_loader_webp_get_pixbuf;
-	funcs->close = image_loader_webp_close;
-	funcs->abort = image_loader_webp_abort;
-	funcs->free = image_loader_webp_free;
-	funcs->get_format_name = image_loader_webp_get_format_name;
-	funcs->get_format_mime_types = image_loader_webp_get_format_mime_types;
+	DEBUG_0("        "     );
+	return std::make_unique<ImageLoaderWEBP>();
 }
 
 #endif

--- a/src/image-load-webp.h
+++ b/src/image-load-webp.h
@@ -24,9 +24,11 @@
 #include <config.h>
 
 #if HAVE_WEBP
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_webp(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_webp();
 #endif
 
 #endif

--- a/src/image-load-zxscr.h
+++ b/src/image-load-zxscr.h
@@ -21,9 +21,11 @@
 #ifndef IMAGE_LOAD_ZXSCR_H
 #define IMAGE_LOAD_ZXSCR_H
 
+#include <memory>
+
 struct ImageLoaderBackend;
 
-void image_loader_backend_set_zxscr(ImageLoaderBackend *funcs);
+std::unique_ptr<ImageLoaderBackend> get_image_loader_backend_zxscr();
 
 #endif
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */


### PR DESCRIPTION
Add parameters to `ImageLoaderBackend` methods.
Remove unused members from backend implementations.
Rename `ImageLoaderBackend::loader_new` to `ImageLoaderBackend::init`.
Move callbacks aliases to `ImageLoaderBackend` and rename `SizeCb` to `SizePreparedCb`.