### PR TITLE
Simplify GObject data destroying

### DIFF
--- a/src/bar-comment.cc
+++ b/src/bar-comment.cc
@@ -251,7 +251,7 @@ static void bar_pane_comment_populate_popup(GtkTextView *, GtkMenu *menu, gpoint
 	menu_item_add_icon(GTK_WIDGET(menu), _("Replace existing text in selected files"), GQ_ICON_REPLACE, G_CALLBACK(bar_pane_comment_sel_replace_cb), data);
 }
 
-static void bar_pane_comment_destroy(GtkWidget *, gpointer data)
+static void bar_pane_comment_destroy(gpointer data)
 {
 	auto pcd = static_cast<PaneCommentData *>(data);
 
@@ -293,9 +293,7 @@ static GtkWidget *bar_pane_comment_new(const gchar *id, const gchar *title, cons
 	scrolled = gq_gtk_scrolled_window_new(nullptr, nullptr);
 
 	pcd->widget = scrolled;
-	g_object_set_data(G_OBJECT(pcd->widget), "pane_data", pcd);
-	g_signal_connect(G_OBJECT(pcd->widget), "destroy",
-			 G_CALLBACK(bar_pane_comment_destroy), pcd);
+	g_object_set_data_full(G_OBJECT(pcd->widget), "pane_data", pcd, bar_pane_comment_destroy);
 
 	gq_gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(scrolled), GTK_SHADOW_IN);
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),

--- a/src/bar-exif.cc
+++ b/src/bar-exif.cc
@@ -121,7 +121,7 @@ void bar_pane_exif_entry_changed(GtkEntry *, gpointer data)
 	g_free(text);
 }
 
