### PR TITLE
For POTFILES, look for whereami and zonedetect in third-party folder

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -131,6 +131,6 @@ src/view-dir-tree.cc
 src/view-file/view-file.cc
 src/view-file/view-file-icon.cc
 src/view-file/view-file-list.cc
-src/whereami.cc
+src/third-party/whereami.cc
 src/window.cc
-src/zonedetect.cc
+src/third-party/zonedetect.cc


### PR DESCRIPTION
Without this `meson compile geeqie-pot` won't work.
