### PR TITLE
Changes forward declarations to `class FileData` to align with updated main class declaration/definition.

### DIFF
--- a/src/advanced-exif.h
+++ b/src/advanced-exif.h
@@ -24,7 +24,7 @@
 
 #include <gtk/gtk.h>
 
-struct FileData;
+class FileData;
 struct LayoutWindow;
 
 GtkWidget *advanced_exif_new(LayoutWindow *lw);

--- a/src/archives.h
+++ b/src/archives.h
@@ -23,7 +23,7 @@
 
 #include <glib.h>
 
-struct FileData;
+class FileData;
 
 gchar *open_archive(const FileData *fd);
 

--- a/src/bar.h
+++ b/src/bar.h
@@ -26,7 +26,7 @@
 #include <glib.h>
 #include <gtk/gtk.h>
 
-struct FileData;
+class FileData;
 struct LayoutWindow;
 
 enum PaneType {

--- a/src/cache-loader.h
+++ b/src/cache-loader.h
@@ -25,7 +25,7 @@
 #include <glib.h>
 
 struct CacheData;
-struct FileData;
+class FileData;
 struct ImageLoader;
 
 enum CacheDataType {

--- a/src/cache-maint.h
+++ b/src/cache-maint.h
@@ -27,7 +27,7 @@
 
 #include "typedefs.h"
 
-struct FileData;
+class FileData;
 
 void cache_maintain_home(gboolean metadata, gboolean clear, GtkWidget *parent);
 void cache_notify_cb(FileData *fd, NotifyType type, gpointer data);

--- a/src/collect-io.h
+++ b/src/collect-io.h
@@ -27,7 +27,7 @@
 #include "typedefs.h"
 
 struct CollectionData;
-struct FileData;
+class FileData;
 
 enum CollectionLoadFlags {
 	COLLECTION_LOAD_NONE	= 0,

--- a/src/collect.h
+++ b/src/collect.h
@@ -30,7 +30,7 @@
 #include "typedefs.h"
 
 struct CollectTable;
-struct FileData;
+class FileData;
 struct ThumbLoader;
 
 struct CollectInfo

--- a/src/color-man.h
+++ b/src/color-man.h
@@ -25,7 +25,7 @@
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <glib.h>
 
-struct FileData;
+class FileData;
 struct ImageWindow;
 
 enum ColorManProfileType {

--- a/src/dupe.h
+++ b/src/dupe.h
@@ -28,7 +28,7 @@
 
 struct CollectInfo;
 struct CollectionData;
-struct FileData;
+class FileData;
 struct ImageLoader;
 struct ImageSimilarityData;
 struct ThumbLoader;

--- a/src/editors.h
+++ b/src/editors.h
@@ -25,7 +25,7 @@
 #include <glib.h>
 #include <gtk/gtk.h>
 
-struct FileData;
+class FileData;
 
 enum EditorFlags {
 	EDITOR_KEEP_FS            = 0x00000001,

--- a/src/exif.cc
+++ b/src/exif.cc
@@ -66,7 +66,7 @@
 #include "typedefs.h"
 #include "ui-fileops.h"
 
-struct FileData;
+class FileData;
 
 /*
  *-----------------------------------------------------------------------------

--- a/src/exif.h
+++ b/src/exif.h
@@ -28,7 +28,7 @@
 
 struct ExifData;
 struct ExifItem;
-struct FileData;
+class FileData;
 
 #define EXIF_FORMATTED() "formatted."
 #define EXIF_FORMATTED_LEN (sizeof(EXIF_FORMATTED()) - 1)

--- a/src/filecache.h
+++ b/src/filecache.h
@@ -24,7 +24,7 @@
 #include <glib.h>
 
 struct FileCacheData;
-struct FileData;
+class FileData;
 
 using FileCacheReleaseFunc = void (*)(FileData *);
 

--- a/src/glua.h
+++ b/src/glua.h
@@ -23,7 +23,7 @@
 
 #include <glib.h>
 
-struct FileData;
+class FileData;
 
 void lua_init();
 

--- a/src/histogram.h
+++ b/src/histogram.h
@@ -26,7 +26,7 @@
 
 #include "typedefs.h"
 
-struct FileData;
+class FileData;
 struct HistMap;
 
 /* Note: The order is important */

--- a/src/image-load.h
+++ b/src/image-load.h
@@ -28,7 +28,7 @@
 #include <glib-object.h>
 #include <glib.h>
 
-struct FileData;
+class FileData;
 
 #define TYPE_IMAGE_LOADER		(image_loader_get_type())
 

--- a/src/image.h
+++ b/src/image.h
@@ -31,7 +31,7 @@
 
 struct CollectInfo;
 struct CollectionData;
-struct FileData;
+class FileData;
 struct ImageLoader;
 
 enum RectangleDrawAspectRatio

--- a/src/img-view.h
+++ b/src/img-view.h
@@ -26,7 +26,7 @@
 
 struct CollectInfo;
 struct CollectionData;
-struct FileData;
+class FileData;
 struct ImageWindow;
 
 void view_window_new(FileData *fd);

--- a/src/layout-image.h
+++ b/src/layout-image.h
@@ -29,7 +29,7 @@
 
 struct CollectInfo;
 struct CollectionData;
-struct FileData;
+class FileData;
 struct LayoutWindow;
 
 GtkWidget *layout_image_new(LayoutWindow *lw, gint i);

--- a/src/layout.h
+++ b/src/layout.h
@@ -29,7 +29,7 @@
 #include "typedefs.h"
 
 struct AnimationData;
-struct FileData;
+class FileData;
 struct FullScreenData;
 struct ImageWindow;
 struct SlideShowData;

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -27,7 +27,7 @@
 
 #include "typedefs.h"
 
-struct FileData;
+class FileData;
 
 #define COMMENT_KEY "Xmp.dc.description"
 #define KEYWORD_KEY "Xmp.dc.subject"

--- a/src/osd.h
+++ b/src/osd.h
@@ -24,7 +24,7 @@
 #include <glib.h>
 #include <gtk/gtk.h>
 
-struct FileData;
+class FileData;
 
 enum OsdTemplateFlags {
 	OSDT_NONE 	= 0,

--- a/src/pan-view.h
+++ b/src/pan-view.h
@@ -22,7 +22,7 @@
 #ifndef PAN_VIEW_H
 #define PAN_VIEW_H
 
-struct FileData;
+class FileData;
 
 void pan_window_new(FileData *dir_fd);
 

--- a/src/pan-view/pan-calendar.h
+++ b/src/pan-view/pan-calendar.h
@@ -24,7 +24,7 @@
 
 #include <glib.h>
 
-struct FileData;
+class FileData;
 struct PanItem;
 struct PanWindow;
 

--- a/src/pan-view/pan-folder.h
+++ b/src/pan-view/pan-folder.h
@@ -24,7 +24,7 @@
 
 #include <glib.h>
 
-struct FileData;
+class FileData;
 struct PanWindow;
 
 void pan_flower_compute(PanWindow *pw, FileData *dir_fd,

--- a/src/pan-view/pan-grid.h
+++ b/src/pan-view/pan-grid.h
@@ -24,7 +24,7 @@
 
 #include <glib.h>
 
-struct FileData;
+class FileData;
 struct PanWindow;
 
 void pan_grid_compute(PanWindow *pw, FileData *dir_fd, gint &width, gint &height);

--- a/src/pan-view/pan-item.h
+++ b/src/pan-view/pan-item.h
@@ -27,7 +27,7 @@
 
 #include "pan-types.h"
 
-struct FileData;
+class FileData;
 struct PixbufRenderer;
 
 void pan_item_free(PanItem *pi);

--- a/src/pan-view/pan-timeline.h
+++ b/src/pan-view/pan-timeline.h
@@ -24,7 +24,7 @@
 
 #include <glib.h>
 
-struct FileData;
+class FileData;
 struct PanWindow;
 
 void pan_timeline_compute(PanWindow *pw, FileData *dir_fd, gint &width, gint &height);

--- a/src/pan-view/pan-util.h
+++ b/src/pan-view/pan-util.h
@@ -28,7 +28,7 @@
 
 #include "typedefs.h"
 
-struct FileData;
+class FileData;
 
 enum PanDateLengthType {
 	PAN_DATE_LENGTH_EXACT,

--- a/src/pixbuf-util.h
+++ b/src/pixbuf-util.h
@@ -27,7 +27,7 @@
 #include <gtk/gtk.h>
 #include <pango/pango.h>
 
-struct FileData;
+class FileData;
 
 gboolean pixbuf_to_file_as_png (GdkPixbuf *pixbuf, const gchar *filename);
 

--- a/src/print.h
+++ b/src/print.h
@@ -25,7 +25,7 @@
 #include <glib.h>
 #include <gtk/gtk.h>
 
-struct FileData;
+class FileData;
 
 /**
  * @headerfile print_window_new

--- a/src/search.h
+++ b/src/search.h
@@ -22,7 +22,7 @@
 #ifndef SEARCH_H
 #define SEARCH_H
 
-struct FileData;
+class FileData;
 
 void search_new(FileData *dir_fd, FileData *example_file);
 

--- a/src/slideshow.h
+++ b/src/slideshow.h
@@ -26,7 +26,7 @@
 
 struct CollectInfo;
 struct CollectionData;
-struct FileData;
+class FileData;
 struct ImageWindow;
 struct LayoutWindow;
 

--- a/src/thumb-standard.h
+++ b/src/thumb-standard.h
@@ -31,7 +31,7 @@
 
 #include "main-defines.h"
 
-struct FileData;
+class FileData;
 struct ImageLoader;
 
 #if GLIB_CHECK_VERSION (2, 34, 0)

--- a/src/thumb.h
+++ b/src/thumb.h
@@ -27,7 +27,7 @@
 
 #include "typedefs.h"
 
-struct FileData;
+class FileData;
 struct ImageLoader;
 
 struct ThumbLoader

--- a/src/ui-utildlg.h
+++ b/src/ui-utildlg.h
@@ -25,7 +25,7 @@
 #include <glib.h>
 #include <gtk/gtk.h>
 
-struct FileData;
+class FileData;
 
 struct GenericDialog
 {

--- a/src/utilops.h
+++ b/src/utilops.h
@@ -27,7 +27,7 @@
 
 #include "typedefs.h"
 
-struct FileData;
+class FileData;
 struct FileDialog;
 struct GenericDialog;
 

--- a/src/view-dir-list.h
+++ b/src/view-dir-list.h
@@ -26,7 +26,7 @@
 #include <glib.h>
 #include <gtk/gtk.h>
 
-struct FileData;
+class FileData;
 struct ViewDir;
 
 ViewDir *vdlist_new(ViewDir *vd, FileData *dir_fd);

--- a/src/view-dir-tree.h
+++ b/src/view-dir-tree.h
@@ -28,7 +28,7 @@
 #include <glib.h>
 #include <gtk/gtk.h>
 
-struct FileData;
+class FileData;
 struct ViewDir;
 
 struct NodeData

--- a/src/view-dir.h
+++ b/src/view-dir.h
@@ -28,7 +28,7 @@
 
 #include "typedefs.h"
 
-struct FileData;
+class FileData;
 struct LayoutWindow;
 
 enum {

--- a/src/view-file.h
+++ b/src/view-file.h
@@ -29,7 +29,7 @@
 
 #include "typedefs.h"
 
-struct FileData;
+class FileData;
 struct LayoutWindow;
 struct ThumbLoader;
 

--- a/src/view-file/view-file-icon.h
+++ b/src/view-file/view-file-icon.h
@@ -29,7 +29,7 @@
 #include "typedefs.h"
 #include "view-file.h"
 
-struct FileData;
+class FileData;
 
 struct ViewFileInfoIcon
 {

--- a/src/view-file/view-file-list.h
+++ b/src/view-file/view-file-list.h
@@ -29,7 +29,7 @@
 #include "typedefs.h"
 #include "view-file.h"
 
-struct FileData;
+class FileData;
 
 struct ViewFileInfoList
 {


### PR DESCRIPTION
The class declaration/definition was changed from `struct FileData` in commit [1ebf122bc](https://github.com/BestImageViewer/geeqie/commit/1ebf122bce5e628f46bec219b2a1d304e635fca4)

This was pointed out by @qarkai in https://github.com/BestImageViewer/geeqie/pull/1375#pullrequestreview-2105139656