### PR TITLE
Fixes corrupted rendering in PanView on hidpi displays

### DIFF
--- a/src/renderer-tiles.cc
+++ b/src/renderer-tiles.cc
@@ -1193,7 +1193,7 @@ static gboolean rt_source_tile_render(RendererTiles *rt, ImageTile *it,
 
 		// We find the overlapping region (r{x,y,w,h}) between the ImageTile (output)
 		// region and the region that's covered by this SourceTile (input).
-		gint rx, ry, rw, rh;
+		gint rx, ry, rw, rh;  // NOLINT(readability-isolate-declaration)
 		if (pr_clip_region(stx, sty, stw, sth,
 				   it->x + x, it->y + y, w, h,
 				   &rx, &ry, &rw, &rh))

--- a/src/renderer-tiles.cc
+++ b/src/renderer-tiles.cc
@@ -481,18 +481,10 @@ static void rt_hidpi_aware_draw(
 	cairo_t *cr,
 	GdkPixbuf *pixbuf,
 	double x,
-	double y,
-        gboolean should_scale = TRUE)
+	double y)
 {
 	cairo_surface_t *surface;
-        if (should_scale)
-		{
-		surface = gdk_cairo_surface_create_from_pixbuf(pixbuf, rt->hidpi_scale, nullptr);
-		}
-	else
-		{
-		surface = gdk_cairo_surface_create_from_pixbuf(pixbuf, 1, nullptr);
-		}
+	surface = gdk_cairo_surface_create_from_pixbuf(pixbuf, rt->hidpi_scale, nullptr);
 	cairo_set_source_surface(cr, surface, x, y);
 	cairo_fill(cr);
 	cairo_surface_destroy(surface);

--- a/src/renderer-tiles.cc
+++ b/src/renderer-tiles.cc
@@ -1167,7 +1167,7 @@ static gboolean rt_source_tile_render(RendererTiles *rt, ImageTile *it,
 
 #if 0
 	// Draws red over draw region, to check for leaks (regions not filled)
-	pixbuf_set_rect_fill(it->pixbuf, x, y, 2*w, 2*h, 255, 0, 0, 255);
+	pixbuf_set_rect_fill(it->pixbuf, x, y, rt->hidpi_scale * w, rt->hidpi_scale * h, 255, 0, 0, 255);
 #endif
 
 	// Since the RendererTiles ImageTiles and PixbufRenderer SourceTiles are different


### PR DESCRIPTION
This is a 95% fix for #1316 .  There is still a bug where rendering corruption will show up if the user zooms all the way out, and will then persist even if they zoom back in again.

The crux of this fix is to account for the hidpi scaling factor in `rt_source_tile_render`.  This PR also adds a significant amount of comments to explain that function's somewhat non-intuitive API, as well as how it operates internally.

A future commit will update the variable names to be more descriptive.