### PR TITLE
Creates initial unit tests for `FileData` instantiation, and fixes two latent bugs revealed by those tests.

### DIFF
--- a/src/tests/filedata/filedata.cc
+++ b/src/tests/filedata/filedata.cc
@@ -124,7 +124,6 @@ TEST_F(FileDataTest, FileDataNewSimpleAndFree)
 	auto *_fd = FileData::file_data_new_simple("/does/not/exist.jpg", &context);
 	ASSERT_NE(_fd, nullptr);
 	ASSERT_EQ(1, context.global_file_data_count);
-	// This currently fails because of a bug in file_data_new_simple.
 	ASSERT_EQ(1, _fd->ref);
 
 	_fd->file_data_unref();
@@ -139,7 +138,6 @@ TEST_F(FileDataTest, FileDataNewGroupAndFree)
 	auto *_fd = FileData::file_data_new_group("/does/not/exist/file.jpg", &context);
 	ASSERT_NE(_fd, nullptr);
 	EXPECT_EQ(1, context.global_file_data_count);
-	// This currently fails because of a bug in file_data_new_group.
 	ASSERT_EQ(1, _fd->ref);
 
 	_fd->file_data_unref();

--- a/src/tests/filedata/filedata.cc
+++ b/src/tests/filedata/filedata.cc
@@ -38,6 +38,7 @@ namespace {
 // For convenience.
 namespace t = ::testing;
 
+
 class FileDataTest : public t::Test
 {
     protected:
@@ -57,6 +58,7 @@ class FileDataTest : public t::Test
 
 	FileData *fd = nullptr;
 	FileData *parent_fd = nullptr;
+	FileDataContext context;
 };
 
 TEST_F(FileDataTest, text_from_size_test)
@@ -113,6 +115,36 @@ TEST_F(FileDataTest, text_from_size_abrev_test)
 		ASSERT_EQ(test_case.second, std::string(generated));
 		g_free(generated);
 	}
+}
+
+TEST_F(FileDataTest, FileDataNewSimpleAndFree)
+{
+	ASSERT_EQ(0, context.global_file_data_count);
+
+	auto *_fd = FileData::file_data_new_simple("/does/not/exist.jpg", &context);
+	ASSERT_NE(_fd, nullptr);
+	ASSERT_EQ(1, context.global_file_data_count);
+	// This currently fails because of a bug in file_data_new_simple.
+	ASSERT_EQ(1, _fd->ref);
+
+	_fd->file_data_unref();
+	_fd = nullptr;
+	ASSERT_EQ(0, context.global_file_data_count);
+}
+
+TEST_F(FileDataTest, FileDataNewGroupAndFree)
+{
+	ASSERT_EQ(0, context.global_file_data_count);
+
+	auto *_fd = FileData::file_data_new_group("/does/not/exist/file.jpg", &context);
+	ASSERT_NE(_fd, nullptr);
+	EXPECT_EQ(1, context.global_file_data_count);
+	// This currently fails because of a bug in file_data_new_group.
+	ASSERT_EQ(1, _fd->ref);
+
+	_fd->file_data_unref();
+	_fd = nullptr;
+	ASSERT_EQ(0, context.global_file_data_count);
 }
 
 TEST_F(FileDataTest, BasicIncrementVersion)


### PR DESCRIPTION
The first was a double-ref-counting bug, where a `FileData` created by either `file_data_new_simple` or `file_data_new_group` would be `file_data_ref`ed once in the sub-call to `file_data_new(...)`, and then once again afterwards.  The resolution was to _only_ increase the refcount when we found an existing `FileData` in the `context->file_data_pool` cache.

Beyond that, because the `stat` structures were not being zero-initialized, in cases where `stat_utf8` failed for any reason, they would be left with arbitrary contents, which caused unpredictable codepaths to be taken.  In particular, the [`S_ISDIR(st.st_mode)`](https://github.com/BestImageViewer/geeqie/blob/a8fa728ff63043c170b4cac017f995b259f4f4fb/src/filedata/filedata.cc#L1230) check would pass or fail randomly.  Zero-initializing the struct makes this behave consistently now.