### PR TITLE
Reduce number of reinterpret_cast

### DIFF
--- a/src/bar.cc
+++ b/src/bar.cc
@@ -608,7 +608,7 @@ void bar_clear(GtkWidget *bar)
 
 	list = gtk_container_get_children(GTK_CONTAINER(bd->vbox));
 
-	g_list_free_full(list, reinterpret_cast<GDestroyNotify>(remove_child_from_parent));
+	g_list_free_full(list, remove_child_from_parent);
 }
 
 void bar_write_config(GtkWidget *bar, GString *outstr, gint indent)

--- a/src/cache-maint.h
+++ b/src/cache-maint.h
@@ -33,10 +33,9 @@ void cache_maintain_home(gboolean metadata, gboolean clear, GtkWidget *parent);
 void cache_notify_cb(FileData *fd, NotifyType type, gpointer data);
 void cache_manager_show();
 
-void cache_maintain_home_remote(gboolean metadata, gboolean clear, GDestroyNotify *func);
+void cache_maintain_home_remote(gboolean metadata, gboolean clear, GDestroyNotify func);
 void cache_manager_standard_process_remote(gboolean clear);
-void cache_manager_render_remote(const gchar *path, gboolean recurse, gboolean local, GDestroyNotify *func);
-void cache_manager_sim_remote(const gchar *path, gboolean recurse, GDestroyNotify *func);
+void cache_manager_render_remote(const gchar *path, gboolean recurse, gboolean local, GSourceFunc destroy_func);
 void cache_maintenance(const gchar *path);
 #endif
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/cellrenderericon.cc
+++ b/src/cellrenderericon.cc
@@ -557,7 +557,7 @@ static void gqv_cell_renderer_icon_get_size(GtkCellRenderer    *cell,
 					    gint	       *width,
 					    gint	       *height)
 {
-	auto cellicon = reinterpret_cast<GQvCellRendererIcon *>(cell);
+	GQvCellRendererIcon *cellicon = GQV_CELL_RENDERER_ICON(cell);
 	gint calc_width;
 	gint calc_height;
 	gint xpad;
@@ -638,7 +638,7 @@ static void gqv_cell_renderer_icon_render(GtkCellRenderer *cell,
 
 {
 	GtkStyleContext *context = gtk_widget_get_style_context(widget);
-	auto cellicon = reinterpret_cast<GQvCellRendererIcon *>(cell);
+	GQvCellRendererIcon *cellicon = GQV_CELL_RENDERER_ICON(cell);
 	GdkPixbuf *pixbuf;
 	const gchar *text;
 	GdkRectangle cell_rect;
@@ -806,7 +806,7 @@ static gboolean gqv_cell_renderer_icon_activate(GtkCellRenderer      *cell,
 						const GdkRectangle   *cell_area,
 						GtkCellRendererState)
 {
-	auto cellicon = reinterpret_cast<GQvCellRendererIcon *>(cell);
+	GQvCellRendererIcon *cellicon = GQV_CELL_RENDERER_ICON(cell);
 	GdkEventButton *bevent = &event->button;
 
 	if (cellicon->show_marks &&

--- a/src/compat.cc
+++ b/src/compat.cc
@@ -73,7 +73,7 @@ void gq_gtk_container_add(GtkWidget *container, GtkWidget *widget)
 #else
 void gq_gtk_container_add(GtkWidget *container, GtkWidget *widget)
 {
-	gtk_container_add(reinterpret_cast<GtkContainer *>(container), widget);
+	gtk_container_add(GTK_CONTAINER(container), widget);
 }
 #endif
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/filedata.cc
+++ b/src/filedata.cc
@@ -153,12 +153,12 @@ void file_data_disable_grouping_list(GList *fd_list, gboolean disable)
 }
 
 
-gint filelist_sort_compare_filedata(FileData *fa, FileData *fb)
+gint filelist_sort_compare_filedata(const FileData *fa, const FileData *fb)
 {
 	return FileData::FileList::sort_compare_filedata(fa, fb);
 }
 
-gint filelist_sort_compare_filedata_full(FileData *fa, FileData *fb, SortType method, gboolean ascend)
+gint filelist_sort_compare_filedata_full(const FileData *fa, const FileData *fb, SortType method, gboolean ascend)
 {
 	return FileData::FileList::sort_compare_filedata_full(fa, fb, method, ascend);
 }

--- a/src/filedata.h
+++ b/src/filedata.h
@@ -302,8 +302,8 @@ class FileData::FileList
 	static gboolean sort_case;
 
     public:
-	static gint sort_compare_filedata(FileData *fa, FileData *fb);
-	static gint sort_compare_filedata_full(FileData *fa, FileData *fb, SortType method, gboolean ascend);
+	static gint sort_compare_filedata(const FileData *fa, const FileData *fb);
+	static gint sort_compare_filedata_full(const FileData *fa, const FileData *fb, SortType method, gboolean ascend);
 	static GList *sort(GList *list, SortType method, gboolean ascend, gboolean case_sensitive);
 	static GList *sort_full(GList *list, SortType method, gboolean ascend, gboolean case_sensitive, GCompareFunc cb);
 
@@ -324,7 +324,7 @@ class FileData::FileList
 	static GList *filter_out_sidecars(GList *flist);
 	static gboolean is_hidden_file(const gchar *name);
 	static gboolean read_list_real(const gchar *dir_path, GList **files, GList **dirs, gboolean follow_symlinks);
-	static gint sort_file_cb(gpointer a, gpointer b);
+	static gint sort_file_cb(gconstpointer a, gconstpointer b);
 	static gint sort_path_cb(gconstpointer a, gconstpointer b);
 	static void recursive_append(GList **list, GList *dirs);
 	static void recursive_append_full(GList **list, GList *dirs, SortType method, gboolean ascend, gboolean case_sensitive);
@@ -377,8 +377,8 @@ void file_data_change_info_free(FileDataChangeInfo *fdci, FileData *fd);
 void file_data_disable_grouping(FileData *fd, gboolean disable);
 void file_data_disable_grouping_list(GList *fd_list, gboolean disable);
 
-gint filelist_sort_compare_filedata(FileData *fa, FileData *fb);
-gint filelist_sort_compare_filedata_full(FileData *fa, FileData *fb, SortType method, gboolean ascend);
+gint filelist_sort_compare_filedata(const FileData *fa, const FileData *fb);
+gint filelist_sort_compare_filedata_full(const FileData *fa, const FileData *fb, SortType method, gboolean ascend);
 GList *filelist_sort(GList *list, SortType method, gboolean ascend, gboolean case_sensitive);
 GList *filelist_sort_full(GList *list, SortType method, gboolean ascend, gboolean case_sensitive, GCompareFunc cb);
 

--- a/src/filedata/filelist.cc
+++ b/src/filedata/filelist.cc
@@ -202,7 +202,7 @@ gboolean FileData::FileList::read_list_real(const gchar *dir_path, GList **files
  */
 
 
-gint FileData::FileList::sort_compare_filedata(FileData *fa, FileData *fb)
+gint FileData::FileList::sort_compare_filedata(const FileData *fa, const FileData *fb)
 {
 	gint ret;
 	if (!sort_ascend)
@@ -271,16 +271,16 @@ gint FileData::FileList::sort_compare_filedata(FileData *fa, FileData *fb)
 	return strcmp(fa->original_path, fb->original_path);
 }
 
-gint FileData::FileList::sort_compare_filedata_full(FileData *fa, FileData *fb, SortType method, gboolean ascend)
+gint FileData::FileList::sort_compare_filedata_full(const FileData *fa, const FileData *fb, SortType method, gboolean ascend)
 {
 	sort_method = method;
 	sort_ascend = ascend;
 	return sort_compare_filedata(fa, fb);
 }
 
-gint FileData::FileList::sort_file_cb(gpointer a, gpointer b)
+gint FileData::FileList::sort_file_cb(gconstpointer a, gconstpointer b)
 {
-	return FileData::FileList::sort_compare_filedata(static_cast<FileData *>(a), static_cast<FileData *>(b));
+	return FileData::FileList::sort_compare_filedata(static_cast<const FileData *>(a), static_cast<const FileData *>(b));
 }
 
 GList *FileData::FileList::sort_full(GList *list, SortType method, gboolean ascend, gboolean case_sensitive, GCompareFunc cb)
@@ -293,7 +293,7 @@ GList *FileData::FileList::sort_full(GList *list, SortType method, gboolean asce
 
 GList *FileData::FileList::sort(GList *list, SortType method, gboolean ascend, gboolean case_sensitive)
 {
-	return sort_full(list, method, ascend, case_sensitive, reinterpret_cast<GCompareFunc>(sort_file_cb));
+	return sort_full(list, method, ascend, case_sensitive, sort_file_cb);
 }
 
 gboolean FileData::FileList::read_list(FileData *dir_fd, GList **files, GList **dirs)
@@ -458,7 +458,7 @@ void FileData::FileList::recursive_append_full(GList **list, GList *dirs, SortTy
 		if (read_list(fd, &f, &d))
 			{
 			f = filter(f, FALSE);
-			f = sort_full(f, method, ascend, case_sensitive, reinterpret_cast<GCompareFunc>(sort_file_cb));
+			f = sort_full(f, method, ascend, case_sensitive, sort_file_cb);
 			*list = g_list_concat(*list, f);
 
 			d = filter(d, TRUE);
@@ -495,7 +495,7 @@ GList *FileData::FileList::recursive_full(FileData *dir_fd, SortType method, gbo
 
 	if (!read_list(dir_fd, &list, &d)) return nullptr;
 	list = filter(list, FALSE);
-	list = sort_full(list, method, ascend, case_sensitive, reinterpret_cast<GCompareFunc>(sort_file_cb));
+	list = sort_full(list, method, ascend, case_sensitive, sort_file_cb);
 
 	d = filter(d, TRUE);
 	d = sort_path(d);

--- a/src/image-overlay.cc
+++ b/src/image-overlay.cc
@@ -551,17 +551,17 @@ static GdkPixbuf *image_osd_icon_pixbuf(ImageOSDFlag flag)
 static gint image_overlay_add(ImageWindow *imd, GdkPixbuf *pixbuf, gint x, gint y,
 			      OverlayRendererFlags flags)
 {
-	return pixbuf_renderer_overlay_add(reinterpret_cast<PixbufRenderer *>(imd->pr), pixbuf, x, y, flags);
+	return pixbuf_renderer_overlay_add(PIXBUF_RENDERER(imd->pr), pixbuf, x, y, flags);
 }
 
 static void image_overlay_set(ImageWindow *imd, gint id, GdkPixbuf *pixbuf, gint x, gint y)
 {
-	pixbuf_renderer_overlay_set(reinterpret_cast<PixbufRenderer *>(imd->pr), id, pixbuf, x, y);
+	pixbuf_renderer_overlay_set(PIXBUF_RENDERER(imd->pr), id, pixbuf, x, y);
 }
 
 static void image_overlay_remove(ImageWindow *imd, gint id)
 {
-	pixbuf_renderer_overlay_remove(reinterpret_cast<PixbufRenderer *>(imd->pr), id);
+	pixbuf_renderer_overlay_remove(PIXBUF_RENDERER(imd->pr), id);
 }
 
 static void image_osd_icon_show(OverlayStateData *osd, ImageOSDFlag flag)

--- a/src/image.cc
+++ b/src/image.cc
@@ -184,7 +184,7 @@ static void image_press_cb(PixbufRenderer *pr, GdkEventButton *event, gpointer d
 
 	if (rect_id)
 		{
-		pixbuf_renderer_overlay_remove(reinterpret_cast<PixbufRenderer *>(imd->pr), rect_id);
+		pixbuf_renderer_overlay_remove(PIXBUF_RENDERER(imd->pr), rect_id);
 		}
 
 	lw = layout_find_by_image(imd);
@@ -288,7 +288,7 @@ static void image_drag_cb(PixbufRenderer *pr, GdkEventMotion *event, gpointer da
 
 		if (rect_id)
 			{
-			pixbuf_renderer_overlay_remove(reinterpret_cast<PixbufRenderer *>(imd->pr), rect_id);
+			pixbuf_renderer_overlay_remove(PIXBUF_RENDERER(imd->pr), rect_id);
 			}
 
 		rect_width = pr->drag_last_x - pixbuf_start_x;
@@ -319,7 +319,7 @@ static void image_drag_cb(PixbufRenderer *pr, GdkEventMotion *event, gpointer da
 		pixbuf_set_rect(rect_pixbuf, 1, 1, rect_width-2, rect_height - 2, 0, 0, 0, 255, 1, 1, 1, 1);
 		pixbuf_set_rect(rect_pixbuf, 0, 0, rect_width, rect_height, 255, 255, 255, 255, 1, 1, 1, 1);
 
-		rect_id = pixbuf_renderer_overlay_add(reinterpret_cast<PixbufRenderer *>(imd->pr), rect_pixbuf, pixbuf_start_x, pixbuf_start_y, OVL_NORMAL);
+		rect_id = pixbuf_renderer_overlay_add(PIXBUF_RENDERER(imd->pr), rect_pixbuf, pixbuf_start_x, pixbuf_start_y, OVL_NORMAL);
 		}
 
 	pixbuf_renderer_get_scaled_size(pr, &width, &height);
@@ -751,7 +751,7 @@ void image_alter_orientation(ImageWindow *imd, FileData *fd_n, AlterType type)
 	if (imd->image_fd == fd_n && (!options->metadata.write_orientation || options->image.exif_rotate_enable))
 		{
 		imd->orientation = orientation;
-		pixbuf_renderer_set_orientation(reinterpret_cast<PixbufRenderer *>(imd->pr), orientation);
+		pixbuf_renderer_set_orientation(PIXBUF_RENDERER(imd->pr), orientation);
 		}
 }
 
@@ -759,10 +759,10 @@ void image_set_desaturate(ImageWindow *imd, gboolean desaturate)
 {
 	imd->desaturate = desaturate;
 	if (imd->cm || imd->desaturate || imd->overunderexposed)
-		pixbuf_renderer_set_post_process_func(reinterpret_cast<PixbufRenderer *>(imd->pr), image_post_process_tile_color_cb, imd, (imd->cm != nullptr) );
+		pixbuf_renderer_set_post_process_func(PIXBUF_RENDERER(imd->pr), image_post_process_tile_color_cb, imd, (imd->cm != nullptr) );
 	else
-		pixbuf_renderer_set_post_process_func(reinterpret_cast<PixbufRenderer *>(imd->pr), nullptr, nullptr, TRUE);
-	pixbuf_renderer_set_orientation(reinterpret_cast<PixbufRenderer *>(imd->pr), imd->orientation);
+		pixbuf_renderer_set_post_process_func(PIXBUF_RENDERER(imd->pr), nullptr, nullptr, TRUE);
+	pixbuf_renderer_set_orientation(PIXBUF_RENDERER(imd->pr), imd->orientation);
 }
 
 gboolean image_get_desaturate(ImageWindow *imd)
@@ -774,15 +774,15 @@ void image_set_overunderexposed(ImageWindow *imd, gboolean overunderexposed)
 {
 	imd->overunderexposed = overunderexposed;
 	if (imd->cm || imd->desaturate || imd->overunderexposed)
-		pixbuf_renderer_set_post_process_func(reinterpret_cast<PixbufRenderer *>(imd->pr), image_post_process_tile_color_cb, imd, (imd->cm != nullptr) );
+		pixbuf_renderer_set_post_process_func(PIXBUF_RENDERER(imd->pr), image_post_process_tile_color_cb, imd, (imd->cm != nullptr) );
 	else
-		pixbuf_renderer_set_post_process_func(reinterpret_cast<PixbufRenderer *>(imd->pr), nullptr, nullptr, TRUE);
-	pixbuf_renderer_set_orientation(reinterpret_cast<PixbufRenderer *>(imd->pr), imd->orientation);
+		pixbuf_renderer_set_post_process_func(PIXBUF_RENDERER(imd->pr), nullptr, nullptr, TRUE);
+	pixbuf_renderer_set_orientation(PIXBUF_RENDERER(imd->pr), imd->orientation);
 }
 
 void image_set_ignore_alpha(ImageWindow *imd, gboolean ignore_alpha)
 {
-   pixbuf_renderer_set_ignore_alpha(reinterpret_cast<PixbufRenderer *>(imd->pr), ignore_alpha);
+   pixbuf_renderer_set_ignore_alpha(PIXBUF_RENDERER(imd->pr), ignore_alpha);
 }
 
 /*
@@ -926,9 +926,7 @@ static void image_load_pixbuf_ready(ImageWindow *imd)
 static void image_load_area_cb(ImageLoader *il, guint x, guint y, guint w, guint h, gpointer data)
 {
 	auto imd = static_cast<ImageWindow *>(data);
-	PixbufRenderer *pr;
-
-	pr = reinterpret_cast<PixbufRenderer *>(imd->pr);
+	PixbufRenderer *pr = PIXBUF_RENDERER(imd->pr);
 
 	if (imd->delay_flip &&
 	    pr->pixbuf != image_loader_get_pixbuf(il))
@@ -983,7 +981,7 @@ static void image_load_size_cb(ImageLoader *, guint width, guint height, gpointe
 	auto imd = static_cast<ImageWindow *>(data);
 
 	DEBUG_1("image_load_size_cb: %dx%d", width, height);
-	pixbuf_renderer_set_size_early(reinterpret_cast<PixbufRenderer *>(imd->pr), width, height);
+	pixbuf_renderer_set_size_early(PIXBUF_RENDERER(imd->pr), width, height);
 }
 
 static void image_load_error_cb(ImageLoader *il, gpointer data)
@@ -1306,7 +1304,7 @@ void image_attach_window(ImageWindow *imd, GtkWidget *window,
 
 	if (!options->image.fit_window_to_image || !lw || (!lw->options.tools_float && !lw->options.tools_hidden)) window = nullptr;
 
-	pixbuf_renderer_set_parent(reinterpret_cast<PixbufRenderer *>(imd->pr), reinterpret_cast<GtkWindow *>(window));
+	pixbuf_renderer_set_parent(PIXBUF_RENDERER(imd->pr), GTK_WINDOW(window));
 
 	image_update_title(imd);
 }
@@ -1419,7 +1417,7 @@ gboolean image_get_image_size(ImageWindow *imd, gint *width, gint *height)
 
 GdkPixbuf *image_get_pixbuf(ImageWindow *imd)
 {
-	return pixbuf_renderer_get_pixbuf(reinterpret_cast<PixbufRenderer *>(imd->pr));
+	return pixbuf_renderer_get_pixbuf(PIXBUF_RENDERER(imd->pr));
 }
 
 void image_change_pixbuf(ImageWindow *imd, GdkPixbuf *pixbuf, gdouble zoom, gboolean lazy)
@@ -1462,7 +1460,7 @@ void image_change_pixbuf(ImageWindow *imd, GdkPixbuf *pixbuf, gdouble zoom, gboo
 			}
 		}
 
-	pixbuf_renderer_set_post_process_func(reinterpret_cast<PixbufRenderer *>(imd->pr), nullptr, nullptr, FALSE);
+	pixbuf_renderer_set_post_process_func(PIXBUF_RENDERER(imd->pr), nullptr, nullptr, FALSE);
 	if (imd->cm)
 		{
 		color_man_free(static_cast<ColorMan *>(imd->cm));
@@ -1471,13 +1469,13 @@ void image_change_pixbuf(ImageWindow *imd, GdkPixbuf *pixbuf, gdouble zoom, gboo
 
 	if (lazy)
 		{
-		pixbuf_renderer_set_pixbuf_lazy(reinterpret_cast<PixbufRenderer *>(imd->pr), pixbuf, zoom, imd->orientation, stereo_data);
+		pixbuf_renderer_set_pixbuf_lazy(PIXBUF_RENDERER(imd->pr), pixbuf, zoom, imd->orientation, stereo_data);
 		}
 	else
 		{
-		pixbuf_renderer_set_pixbuf(reinterpret_cast<PixbufRenderer *>(imd->pr), pixbuf, zoom);
-		pixbuf_renderer_set_orientation(reinterpret_cast<PixbufRenderer *>(imd->pr), imd->orientation);
-		pixbuf_renderer_set_stereo_data(reinterpret_cast<PixbufRenderer *>(imd->pr), stereo_data);
+		pixbuf_renderer_set_pixbuf(PIXBUF_RENDERER(imd->pr), pixbuf, zoom);
+		pixbuf_renderer_set_orientation(PIXBUF_RENDERER(imd->pr), imd->orientation);
+		pixbuf_renderer_set_stereo_data(PIXBUF_RENDERER(imd->pr), stereo_data);
 		}
 
 	if (pixbuf) g_object_unref(pixbuf);
@@ -1490,7 +1488,7 @@ void image_change_pixbuf(ImageWindow *imd, GdkPixbuf *pixbuf, gdouble zoom, gboo
 		}
 
 	if (imd->cm || imd->desaturate || imd->overunderexposed)
-		pixbuf_renderer_set_post_process_func(reinterpret_cast<PixbufRenderer *>(imd->pr), image_post_process_tile_color_cb, imd, (imd->cm != nullptr) );
+		pixbuf_renderer_set_post_process_func(PIXBUF_RENDERER(imd->pr), image_post_process_tile_color_cb, imd, (imd->cm != nullptr) );
 
 	image_state_set(imd, IMAGE_STATE_IMAGE);
 }
@@ -1613,9 +1611,9 @@ void image_move_from_image(ImageWindow *imd, ImageWindow *source)
 	pixbuf_renderer_move(PIXBUF_RENDERER(imd->pr), PIXBUF_RENDERER(source->pr));
 
 	if (imd->cm || imd->desaturate || imd->overunderexposed)
-		pixbuf_renderer_set_post_process_func(reinterpret_cast<PixbufRenderer *>(imd->pr), image_post_process_tile_color_cb, imd, (imd->cm != nullptr) );
+		pixbuf_renderer_set_post_process_func(PIXBUF_RENDERER(imd->pr), image_post_process_tile_color_cb, imd, (imd->cm != nullptr) );
 	else
-		pixbuf_renderer_set_post_process_func(reinterpret_cast<PixbufRenderer *>(imd->pr), nullptr, nullptr, TRUE);
+		pixbuf_renderer_set_post_process_func(PIXBUF_RENDERER(imd->pr), nullptr, nullptr, TRUE);
 
 }
 
@@ -1675,9 +1673,9 @@ void image_copy_from_image(ImageWindow *imd, ImageWindow *source)
 	pixbuf_renderer_copy(PIXBUF_RENDERER(imd->pr), PIXBUF_RENDERER(source->pr));
 
 	if (imd->cm || imd->desaturate || imd->overunderexposed)
-		pixbuf_renderer_set_post_process_func(reinterpret_cast<PixbufRenderer *>(imd->pr), image_post_process_tile_color_cb, imd, (imd->cm != nullptr) );
+		pixbuf_renderer_set_post_process_func(PIXBUF_RENDERER(imd->pr), image_post_process_tile_color_cb, imd, (imd->cm != nullptr) );
 	else
-		pixbuf_renderer_set_post_process_func(reinterpret_cast<PixbufRenderer *>(imd->pr), nullptr, nullptr, TRUE);
+		pixbuf_renderer_set_post_process_func(PIXBUF_RENDERER(imd->pr), nullptr, nullptr, TRUE);
 
 }
 
@@ -1686,25 +1684,25 @@ void image_copy_from_image(ImageWindow *imd, ImageWindow *source)
 
 void image_area_changed(ImageWindow *imd, gint x, gint y, gint width, gint height)
 {
-	pixbuf_renderer_area_changed(reinterpret_cast<PixbufRenderer *>(imd->pr), x, y, width, height);
+	pixbuf_renderer_area_changed(PIXBUF_RENDERER(imd->pr), x, y, width, height);
 }
 
 void image_reload(ImageWindow *imd)
 {
-	if (pixbuf_renderer_get_tiles(reinterpret_cast<PixbufRenderer *>(imd->pr))) return;
+	if (pixbuf_renderer_get_tiles(PIXBUF_RENDERER(imd->pr))) return;
 
 	image_change_complete(imd, image_zoom_get(imd));
 }
 
 void image_scroll(ImageWindow *imd, gint x, gint y)
 {
-	pixbuf_renderer_scroll(reinterpret_cast<PixbufRenderer *>(imd->pr), x, y);
+	pixbuf_renderer_scroll(PIXBUF_RENDERER(imd->pr), x, y);
 }
 
 void image_scroll_to_point(ImageWindow *imd, gint x, gint y,
 			   gdouble x_align, gdouble y_align)
 {
-	pixbuf_renderer_scroll_to_point(reinterpret_cast<PixbufRenderer *>(imd->pr), x, y, x_align, y_align);
+	pixbuf_renderer_scroll_to_point(PIXBUF_RENDERER(imd->pr), x, y, x_align, y_align);
 }
 
 void image_get_scroll_center(ImageWindow *imd, gdouble *x, gdouble *y)
@@ -1719,32 +1717,30 @@ void image_set_scroll_center(ImageWindow *imd, gdouble x, gdouble y)
 
 void image_zoom_adjust(ImageWindow *imd, gdouble increment)
 {
-	pixbuf_renderer_zoom_adjust(reinterpret_cast<PixbufRenderer *>(imd->pr), increment);
+	pixbuf_renderer_zoom_adjust(PIXBUF_RENDERER(imd->pr), increment);
 }
 
 void image_zoom_adjust_at_point(ImageWindow *imd, gdouble increment, gint x, gint y)
 {
-	pixbuf_renderer_zoom_adjust_at_point(reinterpret_cast<PixbufRenderer *>(imd->pr), increment, x, y);
+	pixbuf_renderer_zoom_adjust_at_point(PIXBUF_RENDERER(imd->pr), increment, x, y);
 }
 
 void image_zoom_set_limits(ImageWindow *imd, gdouble min, gdouble max)
 {
-	pixbuf_renderer_zoom_set_limits(reinterpret_cast<PixbufRenderer *>(imd->pr), min, max);
+	pixbuf_renderer_zoom_set_limits(PIXBUF_RENDERER(imd->pr), min, max);
 }
 
 void image_zoom_set(ImageWindow *imd, gdouble zoom)
 {
-	pixbuf_renderer_zoom_set(reinterpret_cast<PixbufRenderer *>(imd->pr), zoom);
+	pixbuf_renderer_zoom_set(PIXBUF_RENDERER(imd->pr), zoom);
 }
 
 void image_zoom_set_fill_geometry(ImageWindow *imd, gboolean vertical)
 {
-	PixbufRenderer *pr;
+	PixbufRenderer *pr = PIXBUF_RENDERER(imd->pr);
 	gdouble zoom;
 	gint width;
 	gint height;
-
-	pr = reinterpret_cast<PixbufRenderer *>(imd->pr);
 
 	if (!pixbuf_renderer_get_pixbuf(pr) ||
 	    !pixbuf_renderer_get_image_size(pr, &width, &height)) return;
@@ -1768,12 +1764,12 @@ void image_zoom_set_fill_geometry(ImageWindow *imd, gboolean vertical)
 
 gdouble image_zoom_get(ImageWindow *imd)
 {
-	return pixbuf_renderer_zoom_get(reinterpret_cast<PixbufRenderer *>(imd->pr));
+	return pixbuf_renderer_zoom_get(PIXBUF_RENDERER(imd->pr));
 }
 
 gdouble image_zoom_get_real(ImageWindow *imd)
 {
-	return pixbuf_renderer_zoom_get_scale(reinterpret_cast<PixbufRenderer *>(imd->pr));
+	return pixbuf_renderer_zoom_get_scale(PIXBUF_RENDERER(imd->pr));
 }
 
 gchar *image_zoom_get_as_text(ImageWindow *imd)
@@ -1840,7 +1836,7 @@ gdouble image_zoom_get_default(ImageWindow *imd)
 void image_stereo_set(ImageWindow *imd, gint stereo_mode)
 {
 	DEBUG_1("Setting stereo mode %04x for imd %p", stereo_mode, (void *)imd);
-	pixbuf_renderer_stereo_set(reinterpret_cast<PixbufRenderer *>(imd->pr), stereo_mode);
+	pixbuf_renderer_stereo_set(PIXBUF_RENDERER(imd->pr), stereo_mode);
 }
 
 StereoPixbufData image_stereo_pixbuf_get(ImageWindow *imd)
@@ -1858,7 +1854,7 @@ void image_stereo_pixbuf_set(ImageWindow *imd, StereoPixbufData stereo_mode)
 
 void image_prebuffer_set(ImageWindow *imd, FileData *fd)
 {
-	if (pixbuf_renderer_get_tiles(reinterpret_cast<PixbufRenderer *>(imd->pr))) return;
+	if (pixbuf_renderer_get_tiles(PIXBUF_RENDERER(imd->pr))) return;
 
 	if (fd)
 		{
@@ -1914,7 +1910,7 @@ void image_top_window_set_sync(ImageWindow *imd, gboolean allow_sync)
 
 void image_background_set_color(ImageWindow *imd, GdkRGBA *color)
 {
-	pixbuf_renderer_set_color(reinterpret_cast<PixbufRenderer *>(imd->pr), color);
+	pixbuf_renderer_set_color(PIXBUF_RENDERER(imd->pr), color);
 }
 
 void image_background_set_color_from_options(ImageWindow *imd, gboolean fullscreen)
@@ -2079,10 +2075,10 @@ static void image_options_set(ImageWindow *imd)
 
 					NULL);
 
-	pixbuf_renderer_set_parent(reinterpret_cast<PixbufRenderer *>(imd->pr), reinterpret_cast<GtkWindow *>(imd->top_window));
+	pixbuf_renderer_set_parent(PIXBUF_RENDERER(imd->pr), GTK_WINDOW(imd->top_window));
 
 	image_stereo_set(imd, options->stereo.mode);
-	pixbuf_renderer_stereo_fixed_set(reinterpret_cast<PixbufRenderer *>(imd->pr),
+	pixbuf_renderer_stereo_fixed_set(PIXBUF_RENDERER(imd->pr),
 					options->stereo.fixed_w, options->stereo.fixed_h,
 					options->stereo.fixed_x1, options->stereo.fixed_y1,
 					options->stereo.fixed_x2, options->stereo.fixed_y2);

--- a/src/layout-image.cc
+++ b/src/layout-image.cc
@@ -327,7 +327,6 @@ static gboolean show_next_frame(gpointer data)
 {
 	auto fd = static_cast<AnimationData*>(data);
 	int delay;
-	PixbufRenderer *pr;
 
 	if(animation_should_continue(fd)==FALSE)
 		{
@@ -335,7 +334,7 @@ static gboolean show_next_frame(gpointer data)
 		return FALSE;
 		}
 
-	pr = reinterpret_cast<PixbufRenderer*>(fd->iw->pr);
+	PixbufRenderer *pr = PIXBUF_RENDERER(fd->iw->pr);
 
 	if (gdk_pixbuf_animation_iter_advance(fd->iter,nullptr)==FALSE)
 		{
@@ -473,7 +472,7 @@ static gboolean layout_image_animate_new_file(LayoutWindow *lw)
 	if (gfstream)
 		{
 		animation->gfstream = gfstream;
-		gdk_pixbuf_animation_new_from_stream_async(reinterpret_cast<GInputStream*>(gfstream), animation->cancellable, animation_async_ready_cb, animation);
+		gdk_pixbuf_animation_new_from_stream_async(G_INPUT_STREAM(gfstream), animation->cancellable, animation_async_ready_cb, animation);
 		}
 	else
 		{
@@ -1278,7 +1277,7 @@ void layout_image_reset_orientation(LayoutWindow *lw)
 		 imd->orientation = imd->image_fd->user_orientation;
 		}
 
-	pixbuf_renderer_set_orientation(reinterpret_cast<PixbufRenderer *>(imd->pr), imd->orientation);
+	pixbuf_renderer_set_orientation(PIXBUF_RENDERER(imd->pr), imd->orientation);
 }
 
 void layout_image_set_desaturate(LayoutWindow *lw, gboolean desaturate)

--- a/src/pan-view/pan-item.cc
+++ b/src/pan-view/pan-item.cc
@@ -397,7 +397,7 @@ gboolean pan_item_text_draw(PanWindow *, PanItem *pi, GdkPixbuf *pixbuf, PixbufR
 {
 	PangoLayout *layout;
 
-	layout = pan_item_text_layout(pi, reinterpret_cast<GtkWidget *>(pr));
+	layout = pan_item_text_layout(pi, GTK_WIDGET(pr));
 	pixbuf_draw_layout(pixbuf, layout,
 	                   pi->x - x + pi->border, pi->y - y + pi->border,
 	                   pi->color.r, pi->color.g, pi->color.b, pi->color.a);

--- a/src/pan-view/pan-view-filter.cc
+++ b/src/pan-view/pan-view-filter.cc
@@ -118,9 +118,9 @@ PanViewFilterUi *pan_filter_ui_new(PanWindow *pw)
 		gtk_widget_show(ui->filter_check_buttons[i]);
 	}
 
-	gtk_toggle_button_set_active(reinterpret_cast<GtkToggleButton *>(ui->filter_check_buttons[FORMAT_CLASS_IMAGE]), TRUE);
-	gtk_toggle_button_set_active(reinterpret_cast<GtkToggleButton *>(ui->filter_check_buttons[FORMAT_CLASS_RAWIMAGE]), TRUE);
-	gtk_toggle_button_set_active(reinterpret_cast<GtkToggleButton *>(ui->filter_check_buttons[FORMAT_CLASS_VIDEO]), TRUE);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ui->filter_check_buttons[FORMAT_CLASS_IMAGE]), TRUE);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ui->filter_check_buttons[FORMAT_CLASS_RAWIMAGE]), TRUE);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ui->filter_check_buttons[FORMAT_CLASS_VIDEO]), TRUE);
 	ui->filter_classes = (1 << FORMAT_CLASS_IMAGE) | (1 << FORMAT_CLASS_RAWIMAGE) | (1 << FORMAT_CLASS_VIDEO);
 
 	// Connecting the signal before setting the state causes segfault as pw is not yet prepared
@@ -257,7 +257,7 @@ void pan_filter_toggle_button_cb(GtkWidget *, gpointer data)
 
 	for (gint i = 0; i < FILE_FORMAT_CLASSES; i++)
 	{
-		ui->filter_classes |= gtk_toggle_button_get_active(reinterpret_cast<GtkToggleButton *>(ui->filter_check_buttons[i])) ? 1 << i : 0;
+		ui->filter_classes |= gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(ui->filter_check_buttons[i])) ? 1 << i : 0;
 	}
 
 	if (ui->filter_classes != old_classes) 

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -608,16 +608,16 @@ static void pan_window_zoom_limit(PanWindow *pw)
  *-----------------------------------------------------------------------------
  */
 
-static gint pan_cache_sort_file_cb(gpointer a, gpointer b)
+static gint pan_cache_sort_file_cb(gconstpointer a, gconstpointer b)
 {
-	auto pca = static_cast<PanCacheData *>(a);
-	auto pcb = static_cast<PanCacheData *>(b);
+	auto pca = static_cast<const PanCacheData *>(a);
+	auto pcb = static_cast<const PanCacheData *>(b);
 	return filelist_sort_compare_filedata(pca->fd, pcb->fd);
 }
 
 GList *pan_cache_sort(GList *list, SortType method, gboolean ascend, gboolean case_sensitive)
 {
-	return filelist_sort_full(list, method, ascend, case_sensitive, reinterpret_cast<GCompareFunc>(pan_cache_sort_file_cb));
+	return filelist_sort_full(list, method, ascend, case_sensitive, pan_cache_sort_file_cb);
 }
 
 static void pan_cache_free(PanWindow *pw)

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -1361,7 +1361,7 @@ static void filter_remove_cb(GtkWidget *, gpointer data)
 	filter_store_populate();
 }
 
-static gboolean filter_default_ok_scroll(GtkTreeView *data)
+static gboolean filter_default_ok_scroll(gpointer data)
 {
 	GtkTreeIter iter;
 	GtkTreePath *path;
@@ -1377,7 +1377,7 @@ static gboolean filter_default_ok_scroll(GtkTreeView *data)
 
 	gtk_tree_path_free(path);
 
-	return(G_SOURCE_REMOVE);
+	return G_SOURCE_REMOVE;
 }
 
 static void filter_default_ok_cb(GenericDialog *gd, gpointer)
@@ -1387,7 +1387,7 @@ static void filter_default_ok_cb(GenericDialog *gd, gpointer)
 	filter_rebuild();
 	filter_store_populate();
 
-	g_idle_add(reinterpret_cast<GSourceFunc>(filter_default_ok_scroll), gd->data);
+	g_idle_add(filter_default_ok_scroll, gd->data);
 }
 
 static void dummy_cancel_cb(GenericDialog *, gpointer)
@@ -1731,7 +1731,7 @@ static gboolean accel_remove_key_cb(GtkTreeModel *model, GtkTreePath *, GtkTreeI
 
 static void accel_store_edited_cb(GtkCellRendererAccel *, gchar *path_string, guint accel_key, GdkModifierType accel_mods, guint, gpointer)
 {
-	auto model = reinterpret_cast<GtkTreeModel *>(accel_store);
+	GtkTreeModel *model = GTK_TREE_MODEL(accel_store);
 	GtkTreeIter iter;
 	gchar *acc;
 	gchar *accel_path;
@@ -1760,7 +1760,7 @@ static void accel_store_edited_cb(GtkCellRendererAccel *, gchar *path_string, gu
 	g_free(acc);
 }
 
-static gboolean accel_default_scroll(GtkTreeView *data)
+static gboolean accel_default_scroll(gpointer data)
 {
 	GtkTreeIter iter;
 	GtkTreePath *path;
@@ -1776,14 +1776,14 @@ static gboolean accel_default_scroll(GtkTreeView *data)
 
 	gtk_tree_path_free(path);
 
-	return(G_SOURCE_REMOVE);
+	return G_SOURCE_REMOVE;
 }
 
 static void accel_default_cb(GtkWidget *, gpointer data)
 {
 	accel_store_populate();
 
-	g_idle_add(reinterpret_cast<GSourceFunc>(accel_default_scroll), data);
+	g_idle_add(accel_default_scroll, data);
 }
 
 void accel_clear_selection(GtkTreeModel *, GtkTreePath *, GtkTreeIter *iter, gpointer)

--- a/src/remote.cc
+++ b/src/remote.cc
@@ -776,7 +776,7 @@ static void gr_pixel_info(const gchar *, GIOChannel *channel, gpointer)
 
 	if (!layout_valid(&lw_id)) return;
 
-	pr = reinterpret_cast<PixbufRenderer*>(lw_id->image->pr);
+	pr = PIXBUF_RENDERER(lw_id->image->pr);
 
 	if (pr)
 		{
@@ -815,7 +815,7 @@ static void gr_rectangle(const gchar *, GIOChannel *channel, gpointer)
 	if (!options->draw_rectangle) return;
 	if (!layout_valid(&lw_id)) return;
 
-	auto *pr = reinterpret_cast<PixbufRenderer *>(lw_id->image->pr);
+	auto *pr = PIXBUF_RENDERER(lw_id->image->pr);
 	if (!pr) return;
 
 	gint x1;

--- a/src/renderer-tiles.cc
+++ b/src/renderer-tiles.cc
@@ -472,7 +472,7 @@ static void rt_tile_prepare(RendererTiles *rt, ImageTile *it)
 		cairo_surface_t *surface;
 		guint size;
 
-		surface = gdk_window_create_similar_surface(gtk_widget_get_window(reinterpret_cast<GtkWidget *>(pr)),
+		surface = gdk_window_create_similar_surface(gtk_widget_get_window(GTK_WIDGET(pr)),
 		                                            CAIRO_CONTENT_COLOR,
 		                                            rt->tile_width, rt->tile_height);
 
@@ -560,7 +560,7 @@ static void rt_overlay_draw(RendererTiles *rt, const GdkRectangle &request_rect,
 			{
 			if (!rt->overlay_buffer)
 				{
-				rt->overlay_buffer = gdk_window_create_similar_surface(gtk_widget_get_window(reinterpret_cast<GtkWidget *>(rt->pr)),
+				rt->overlay_buffer = gdk_window_create_similar_surface(gtk_widget_get_window(GTK_WIDGET(rt->pr)),
 				                                                       CAIRO_CONTENT_COLOR,
 				                                                       rt->tile_width, rt->tile_height);
 				}

--- a/src/slideshow.cc
+++ b/src/slideshow.cc
@@ -75,21 +75,17 @@ static GList *generate_list(SlideShowData *ss)
 	return list;
 }
 
-static void ptr_array_add(gpointer data, GPtrArray *array)
-{
-	g_ptr_array_add(array, data);
-}
-
-static void list_prepend(gpointer data, GList **list)
-{
-	*list = g_list_prepend(*list, data);
-}
-
 static GPtrArray *generate_ptr_array_from_list(GList *src_list)
 {
 	GPtrArray *arr = g_ptr_array_sized_new(g_list_length(src_list));
 
-	g_list_foreach(src_list, reinterpret_cast<GFunc>(ptr_array_add), arr);
+	static const auto ptr_array_add = [](gpointer data, gpointer user_data)
+	{
+		auto *array = static_cast<GPtrArray *>(user_data);
+		g_ptr_array_add(array, data);
+	};
+
+	g_list_foreach(src_list, ptr_array_add, arr);
 
 	return arr;
 }
@@ -114,8 +110,14 @@ static GList *generate_random_list(SlideShowData *ss)
 	src_array = generate_ptr_array_from_list(src_list);
 	g_list_free(src_list);
 
+	static const auto list_prepend = [](gpointer data, gpointer user_data)
+	{
+		auto list = static_cast<GList **>(user_data);
+		*list = g_list_prepend(*list, data);
+	};
+
 	ptr_array_random_shuffle(src_array);
-	g_ptr_array_foreach(src_array, reinterpret_cast<GFunc>(list_prepend), &list);
+	g_ptr_array_foreach(src_array, list_prepend, &list);
 	g_ptr_array_free(src_array, TRUE);
 
 	return list;

--- a/src/ui-pathsel.cc
+++ b/src/ui-pathsel.cc
@@ -155,9 +155,9 @@ static gboolean dest_check_filter(const gchar *filter, const gchar *file)
 #define CASE_SORT strcmp
 #endif
 
-static gint dest_sort_cb(gpointer a, gpointer b)
+static gint dest_sort_cb(gconstpointer a, gconstpointer b)
 {
-	return CASE_SORT((gchar *)a, (gchar *)b);
+	return CASE_SORT(static_cast<const gchar *>(a), static_cast<const gchar *>(b));
 }
 
 static gboolean is_hidden(const gchar *name)
@@ -216,8 +216,8 @@ static void dest_populate(Dest_Data *dd, const gchar *path)
 	closedir(dp);
 	g_free(pathl);
 
-	path_list = g_list_sort(path_list, reinterpret_cast<GCompareFunc>(dest_sort_cb));
-	file_list = g_list_sort(file_list, reinterpret_cast<GCompareFunc>(dest_sort_cb));
+	path_list = g_list_sort(path_list, dest_sort_cb);
+	file_list = g_list_sort(file_list, dest_sort_cb);
 
 	store = GTK_LIST_STORE(gtk_tree_view_get_model(GTK_TREE_VIEW(dd->d_view)));
 	gtk_list_store_clear(store);


### PR DESCRIPTION
Use GObject macros.
Fix types in callbacks.
Remove redundant calls.