### PR TITLE
Move keyboard_scroll_calc() to layout-util

### DIFF
--- a/src/img-view.cc
+++ b/src/img-view.cc
@@ -41,7 +41,6 @@
 #include "layout-util.h"
 #include "layout.h"
 #include "main-defines.h"
-#include "main.h"
 #include "menu.h"
 #include "misc.h"
 #include "options.h"
@@ -442,13 +441,7 @@ static gboolean view_window_key_press_cb(GtkWidget * (widget), GdkEventKey *even
 
 	if (x != 0 || y!= 0)
 		{
-		if (event->state & GDK_SHIFT_MASK)
-			{
-			x *= 3;
-			y *= 3;
-			}
-
-		keyboard_scroll_calc(&x, &y, event);
+		keyboard_scroll_calc(x, y, event);
 		image_scroll(imd, x, y);
 		}
 

--- a/src/layout-util.h
+++ b/src/layout-util.h
@@ -30,6 +30,8 @@
 
 struct LayoutWindow;
 
+void keyboard_scroll_calc(gint &x, gint &y, const GdkEventKey *event);
+
 gboolean layout_key_press_cb(GtkWidget *widget, GdkEventKey *event, gpointer data);
 
 void layout_util_sync_thumb(LayoutWindow *lw);

--- a/src/main.cc
+++ b/src/main.cc
@@ -40,8 +40,10 @@
 #include <execinfo.h>
 #endif
 
+#include <gdk/gdk.h>
 #include <gio/gio.h>
 #include <glib-object.h>
+#include <gtk/gtk.h>
 
 #ifdef ENABLE_NLS
 #  include <libintl.h>
@@ -219,53 +221,6 @@ void sig_handler_cb(int)
 	exit(EXIT_FAILURE);
 }
 #endif /* defined(SA_SIGINFO) */
-
-/*
- *-----------------------------------------------------------------------------
- * keyboard functions
- *-----------------------------------------------------------------------------
- */
-
-void keyboard_scroll_calc(gint *x, gint *y, GdkEventKey *event)
-{
-	static gint delta = 0;
-	static guint32 time_old = 0;
-	static guint keyval_old = 0;
-
-	if (event->state & GDK_CONTROL_MASK)
-		{
-		if (*x < 0) *x = G_MININT / 2;
-		if (*x > 0) *x = G_MAXINT / 2;
-		if (*y < 0) *y = G_MININT / 2;
-		if (*y > 0) *y = G_MAXINT / 2;
-
-		return;
-		}
-
-	if (options->progressive_key_scrolling)
-		{
-		guint32 time_diff;
-
-		time_diff = event->time - time_old;
-
-		/* key pressed within 125ms ? (1/8 second) */
-		if (time_diff > 125 || event->keyval != keyval_old) delta = 0;
-
-		time_old = event->time;
-		keyval_old = event->keyval;
-
-		delta += 2;
-		}
-	else
-		{
-		delta = 8;
-		}
-
-	*x = *x * delta * options->keyboard_scroll_step;
-	*y = *y * delta * options->keyboard_scroll_step;
-}
-
-
 
 /*
  *-----------------------------------------------------------------------------

--- a/src/main.h
+++ b/src/main.h
@@ -22,9 +22,7 @@
 #ifndef MAIN_H
 #define MAIN_H
 
-#include <gdk/gdk.h>
 #include <glib.h>
-#include <gtk/gtk.h>
 
 extern gboolean thumb_format_changed;
 
@@ -37,8 +35,6 @@ extern gchar *gq_bindir;
 extern gchar *gq_executable_path;
 extern gchar *desktop_file_template;
 extern gchar *instance_identifier;
-
-void keyboard_scroll_calc(gint *x, gint *y, GdkEventKey *event);
 
 void exit_program();
 

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -46,7 +46,6 @@
 #include "layout-util.h"
 #include "layout.h"
 #include "main-defines.h"
-#include "main.h"
 #include "menu.h"
 #include "metadata.h"
 #include "options.h"
@@ -1250,12 +1249,7 @@ static gboolean pan_window_key_press_cb(GtkWidget *widget, GdkEventKey *event, g
 
 		if (x != 0 || y!= 0)
 			{
-			if (event->state & GDK_SHIFT_MASK)
-				{
-				x *= 3;
-				y *= 3;
-				}
-			keyboard_scroll_calc(&x, &y, event);
+			keyboard_scroll_calc(x, y, event);
 			pixbuf_renderer_scroll(pr, x, y);
 			}
 		}


### PR DESCRIPTION
Convert parameters from pointers to references.
Move Shift processing inside keyboard_scroll_calc().