### PR TITLE
Silence GTK deprecation warning in unused function

### DIFF
--- a/src/bar-gps.cc
+++ b/src/bar-gps.cc
@@ -24,10 +24,9 @@
 #include <cstring>
 
 #include <cairo.h>
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 #include <champlain-gtk/champlain-gtk.h>
-#pragma GCC diagnostic pop
+G_GNUC_END_IGNORE_DEPRECATIONS
 #include <champlain/champlain.h>
 #include <clutter-gtk/clutter-gtk.h>
 #include <clutter/clutter.h>

--- a/src/fullscreen.cc
+++ b/src/fullscreen.cc
@@ -388,7 +388,9 @@ gint fullscreen_prefs_find_screen_for_widget_unused(GtkWidget *widget)
 	if (!widget || !gtk_widget_get_window(widget)) return 0;
 
 	screen = gtk_widget_get_screen(widget);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	monitor = gdk_screen_get_monitor_at_window(screen, gtk_widget_get_window(widget));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	n = 100 + monitor + 1;
 

--- a/src/ui-menu.cc
+++ b/src/ui-menu.cc
@@ -429,8 +429,6 @@ GtkWidget *popup_menu_short_lived()
 	return menu;
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // @todo Used only in vd_menu_position_cb_unused(). Remove?
 gboolean popup_menu_position_clamp(GtkMenu *menu, gint *x, gint *y, gint height)
 {
@@ -441,11 +439,13 @@ gboolean popup_menu_position_clamp(GtkMenu *menu, gint *x, gint *y, gint height)
 	gint xh;
 	GtkRequisition requisition;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_widget_get_requisition(GTK_WIDGET(menu), &requisition);
 	w = requisition.width;
 	h = requisition.height;
 	xw = gdk_screen_width();
 	xh = gdk_screen_height();
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	if (*x + w > xw)
 		{
@@ -478,5 +478,4 @@ gboolean popup_menu_position_clamp(GtkMenu *menu, gint *x, gint *y, gint height)
 
 	return adjusted;
 }
-#pragma GCC diagnostic pop
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */


### PR DESCRIPTION
Also use G_GNUC_BEGIN/END_IGNORE_DEPRECATIONS macros instead of pragmas.