### PR TITLE
Fix memory leaks after read_char_option() calls

### DIFF
--- a/src/bar-rating.cc
+++ b/src/bar-rating.cc
@@ -258,7 +258,7 @@ GtkWidget *bar_pane_rating_new_from_config(const gchar **attribute_names, const 
 void bar_pane_rating_update_from_config(GtkWidget *pane, const gchar **attribute_names, const gchar **attribute_values)
 {
 	PaneRatingData *prd;
-	gchar *title = nullptr;
+	g_autofree gchar *title = nullptr;
 
 	prd = static_cast<PaneRatingData *>(g_object_get_data(G_OBJECT(pane), "pane_data"));
 	if (!prd) return;
@@ -268,9 +268,9 @@ void bar_pane_rating_update_from_config(GtkWidget *pane, const gchar **attribute
 		const gchar *option = *attribute_names++;
 		const gchar *value = *attribute_values++;
 
-		if (READ_CHAR_FULL("title", title)) continue;
-		if (READ_CHAR_FULL("id", prd->pane.id)) continue;
-		if (READ_BOOL_FULL("expanded", prd->pane.expanded)) continue;
+		if (READ_CHAR_FULL("title", title)) continue; // FIXME Is it intended to set title to GTK_LABEL(prd->pane.title) or simply avoid "unknown attribute"?
+		if (READ_CHAR(prd->pane, id)) continue;
+		if (READ_BOOL(prd->pane, expanded)) continue;
 
 		log_printf("unknown attribute %s = %s\n", option, value);
 		}

--- a/src/bar-sort.cc
+++ b/src/bar-sort.cc
@@ -818,10 +818,8 @@ void bar_sort_cold_start(LayoutWindow *lw, const gchar **attribute_names, const 
 	lw->options.action = static_cast<SortActionType>(action);
 	lw->options.mode = static_cast<SortModeType>(mode);
 	lw->options.selection = static_cast<SortSelectionType>(selection);
-	lw->options.filter_key = g_strdup(filter_key);
+	lw->options.filter_key = filter_key;
 	lw->bar_sort_enabled = enabled;
-
-	g_free(filter_key);
 }
 
 GtkWidget *bar_sort_new_default(LayoutWindow *lw)

--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -1842,9 +1842,9 @@ void keyword_tree_disconnect_marks()
 
 GtkTreeIter *keyword_add_from_config(GtkTreeStore *keyword_tree, GtkTreeIter *parent, const gchar **attribute_names, const gchar **attribute_values)
 {
-	gchar *name = nullptr;
+	g_autofree gchar *name = nullptr;
 	gboolean is_kw = TRUE;
-	gchar *mark_str = nullptr;
+	g_autofree gchar *mark_str = nullptr;
 
 	while (*attribute_names)
 		{
@@ -1857,6 +1857,7 @@ GtkTreeIter *keyword_add_from_config(GtkTreeStore *keyword_tree, GtkTreeIter *pa
 
 		log_printf("unknown attribute %s = %s\n", option, value);
 		}
+
 	if (name && name[0])
 		{
 		GtkTreeIter iter;
@@ -1876,10 +1877,9 @@ GtkTreeIter *keyword_add_from_config(GtkTreeStore *keyword_tree, GtkTreeIter *pa
 											&iter, i - 1);
 			}
 
-		g_free(name);
 		return gtk_tree_iter_copy(&iter);
 		}
-	g_free(name);
+
 	return nullptr;
 }
 

--- a/src/rcfile.cc
+++ b/src/rcfile.cc
@@ -1141,18 +1141,16 @@ static void options_load_marks_tooltips(GQParserData *parser_data, GMarkupParseC
 static void options_load_disabled_plugins(GQParserData *parser_data, GMarkupParseContext *, const gchar *, const gchar **attribute_names, const gchar **attribute_values, gpointer data, GError **)
 {
 	gint i = GPOINTER_TO_INT(data);
-	struct {
-		gchar *path;
-	} tmp;
 
 	while (*attribute_names)
 		{
 		const gchar *option = *attribute_names++;
 		const gchar *value = *attribute_values++;
-		tmp.path = nullptr;
-		if (READ_CHAR_FULL("path", tmp.path))
+
+		gchar *path = nullptr;
+		if (READ_CHAR_FULL("path", path))
 			{
-			options->disabled_plugins = g_list_append(options->disabled_plugins, g_strdup(tmp.path));
+			options->disabled_plugins = g_list_append(options->disabled_plugins, path);
 			continue;
 			}
 

--- a/src/ui-utildlg.cc
+++ b/src/ui-utildlg.cc
@@ -335,38 +335,31 @@ GtkWidget *generic_dialog_add_message(GenericDialog *gd, const gchar *icon_name,
 
 void generic_dialog_windows_load_config(const gchar **attribute_names, const gchar **attribute_values)
 {
-	auto dw =  g_new0(DialogWindow, 1);
-	gchar *title = nullptr;
-	gchar *role = nullptr;
-	gint x = 0;
-	gint y = 0;
-	gint w = 0;
-	gint h = 0;
+	auto dw = g_new0(DialogWindow, 1);
 
 	while (*attribute_names)
 		{
 		const gchar *option = *attribute_names++;
 		const gchar *value = *attribute_values++;
-		if (READ_CHAR_FULL("title", title)) continue;
-		if (READ_CHAR_FULL("role", role)) continue;
-		if (READ_INT_FULL("x", x)) continue;
-		if (READ_INT_FULL("y", y)) continue;
-		if (READ_INT_FULL("w", w)) continue;
-		if (READ_INT_FULL("h", h)) continue;
+		if (READ_CHAR(*dw, title)) continue;
+		if (READ_CHAR(*dw, role)) continue;
+		if (READ_INT(*dw, x)) continue;
+		if (READ_INT(*dw, y)) continue;
+		if (READ_INT(*dw, w)) continue;
+		if (READ_INT(*dw, h)) continue;
 
 		log_printf("unknown attribute %s = %s\n", option, value);
 		}
 
-	if (title && title[0] != 0)
+	if (dw->title && dw->title[0] != 0)
 		{
-		dw->title = g_strdup(title);
-		dw->role = g_strdup(role);
-		dw->x = x;
-		dw->y = y;
-		dw->w = w;
-		dw->h = h;
-
 		dialog_windows = g_list_append(dialog_windows, dw);
+		}
+	else
+		{
+		g_free(dw->title);
+		g_free(dw->role);
+		g_free(dw);
 		}
 }
 


### PR DESCRIPTION
Use `g_autofree` macros.
Also remove redundant `g_strdup()`.