-void bar_pane_exif_entry_destroy(GtkWidget *, gpointer data)
+void bar_pane_exif_entry_destroy(gpointer data)
 {
 	auto ee = static_cast<ExifEntry *>(data);
 
@@ -191,9 +191,7 @@ GtkWidget *bar_pane_exif_add_entry(PaneExifData *ped, const gchar *key, const gc
 	ee->ped = ped;
 
 	ee->ebox = gtk_event_box_new();
-	g_object_set_data(G_OBJECT(ee->ebox), "entry_data", ee);
-	g_signal_connect_after(G_OBJECT(ee->ebox), "destroy",
-			       G_CALLBACK(bar_pane_exif_entry_destroy), ee);
+	g_object_set_data_full(G_OBJECT(ee->ebox), "entry_data", ee, bar_pane_exif_entry_destroy);
 
 	gq_gtk_box_pack_start(GTK_BOX(ped->vbox), ee->ebox, FALSE, FALSE, 0);
 
@@ -769,7 +767,7 @@ void bar_pane_exif_write_config(GtkWidget *pane, GString *outstr, gint indent)
 	WRITE_NL(); WRITE_STRING("</pane_exif>");
 }
 
-void bar_pane_exif_destroy(GtkWidget *, gpointer data)
+void bar_pane_exif_destroy(gpointer data)
 {
 	auto ped = static_cast<PaneExifData *>(data);
 
@@ -809,9 +807,7 @@ GtkWidget *bar_pane_exif_new(const gchar *id, const gchar *title, gboolean expan
 	gtk_widget_show(ped->vbox);
 
 	ped->min_height = MIN_HEIGHT;
-	g_object_set_data(G_OBJECT(ped->widget), "pane_data", ped);
-	g_signal_connect_after(G_OBJECT(ped->widget), "destroy",
-			       G_CALLBACK(bar_pane_exif_destroy), ped);
+	g_object_set_data_full(G_OBJECT(ped->widget), "pane_data", ped, bar_pane_exif_destroy);
 	gtk_widget_set_size_request(ped->widget, -1, ped->min_height);
 	g_signal_connect(G_OBJECT(ped->widget), "size-allocate",
 			 G_CALLBACK(bar_pane_exif_size_allocate), ped);

--- a/src/bar-gps.cc
+++ b/src/bar-gps.cc
@@ -901,7 +901,7 @@ static gboolean bar_pane_gps_map_keypress_cb(GtkWidget *, GdkEventButton *bevent
 }
 #endif
 
-static void bar_pane_gps_destroy(GtkWidget *, gpointer data)
+static void bar_pane_gps_destroy(gpointer data)
 {
 	auto pgd = static_cast<PaneGPSData *>(data);
 
@@ -1004,8 +1004,7 @@ GtkWidget *bar_pane_gps_new(const gchar *id, const gchar *title, const gchar *ma
 				     NULL);
 	champlain_view_center_on(view, latitude, longitude);
 	pgd->centre_map_checked = TRUE;
-	g_object_set_data(G_OBJECT(pgd->widget), "pane_data", pgd);
-	g_signal_connect(G_OBJECT(pgd->widget), "destroy", G_CALLBACK(bar_pane_gps_destroy), pgd);
+	g_object_set_data_full(G_OBJECT(pgd->widget), "pane_data", pgd, bar_pane_gps_destroy);
 
 	gq_gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_IN);
 

--- a/src/bar-histogram.cc
+++ b/src/bar-histogram.cc
@@ -184,7 +184,7 @@ static void bar_pane_histogram_size_cb(GtkWidget *, GtkAllocation *allocation, g
 	bar_pane_histogram_update(phd);
 }
 
-static void bar_pane_histogram_destroy(GtkWidget *, gpointer data)
+static void bar_pane_histogram_destroy(gpointer data)
 {
 	auto phd = static_cast<PaneHistogramData *>(data);
 
@@ -287,12 +287,7 @@ static GtkWidget *bar_pane_histogram_new(const gchar *id, const gchar *title, gi
 	histogram_set_mode(phd->histogram, histogram_mode);
 
 	phd->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, PREF_PAD_GAP);
-
-	g_object_set_data(G_OBJECT(phd->widget), "pane_data", phd);
-	g_signal_connect(G_OBJECT(phd->widget), "destroy",
-			 G_CALLBACK(bar_pane_histogram_destroy), phd);
-
-
+	g_object_set_data_full(G_OBJECT(phd->widget), "pane_data", phd, bar_pane_histogram_destroy);
 	gtk_widget_set_size_request(GTK_WIDGET(phd->widget), -1, height);
 
 	phd->drawing_area = gtk_drawing_area_new();

--- a/src/bar-keywords.cc
+++ b/src/bar-keywords.cc
@@ -1418,7 +1418,7 @@ gboolean bar_pane_keywords_menu_cb(GtkWidget *widget, GdkEventButton *bevent, gp
  *-------------------------------------------------------------------
  */
 
-void bar_pane_keywords_destroy(GtkWidget *, gpointer data)
+void bar_pane_keywords_destroy(gpointer data)
 {
 	auto pkd = static_cast<PaneKeywordsData *>(data);
 	gchar *path;
@@ -1474,9 +1474,7 @@ GtkWidget *bar_pane_keywords_new(const gchar *id, const gchar *title, const gcha
 	gq_gtk_box_pack_start(GTK_BOX(vbox), hbox, TRUE, TRUE, 0);
 
 	pkd->widget = vbox;
-	g_object_set_data(G_OBJECT(pkd->widget), "pane_data", pkd);
-	g_signal_connect(G_OBJECT(pkd->widget), "destroy",
-			 G_CALLBACK(bar_pane_keywords_destroy), pkd);
+	g_object_set_data_full(G_OBJECT(pkd->widget), "pane_data", pkd, bar_pane_keywords_destroy);
 	gtk_widget_set_size_request(pkd->widget, -1, height);
 	gtk_widget_show(hbox);
 

--- a/src/bar-rating.cc
+++ b/src/bar-rating.cc
@@ -103,7 +103,7 @@ static void bar_pane_rating_notify_cb(FileData *fd, NotifyType type, gpointer da
 		}
 }
 
-static void bar_pane_rating_destroy(GtkWidget *, gpointer data)
+static void bar_pane_rating_destroy(gpointer data)
 {
 	auto prd = static_cast<PaneRatingData *>(data);
 
@@ -175,8 +175,7 @@ static GtkWidget *bar_pane_rating_new(const gchar *id, const gchar *title, gbool
 
 	prd->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, PREF_PAD_GAP);
 
-	g_object_set_data(G_OBJECT(prd->widget), "pane_data", prd);
-	g_signal_connect(G_OBJECT(prd->widget), "destroy", G_CALLBACK(bar_pane_rating_destroy), prd);
+	g_object_set_data_full(G_OBJECT(prd->widget), "pane_data", prd, bar_pane_rating_destroy);
 
 	row_1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, PREF_PAD_GAP);
 	gq_gtk_box_pack_start(GTK_BOX(prd->widget), row_1, FALSE, FALSE, 0);

--- a/src/bar-sort.cc
+++ b/src/bar-sort.cc
@@ -619,7 +619,7 @@ void bar_sort_close(GtkWidget *bar)
 	gq_gtk_widget_destroy(sd->vbox);
 }
 
-static void bar_sort_destroy(GtkWidget *, gpointer data)
+static void bar_sort_destroy(gpointer data)
 {
 	auto sd = static_cast<SortData *>(data);
 
@@ -630,11 +630,6 @@ static void bar_sort_destroy(GtkWidget *, gpointer data)
 	g_list_free_full(sd->undo_dest_list, g_free);
 	g_free(sd->undo_collection);
 	g_free(sd);
-}
-
-static void bar_sort_edit_button_free(gpointer data)
-{
-	g_free(data);
 }
 
 static GtkWidget *bar_sort_new(LayoutWindow *lw, SortActionType action,
@@ -671,9 +666,7 @@ static GtkWidget *bar_sort_new(LayoutWindow *lw, SortActionType action,
 
 	sd->vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, PREF_PAD_GAP);
 	DEBUG_NAME(sd->vbox);
-	g_object_set_data(G_OBJECT(sd->vbox), "bar_sort_data", sd);
-	g_signal_connect(G_OBJECT(sd->vbox), "destroy",
-			 G_CALLBACK(bar_sort_destroy), sd);
+	g_object_set_data_full(G_OBJECT(sd->vbox), "bar_sort_data", sd, bar_sort_destroy);
 
 	label = gtk_label_new(_("Sort Manager"));
 	pref_label_bold(label, TRUE, FALSE);
@@ -731,7 +724,7 @@ static GtkWidget *bar_sort_new(LayoutWindow *lw, SortActionType action,
 					      G_CALLBACK(bar_sort_set_filter_cb), sd);
 		g_signal_connect(G_OBJECT(button), "button_press_event", G_CALLBACK(bar_filter_message_cb), NULL);
 
-		g_object_set_data_full(G_OBJECT(button), "filter_key", key, bar_sort_edit_button_free);
+		g_object_set_data_full(G_OBJECT(button), "filter_key", key, g_free);
 		}
 	g_list_free(editors_list);
 

--- a/src/bar.cc
+++ b/src/bar.cc
@@ -728,7 +728,7 @@ void bar_close(GtkWidget *bar)
 	gq_gtk_widget_destroy(bd->widget);
 }
 
-static void bar_destroy(GtkWidget *, gpointer data)
+static void bar_destroy(gpointer data)
 {
 	auto bd = static_cast<BarData *>(data);
 
@@ -765,9 +765,7 @@ GtkWidget *bar_new(LayoutWindow *lw)
 
 	bd->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, PREF_PAD_GAP);
 	DEBUG_NAME(bd->widget);
-	g_object_set_data(G_OBJECT(bd->widget), "bar_data", bd);
-	g_signal_connect(G_OBJECT(bd->widget), "destroy",
-			 G_CALLBACK(bar_destroy), bd);
+	g_object_set_data_full(G_OBJECT(bd->widget), "bar_data", bd, bar_destroy);
 
 	g_signal_connect(G_OBJECT(bd->widget), "size-allocate",
 			 G_CALLBACK(bar_size_allocate), bd);

--- a/src/layout-config.cc
+++ b/src/layout-config.cc
@@ -73,7 +73,7 @@ constexpr gint layout_config_style_count = sizeof(layout_config_styles) / sizeof
 const gchar *layout_titles[] = { N_("Tools"), N_("Files"), N_("Image") };
 
 
-void layout_config_destroy(GtkWidget *, gpointer data)
+void layout_config_destroy(gpointer data)
 {
 	auto lc = static_cast<LayoutConfig *>(data);
 
@@ -374,10 +374,7 @@ GtkWidget *layout_config_new()
 	lc = g_new0(LayoutConfig, 1);
 
 	lc->box = gtk_box_new(GTK_ORIENTATION_VERTICAL, PREF_PAD_GAP);
-	g_object_set_data(G_OBJECT(lc->box), "layout_config", lc);
-
-	g_signal_connect(G_OBJECT(lc->box), "destroy",
-			 G_CALLBACK(layout_config_destroy), lc);
+	g_object_set_data_full(G_OBJECT(lc->box), "layout_config", lc, layout_config_destroy);
 
 	hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, PREF_PAD_SPACE);
 	gq_gtk_box_pack_start(GTK_BOX(lc->box), hbox, FALSE, FALSE, 0);

--- a/src/osd.cc
+++ b/src/osd.cc
@@ -122,13 +122,13 @@ static void osd_dnd_get_cb(GtkWidget *btn, GdkDragContext *, GtkSelectionData *s
 	gtk_widget_grab_focus(GTK_WIDGET(image_overlay_template_view));
 }
 
-static void osd_btn_destroy_cb(GtkWidget *btn, GdkDragContext *, GtkSelectionData *, guint, guint, gpointer)
+static void tag_data_free(gpointer data)
 {
-	TagData *td;
+	auto *td = static_cast<TagData *>(data);
 
-	td = static_cast<TagData *>(g_object_get_data(G_OBJECT(btn), "tag_data"));
 	g_free(td->key);
 	g_free(td->title);
+	g_free(td);
 }
 
 static void set_osd_button(GtkGrid *grid, const gint rows, const gint cols, const gchar *key, const gchar *title, GtkWidget *template_view)
@@ -144,13 +144,11 @@ static void set_osd_button(GtkGrid *grid, const gint rows, const gint cols, cons
 	td->key = g_strdup(key);
 	td->title = g_strdup(title);
 
-	g_object_set_data(G_OBJECT(new_button), "tag_data", td);
+	g_object_set_data_full(G_OBJECT(new_button), "tag_data", td, tag_data_free);
 
 	gtk_drag_source_set(new_button, GDK_BUTTON1_MASK, osd_drag_types, 1, GDK_ACTION_COPY);
 	g_signal_connect(G_OBJECT(new_button), "drag_data_get",
 							G_CALLBACK(osd_dnd_get_cb), template_view);
-	g_signal_connect(G_OBJECT(new_button), "destroy",
-							G_CALLBACK(osd_btn_destroy_cb), new_button);
 
 	gtk_grid_attach(grid, new_button, cols, rows, 1, 1);
 

--- a/src/shortcuts.cc
+++ b/src/shortcuts.cc
@@ -130,7 +130,7 @@ static void shortcuts_add_cb(GtkWidget *button, gpointer data)
 	gtk_widget_show(GENERIC_DIALOG(scd->dialog)->dialog);
 }
 
-static void shortcuts_destroy(GtkWidget *, gpointer data)
+static void shortcuts_destroy(gpointer data)
 {
 	auto scd = static_cast<ShortcutsData *>(data);
 
@@ -151,9 +151,7 @@ static GtkWidget *shortcuts_new(LayoutWindow *lw)
 	scd->lw = lw;
 
 	scd->vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, PREF_PAD_GAP);
-	g_object_set_data(G_OBJECT(scd->vbox), "shortcuts_data", scd);
-	g_signal_connect(G_OBJECT(scd->vbox), "destroy",
-			G_CALLBACK(shortcuts_destroy), scd);
+	g_object_set_data_full(G_OBJECT(scd->vbox), "shortcuts_data", scd, shortcuts_destroy);
 
 	scd->bookmarks = bookmark_list_new(SHORTCUTS, shortcuts_bookmark_select, scd);
 	gq_gtk_box_pack_start(GTK_BOX(scd->vbox), scd->bookmarks, TRUE, TRUE, 0);

--- a/src/toolbar.cc
+++ b/src/toolbar.cc
@@ -164,13 +164,6 @@ static void get_toolbar_item(const gchar *name, gchar **label, gchar **stock_id)
 		}
 }
 
-static void toolbar_button_free(GtkWidget *widget)
-{
-	g_free(g_object_get_data(G_OBJECT(widget), "toolbar_add_name"));
-	g_free(g_object_get_data(G_OBJECT(widget), "toolbar_add_label"));
-	g_free(g_object_get_data(G_OBJECT(widget), "toolbar_add_stock_id"));
-}
-
 static void toolbarlist_add_button(const gchar *name, const gchar *label,
 									const gchar *stock_id, GtkBox *box)
 {
@@ -280,20 +273,18 @@ static gboolean toolbar_menu_add_cb(GtkWidget *, gpointer data)
 	menu = popup_menu_short_lived();
 
 	item = menu_item_add_stock(menu, "Separator", "Separator", G_CALLBACK(toolbarlist_add_cb), data);
-	g_object_set_data(G_OBJECT(item), "toolbar_add_name", g_strdup("Separator"));
-	g_object_set_data(G_OBJECT(item), "toolbar_add_label", g_strdup("Separator"));
-	g_object_set_data(G_OBJECT(item), "toolbar_add_stock_id", g_strdup("no-icon"));
-	g_signal_connect(G_OBJECT(item), "destroy", G_CALLBACK(toolbar_button_free), item);
+	g_object_set_data_full(G_OBJECT(item), "toolbar_add_name", g_strdup("Separator"), g_free);
+	g_object_set_data_full(G_OBJECT(item), "toolbar_add_label", g_strdup("Separator"), g_free);
+	g_object_set_data_full(G_OBJECT(item), "toolbar_add_stock_id", g_strdup("no-icon"), g_free);
 
 	std::vector<ActionItem> list = get_action_items();
 
 	for (const ActionItem &action_item : list)
 		{
 		item = menu_item_add_stock(menu, action_item.label, action_item.icon_name, G_CALLBACK(toolbarlist_add_cb), data);
-		g_object_set_data(G_OBJECT(item), "toolbar_add_name", g_strdup(action_item.name));
-		g_object_set_data(G_OBJECT(item), "toolbar_add_label", g_strdup(action_item.label));
-		g_object_set_data(G_OBJECT(item), "toolbar_add_stock_id", g_strdup(action_item.icon_name));
-		g_signal_connect(G_OBJECT(item), "destroy", G_CALLBACK(toolbar_button_free), item);
+		g_object_set_data_full(G_OBJECT(item), "toolbar_add_name", g_strdup(action_item.name), g_free);
+		g_object_set_data_full(G_OBJECT(item), "toolbar_add_label", g_strdup(action_item.label), g_free);
+		g_object_set_data_full(G_OBJECT(item), "toolbar_add_stock_id", g_strdup(action_item.icon_name), g_free);
 		}
 
 	gtk_menu_popup_at_pointer(GTK_MENU(menu), nullptr);

--- a/src/ui-bookmark.cc
+++ b/src/ui-bookmark.cc
@@ -793,7 +793,7 @@ static void bookmark_dnd_get_data(GtkWidget *, GdkDragContext *,
 		}
 }
 
-static void bookmark_list_destroy(GtkWidget *, gpointer data)
+static void bookmark_list_destroy(gpointer data)
 {
 	auto bm = static_cast<BookMarkData *>(data);
 
@@ -840,9 +840,7 @@ GtkWidget *bookmark_list_new(const gchar *key,
 
 	bookmark_populate(bm);
 
-	g_signal_connect(G_OBJECT(bm->box), "destroy",
-			 G_CALLBACK(bookmark_list_destroy), bm);
-	g_object_set_data(G_OBJECT(bm->box), BOOKMARK_DATA_KEY, bm);
+	g_object_set_data_full(G_OBJECT(bm->box), BOOKMARK_DATA_KEY, bm, bookmark_list_destroy);
 	g_object_set_data(G_OBJECT(scrolled), BOOKMARK_DATA_KEY, bm);
 	bm->widget = scrolled;
 
@@ -962,7 +960,7 @@ struct HistoryComboData
 	gint history_levels;
 };
 
-static void history_combo_destroy(GtkWidget *, gpointer data)
+static void history_combo_destroy(gpointer data)
 {
 	auto hc = static_cast<HistoryComboData *>(data);
 
@@ -986,10 +984,8 @@ GtkWidget *history_combo_new(GtkWidget **entry, const gchar *text,
 
 	hc->entry = gtk_bin_get_child(GTK_BIN(hc->combo));
 
-	g_object_set_data(G_OBJECT(hc->combo), "history_combo_data", hc);
+	g_object_set_data_full(G_OBJECT(hc->combo), "history_combo_data", hc, history_combo_destroy);
 	g_object_set_data(G_OBJECT(hc->entry), "history_combo_data", hc);
-	g_signal_connect(G_OBJECT(hc->combo), "destroy",
-			 G_CALLBACK(history_combo_destroy), hc);
 
 	work = history_list_get_by_key(hc->history_key);
 	while (work)

--- a/src/ui-tabcomp.cc
+++ b/src/ui-tabcomp.cc
@@ -146,7 +146,7 @@ static void tab_completion_read_dir(TabCompData *td, const gchar *path)
 	g_free(pathl);
 }
 
-static void tab_completion_destroy(GtkWidget *, gpointer data)
+static void tab_completion_destroy(gpointer data)
 {
 	auto td = static_cast<TabCompData *>(data);
 
@@ -763,12 +763,10 @@ void tab_completion_add_to_entry(GtkWidget *entry, void (*enter_func)(const gcha
 	td->filter = g_strdup(filter);
 	td->filter_desc = g_strdup(filter_desc);
 
-	g_object_set_data(G_OBJECT(td->entry), "tab_completion_data", td);
+	g_object_set_data_full(G_OBJECT(entry), "tab_completion_data", td, tab_completion_destroy);
 
 	g_signal_connect(G_OBJECT(entry), "key_press_event",
 			 G_CALLBACK(tab_completion_key_pressed), td);
-	g_signal_connect(G_OBJECT(entry), "destroy",
-			 G_CALLBACK(tab_completion_destroy), td);
 }
 
 void tab_completion_add_tab_func(GtkWidget *entry, void (*tab_func)(const gchar *, gpointer), gpointer data)

--- a/src/view-dir.cc
+++ b/src/view-dir.cc
@@ -445,11 +445,6 @@ static void vd_drop_menu_filter_cb(GtkWidget *widget, gpointer data)
 	file_util_start_filter_from_filelist(key, list, path, vd->widget);
 }
 
-static void vd_drop_menu_edit_item_free(gpointer data)
-{
-	g_free(data);
-}
-
 GtkWidget *vd_drop_menu(ViewDir *vd, gint active)
 {
 	GtkWidget *menu;
@@ -468,13 +463,11 @@ GtkWidget *vd_drop_menu(ViewDir *vd, gint active)
 		{
 		GtkWidget *item;
 		auto editor = static_cast<const EditorDescription *>(work->data);
-		gchar *key;
 		work = work->next;
 
 		if (!editor_is_filter(editor->key)) continue;
-		key = g_strdup(editor->key);
 		item = menu_item_add_sensitive(menu, editor->name, active, G_CALLBACK(vd_drop_menu_filter_cb), vd);
-		g_object_set_data_full(G_OBJECT(item), "filter_key", key, vd_drop_menu_edit_item_free);
+		g_object_set_data_full(G_OBJECT(item), "filter_key", g_strdup(editor->key), g_free);
 		}
 
 	g_list_free(editors_list);


### PR DESCRIPTION
Common pattern to associate to GObject and later free data is:

```c++
g_object_set_data(object, "key", data);
g_signal_connect(object, "destroy", G_CALLBACK(destroy_cb), data);
```

where `destroy_cb` usually defined as

```c++
void destroy_cb(GtkWidget *, gpointer data)
{
	// free data
}
```

Connecting to `"destroy"` signal is redundant since the same could be achieved using
```c++
g_object_set_data_full(object, "key", data, destroy_cb);
```

Also unused `GtkWidget *` parameter is not required anymore.