### PR TITLE
Simplify util_clip_region()

### DIFF
--- a/src/pan-view/pan-item.cc
+++ b/src/pan-view/pan-item.cc
@@ -217,42 +217,42 @@ gint pan_item_box_draw(PanWindow *, PanItem *pi, GdkPixbuf *pixbuf, PixbufRender
 		}
 
 	if (util_clip_region(x, y, width, height,
-			     pi->x, pi->y, bw, bh,
-			     &rx, &ry, &rw, &rh))
+	                     pi->x, pi->y, bw, bh,
+	                     rx, ry, rw, rh))
 		{
 		pixbuf_draw_rect_fill(pixbuf,
 				      rx - x, ry - y, rw, rh,
 				      pi->color.r, pi->color.g, pi->color.b, pi->color.a);
 		}
 	if (util_clip_region(x, y, width, height,
-			     pi->x, pi->y, bw, pi->border,
-			     &rx, &ry, &rw, &rh))
+	                     pi->x, pi->y, bw, pi->border,
+	                     rx, ry, rw, rh))
 		{
 		pixbuf_draw_rect_fill(pixbuf,
 				      rx - x, ry - y, rw, rh,
 				      pi->color2.r, pi->color2.g, pi->color2.b, pi->color2.a);
 		}
 	if (util_clip_region(x, y, width, height,
-			     pi->x, pi->y + pi->border, pi->border, bh - pi->border * 2,
-			     &rx, &ry, &rw, &rh))
+	                     pi->x, pi->y + pi->border, pi->border, bh - pi->border * 2,
+	                     rx, ry, rw, rh))
 		{
 		pixbuf_draw_rect_fill(pixbuf,
 				      rx - x, ry - y, rw, rh,
 				      pi->color2.r, pi->color2.g, pi->color2.b, pi->color2.a);
 		}
 	if (util_clip_region(x, y, width, height,
-			     pi->x + bw - pi->border, pi->y + pi->border,
-			     pi->border, bh - pi->border * 2,
-			     &rx, &ry, &rw, &rh))
+	                     pi->x + bw - pi->border, pi->y + pi->border,
+	                     pi->border, bh - pi->border * 2,
+	                     rx, ry, rw, rh))
 		{
 		pixbuf_draw_rect_fill(pixbuf,
 				      rx - x, ry - y, rw, rh,
 				      pi->color2.r, pi->color2.g, pi->color2.b, pi->color2.a);
 		}
 	if (util_clip_region(x, y, width, height,
-			     pi->x, pi->y + bh - pi->border,
-			     bw,  pi->border,
-			     &rx, &ry, &rw, &rh))
+	                     pi->x, pi->y + bh - pi->border,
+	                     bw,  pi->border,
+	                     rx, ry, rw, rh))
 		{
 		pixbuf_draw_rect_fill(pixbuf,
 				      rx - x, ry - y, rw, rh,
@@ -319,8 +319,8 @@ gint pan_item_tri_draw(PanWindow *, PanItem *pi, GdkPixbuf *pixbuf, PixbufRender
 	gint rh;
 
 	if (util_clip_region(x, y, width, height,
-			     pi->x, pi->y, pi->width, pi->height,
-			     &rx, &ry, &rw, &rh) && pi->data)
+	                     pi->x, pi->y, pi->width, pi->height,
+	                     rx, ry, rw, rh) && pi->data)
 		{
 		auto coord = static_cast<gint *>(pi->data);
 		pixbuf_draw_triangle(pixbuf,
@@ -504,8 +504,8 @@ gint pan_item_thumb_draw(PanWindow *pw, PanItem *pi, GdkPixbuf *pixbuf, PixbufRe
 		if (gdk_pixbuf_get_has_alpha(pi->pixbuf))
 			{
 			if (util_clip_region(x, y, width, height,
-					     tx + PAN_SHADOW_OFFSET, ty + PAN_SHADOW_OFFSET, tw, th,
-					     &rx, &ry, &rw, &rh))
+			                     tx + PAN_SHADOW_OFFSET, ty + PAN_SHADOW_OFFSET, tw, th,
+			                     rx, ry, rw, rh))
 				{
 				pixbuf_draw_shadow(pixbuf,
 						   rx - x, ry - y, rw, rh,
@@ -517,9 +517,9 @@ gint pan_item_thumb_draw(PanWindow *pw, PanItem *pi, GdkPixbuf *pixbuf, PixbufRe
 		else
 			{
 			if (util_clip_region(x, y, width, height,
-					     tx + tw, ty + PAN_SHADOW_OFFSET,
-					     PAN_SHADOW_OFFSET, th - PAN_SHADOW_OFFSET,
-					     &rx, &ry, &rw, &rh))
+			                     tx + tw, ty + PAN_SHADOW_OFFSET,
+			                     PAN_SHADOW_OFFSET, th - PAN_SHADOW_OFFSET,
+			                     rx, ry, rw, rh))
 				{
 				pixbuf_draw_shadow(pixbuf,
 						   rx - x, ry - y, rw, rh,
@@ -528,8 +528,8 @@ gint pan_item_thumb_draw(PanWindow *pw, PanItem *pi, GdkPixbuf *pixbuf, PixbufRe
 						   PAN_SHADOW_COLOR, PAN_SHADOW_ALPHA);
 				}
 			if (util_clip_region(x, y, width, height,
-					     tx + PAN_SHADOW_OFFSET, ty + th, tw, PAN_SHADOW_OFFSET,
-					     &rx, &ry, &rw, &rh))
+			                     tx + PAN_SHADOW_OFFSET, ty + th, tw, PAN_SHADOW_OFFSET,
+			                     rx, ry, rw, rh))
 				{
 				pixbuf_draw_shadow(pixbuf,
 						   rx - x, ry - y, rw, rh,
@@ -540,8 +540,8 @@ gint pan_item_thumb_draw(PanWindow *pw, PanItem *pi, GdkPixbuf *pixbuf, PixbufRe
 			}
 
 		if (util_clip_region(x, y, width, height,
-				     tx, ty, tw, th,
-				     &rx, &ry, &rw, &rh))
+		                     tx, ty, tw, th,
+		                     rx, ry, rw, rh))
 			{
 			gdk_pixbuf_composite(pi->pixbuf, pixbuf, rx - x, ry - y, rw, rh,
 					     static_cast<gdouble>(tx) - x,
@@ -551,34 +551,34 @@ gint pan_item_thumb_draw(PanWindow *pw, PanItem *pi, GdkPixbuf *pixbuf, PixbufRe
 			}
 
 		if (util_clip_region(x, y, width, height,
-				     tx, ty, tw, PAN_OUTLINE_THICKNESS,
-				     &rx, &ry, &rw, &rh))
+		                     tx, ty, tw, PAN_OUTLINE_THICKNESS,
+		                     rx, ry, rw, rh))
 			{
 			pixbuf_draw_rect_fill(pixbuf,
 					      rx - x, ry - y, rw, rh,
 					      PAN_OUTLINE_COLOR_1);
 			}
 		if (util_clip_region(x, y, width, height,
-				     tx, ty, PAN_OUTLINE_THICKNESS, th,
-				     &rx, &ry, &rw, &rh))
+		                     tx, ty, PAN_OUTLINE_THICKNESS, th,
+		                     rx, ry, rw, rh))
 			{
 			pixbuf_draw_rect_fill(pixbuf,
 					      rx - x, ry - y, rw, rh,
 					      PAN_OUTLINE_COLOR_1);
 			}
 		if (util_clip_region(x, y, width, height,
-				     tx + tw - PAN_OUTLINE_THICKNESS, ty +  PAN_OUTLINE_THICKNESS,
-				     PAN_OUTLINE_THICKNESS, th - PAN_OUTLINE_THICKNESS,
-				     &rx, &ry, &rw, &rh))
+		                     tx + tw - PAN_OUTLINE_THICKNESS, ty +  PAN_OUTLINE_THICKNESS,
+		                     PAN_OUTLINE_THICKNESS, th - PAN_OUTLINE_THICKNESS,
+		                     rx, ry, rw, rh))
 			{
 			pixbuf_draw_rect_fill(pixbuf,
 					      rx - x, ry - y, rw, rh,
 					      PAN_OUTLINE_COLOR_2);
 			}
 		if (util_clip_region(x, y, width, height,
-				     tx +  PAN_OUTLINE_THICKNESS, ty + th - PAN_OUTLINE_THICKNESS,
-				     tw - PAN_OUTLINE_THICKNESS * 2, PAN_OUTLINE_THICKNESS,
-				     &rx, &ry, &rw, &rh))
+		                     tx +  PAN_OUTLINE_THICKNESS, ty + th - PAN_OUTLINE_THICKNESS,
+		                     tw - PAN_OUTLINE_THICKNESS * 2, PAN_OUTLINE_THICKNESS,
+		                     rx, ry, rw, rh))
 			{
 			pixbuf_draw_rect_fill(pixbuf,
 					      rx - x, ry - y, rw, rh,
@@ -593,8 +593,8 @@ gint pan_item_thumb_draw(PanWindow *pw, PanItem *pi, GdkPixbuf *pixbuf, PixbufRe
 		ty = pi->y + PAN_SHADOW_OFFSET;
 
 		if (util_clip_region(x, y, width, height,
-				     tx, ty, tw, th,
-				     &rx, &ry, &rw, &rh))
+		                     tx, ty, tw, th,
+		                     rx, ry, rw, rh))
 			{
 			gint d;
 
@@ -677,8 +677,8 @@ gint pan_item_image_draw(PanWindow *, PanItem *pi, GdkPixbuf *pixbuf, PixbufRend
 	gint rh;
 
 	if (util_clip_region(x, y, width, height,
-			     pi->x, pi->y, pi->width, pi->height,
-			     &rx, &ry, &rw, &rh))
+	                     pi->x, pi->y, pi->width, pi->height,
+	                     rx, ry, rw, rh))
 		{
 		if (pi->pixbuf)
 			{

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -382,8 +382,8 @@ static gboolean pan_window_request_tile_cb(PixbufRenderer *pr, gint x, gint y,
 		gint rh;
 
 		if (util_clip_region(x, y, width, height,
-				     i, y, 1, height,
-				     &rx, &ry, &rw, &rh))
+		                     i, y, 1, height,
+		                     rx, ry, rw, rh))
 			{
 			pixbuf_draw_rect_fill(pixbuf,
 					      rx - x, ry - y, rw, rh,
@@ -398,8 +398,8 @@ static gboolean pan_window_request_tile_cb(PixbufRenderer *pr, gint x, gint y,
 		gint rh;
 
 		if (util_clip_region(x, y, width, height,
-				     x, i, width, 1,
-				     &rx, &ry, &rw, &rh))
+		                     x, i, width, 1,
+		                     rx, ry, rw, rh))
 			{
 			pixbuf_draw_rect_fill(pixbuf,
 					      rx - x, ry - y, rw, rh,
@@ -829,8 +829,8 @@ static void pan_grid_build(PanWindow *pw, gint width, gint height, gint grid_siz
 			grid = grid->next;
 
 			if (util_clip_region(pi->x, pi->y, pi->width, pi->height,
-					     pg->x, pg->y, pg->w, pg->h,
-					     &rx, &ry, &rw, &rh))
+			                     pg->x, pg->y, pg->w, pg->h,
+			                     rx, ry, rw, rh))
 				{
 				pg->list = g_list_prepend(pg->list, pi);
 				}
@@ -986,8 +986,8 @@ static GList *pan_layout_intersect_l(GList *list, GList *item_list,
 		work = work->next;
 
 		if (util_clip_region(x, y, width, height,
-				     pi->x, pi->y, pi->width, pi->height,
-				     &rx, &ry, &rw, &rh))
+		                     pi->x, pi->y, pi->width, pi->height,
+		                     rx, ry, rw, rh))
 			{
 			list = g_list_prepend(list, pi);
 			}

--- a/src/pixbuf-util.h
+++ b/src/pixbuf-util.h
@@ -233,8 +233,8 @@ void pixbuf_ignore_alpha_rect(GdkPixbuf *pb,
  * @retval TRUE The intersection operation was performed, and the output params were set.
  */
 gboolean util_clip_region(gint x, gint y, gint w, gint h,
-		          gint clip_x, gint clip_y, gint clip_w, gint clip_h,
-		          gint *rx, gint *ry, gint *rw, gint *rh);
+                          gint clip_x, gint clip_y, gint clip_w, gint clip_h,
+                          gint &rx, gint &ry, gint &rw, gint &rh);
 
 // TODO(xsdg): Rename this function to util_triangle_bounding_box.
 /**

--- a/src/tests/pixbuf-util.cc
+++ b/src/tests/pixbuf-util.cc
@@ -40,8 +40,8 @@ class ClipRegionTest : public ::testing::Test
 TEST_F(ClipRegionTest, RegionAContainsRegionB)
 {
 	ASSERT_TRUE(util_clip_region(0, 0, 1000, 1000,
-				     50, 50, 100, 100,
-				     &rx, &ry, &rw, &rh));
+	                             50, 50, 100, 100,
+	                             rx, ry, rw, rh));
 
 	ASSERT_EQ(50, rx);
 	ASSERT_EQ(50, ry);
@@ -52,8 +52,8 @@ TEST_F(ClipRegionTest, RegionAContainsRegionB)
 TEST_F(ClipRegionTest, RegionBContainsRegionA)
 {
 	ASSERT_TRUE(util_clip_region(50, 50, 100, 100,
-				     0, 0, 1000, 1000,
-				     &rx, &ry, &rw, &rh));
+	                             0, 0, 1000, 1000,
+	                             rx, ry, rw, rh));
 
 	ASSERT_EQ(50, rx);
 	ASSERT_EQ(50, ry);
@@ -64,8 +64,8 @@ TEST_F(ClipRegionTest, RegionBContainsRegionA)
 TEST_F(ClipRegionTest, PartialOverlapWithBAfterA)
 {
 	ASSERT_TRUE(util_clip_region(0, 0, 1000, 1000,
-				     500, 500, 1000, 1000,
-				     &rx, &ry, &rw, &rh));
+	                             500, 500, 1000, 1000,
+	                             rx, ry, rw, rh));
 
 	ASSERT_EQ(500, rx);
 	ASSERT_EQ(500, ry);
@@ -76,8 +76,8 @@ TEST_F(ClipRegionTest, PartialOverlapWithBAfterA)
 TEST_F(ClipRegionTest, PartialOverlapWithAAfterB)
 {
 	ASSERT_TRUE(util_clip_region(500, 500, 1000, 1000,
-				     0, 0, 1000, 1000,
-				     &rx, &ry, &rw, &rh));
+	                             0, 0, 1000, 1000,
+	                             rx, ry, rw, rh));
 
 	ASSERT_EQ(500, rx);
 	ASSERT_EQ(500, ry);


### PR DESCRIPTION
* use gdk_rectangle_intersect()
* convert pointers to references

@xsdg 
Is it worth to replace parameters with `GdkRectangle`s, making `util_clip_region` wrapper of `gdk_rectangle_intersect`?