### PR TITLE
Cleanup pixbuf-util a bit

### DIFF
--- a/src/pixbuf-util.h
+++ b/src/pixbuf-util.h
@@ -37,7 +37,7 @@ gboolean register_theme_icon_as_stock(const gchar *key, const gchar *icon);
 GdkPixbuf *pixbuf_inline(const gchar *key);
 GdkPixbuf *pixbuf_fallback(FileData *fd, gint requested_width, gint requested_height);
 
-gboolean pixbuf_scale_aspect(gint req_w, gint req_h, gint old_w, gint old_h, gint *new_w, gint *new_h);
+gboolean pixbuf_scale_aspect(gint req_w, gint req_h, gint old_w, gint old_h, gint &new_w, gint &new_h);
 
 #define PIXBUF_INLINE_ARCHIVE               "gq-icon-archive-file"
 #define PIXBUF_INLINE_BROKEN                "gq-icon-broken"

--- a/src/thumb-standard.cc
+++ b/src/thumb-standard.cc
@@ -560,7 +560,7 @@ static GdkPixbuf *thumb_loader_std_finish(ThumbLoaderStd *tl, GdkPixbuf *pixbuf,
 				struct stat st;
 
 				if (pixbuf_scale_aspect(cache_w, cache_h, sw, sh,
-								  &thumb_w, &thumb_h))
+				                        thumb_w, thumb_h))
 					{
 					pixbuf_thumb = gdk_pixbuf_scale_simple(pixbuf, thumb_w, thumb_h,
 									       static_cast<GdkInterpType>(options->thumbnails.quality));
@@ -616,7 +616,7 @@ static GdkPixbuf *thumb_loader_std_finish(ThumbLoaderStd *tl, GdkPixbuf *pixbuf,
 			}
 
 		if (pixbuf_scale_aspect(tl->requested_width, tl->requested_height, sw, sh,
-						  &thumb_w, &thumb_h))
+		                        thumb_w, thumb_h))
 			{
 			result = gdk_pixbuf_scale_simple(pixbuf, thumb_w, thumb_h,
 							 static_cast<GdkInterpType>(options->thumbnails.quality));

--- a/src/thumb.cc
+++ b/src/thumb.cc
@@ -618,7 +618,7 @@ static GdkPixbuf *get_xv_thumbnail(gchar *thumb_filename, gint max_w, gint max_h
 		pixbuf = gdk_pixbuf_new_from_data(rgb_data, GDK_COLORSPACE_RGB, FALSE, 8,
 						  width, height, 3 * width, free_rgb_buffer, nullptr);
 
-		if (pixbuf_scale_aspect(width, height, max_w, max_h, &width, &height))
+		if (pixbuf_scale_aspect(width, height, max_w, max_h, width, height))
 			{
 			/* scale */
 			GdkPixbuf *tmp;


### PR DESCRIPTION
Convert pointers to references.
Convert enum to constants.
Deduplicate `pixbuf_scale_aspect()` a little.