### PR TITLE
Fixes a thumbnail permissions bug introduced in a4ce95bc1

### DIFF
--- a/src/thumb-standard.cc
+++ b/src/thumb-standard.cc
@@ -369,7 +369,7 @@ static void thumb_loader_std_save(ThumbLoaderStd *tl, GdkPixbuf *pixbuf)
 					  NULL);
 		if (success)
 			{
-			chmod(pathl, (tl->cache_local) ? tl->source_mode : S_IRUSR & S_IWUSR);
+			chmod(pathl, (tl->cache_local) ? tl->source_mode : S_IRUSR | S_IWUSR);
 			success = rename_file(tmp_path, tl->thumb_path);
 			}
 


### PR DESCRIPTION
That bug caused thumbnails to be created with no permissions (0000), instead of U+RW permissions (0600).

Unfortunately, I don't think there's a good way to auto-fix this issue without potentially adjusting permissions that Geeqie didn't originally set, which wouldn't be appropriate.

Fixes #1410 