### PR TITLE
Add wrappers for cache_get_location()

### DIFF
--- a/geeqie.imp
+++ b/geeqie.imp
@@ -1,5 +1,6 @@
 [
     { include: [ "<bits/types/sig_atomic_t.h>",        private, "<csignal>",               public ] },
+    { include: [ "<__stdarg_va_arg.h>",                private, "<cstdarg>",               public ] },
     { include: [ "<bits/types/struct_FILE.h>",         private, "<cstdio>",                public ] },
     { include: [ "<bits/std_abs.h>",                   private, "<cstdlib>",               public ] },
 

--- a/src/cache-loader.cc
+++ b/src/cache-loader.cc
@@ -21,8 +21,6 @@
 
 #include "cache-loader.h"
 
-#include <sys/types.h>
-
 #include <cstdio>
 #include <cstring>
 #include <ctime>
@@ -186,20 +184,16 @@ static gboolean cache_loader_phase2_process(CacheLoader *cl)
 		if (options->thumbnails.enable_caching &&
 		    cl->done_mask != CACHE_LOADER_NONE)
 			{
-			gchar *base;
-			mode_t mode = 0755;
-
-			base = cache_get_location(CACHE_TYPE_SIM, cl->fd->path, FALSE, &mode);
-			if (recursive_mkdir_if_not_exists(base, mode))
+			g_autofree gchar *base = cache_create_location(CACHE_TYPE_SIM, cl->fd->path);
+			if (base)
 				{
 				g_free(cl->cd->path);
-				cl->cd->path = cache_get_location(CACHE_TYPE_SIM, cl->fd->path, TRUE, nullptr);
+				cl->cd->path = cache_get_location(CACHE_TYPE_SIM, cl->fd->path);
 				if (cache_sim_data_save(cl->cd))
 					{
 					filetime_set(cl->cd->path, filetime(cl->fd->path));
 					}
 				}
-			g_free(base);
 			}
 
 		cl->idle_id = 0;

--- a/src/cache-maint.cc
+++ b/src/cache-maint.cc
@@ -22,7 +22,6 @@
 #include "cache-maint.h"
 
 #include <dirent.h>
-#include <sys/types.h>
 
 #include <cstdlib>
 #include <cstring>
@@ -476,7 +475,7 @@ static void cache_maint_moved(FileData *fd)
 		g_autofree gchar *src_path = cache_find_location(cache_type, src);
 		if (!src_path || !isfile(src_path)) return;
 
-		g_autofree gchar *dest_path = cache_get_location(cache_type, dest, TRUE, nullptr);
+		g_autofree gchar *dest_path = cache_get_location(cache_type, dest);
 		if (!dest_path) return;
 
 		if (!move_file(src_path, dest_path))
@@ -487,9 +486,8 @@ static void cache_maint_moved(FileData *fd)
 			}
 	};
 
-	mode_t mode = 0755;
-	g_autofree gchar *dest_base = cache_get_location(CACHE_TYPE_THUMB, dest, FALSE, &mode);
-	if (recursive_mkdir_if_not_exists(dest_base, mode))
+	g_autofree gchar *dest_base = cache_create_location(CACHE_TYPE_THUMB, dest);
+	if (dest_base)
 		{
 		cache_move(CACHE_TYPE_THUMB);
 		cache_move(CACHE_TYPE_SIM);
@@ -500,8 +498,8 @@ static void cache_maint_moved(FileData *fd)
 		}
 
 	g_free(dest_base);
-	dest_base = cache_get_location(CACHE_TYPE_METADATA, dest, FALSE, &mode);
-	if (recursive_mkdir_if_not_exists(dest_base, mode))
+	dest_base = cache_create_location(CACHE_TYPE_METADATA, dest);
+	if (dest_base)
 		{
 		cache_move(CACHE_TYPE_METADATA);
 		}
@@ -536,11 +534,10 @@ static void cache_maint_copied(FileData *fd)
 	g_autofree gchar *src_path = cache_find_location(CACHE_TYPE_METADATA, fd->change->source);
 	if (!src_path) return;
 
-	mode_t mode = 0755;
-	g_autofree gchar *dest_base = cache_get_location(CACHE_TYPE_METADATA, fd->change->dest, FALSE, &mode);
-	if (!recursive_mkdir_if_not_exists(dest_base, mode)) return;
+	g_autofree gchar *dest_base = cache_create_location(CACHE_TYPE_METADATA, fd->change->dest);
+	if (!dest_base) return;
 
-	g_autofree gchar *dest_path = cache_get_location(CACHE_TYPE_METADATA, fd->change->dest, TRUE, nullptr);
+	g_autofree gchar *dest_path = cache_get_location(CACHE_TYPE_METADATA, fd->change->dest);
 	if (!copy_file(src_path, dest_path))
 		{
 		DEBUG_1("failed to copy metadata %s to %s", src_path, dest_path);

--- a/src/cache.h
+++ b/src/cache.h
@@ -76,7 +76,8 @@ void cache_sim_data_set_md5sum(CacheData *cd, const guchar digest[16]);
 void cache_sim_data_set_similarity(CacheData *cd, ImageSimilarityData *sd);
 gint cache_sim_data_filled(ImageSimilarityData *sd);
 
-gchar *cache_get_location(CacheType type, const gchar *source, gint include_name, mode_t *mode);
+gchar *cache_create_location(CacheType cache_type, const gchar *source);
+gchar *cache_get_location(CacheType cache_type, const gchar *source);
 gchar *cache_find_location(CacheType type, const gchar *source);
 
 const gchar *get_thumbnails_cache_dir();

--- a/src/dupe.cc
+++ b/src/dupe.cc
@@ -22,7 +22,6 @@
 #include "dupe.h"
 
 #include <sys/time.h>
-#include <sys/types.h>
 
 #include <array>
 #include <cinttypes>
@@ -526,18 +525,15 @@ static void dupe_item_read_cache(DupeItem *di)
 
 static void dupe_item_write_cache(DupeItem *di)
 {
-	gchar *base;
-	mode_t mode = 0755;
-
 	if (!di) return;
 
-	base = cache_get_location(CACHE_TYPE_SIM, di->fd->path, FALSE, &mode);
-	if (recursive_mkdir_if_not_exists(base, mode))
+	g_autofree gchar *base = cache_create_location(CACHE_TYPE_SIM, di->fd->path);
+	if (base)
 		{
 		CacheData *cd;
 
 		cd = cache_sim_data_new();
-		cd->path = cache_get_location(CACHE_TYPE_SIM, di->fd->path, TRUE, nullptr);
+		cd->path = cache_get_location(CACHE_TYPE_SIM, di->fd->path);
 
 		if (di->width != 0) cache_sim_data_set_dimensions(cd, di->width, di->height);
 		if (di->md5sum)
@@ -553,7 +549,6 @@ static void dupe_item_write_cache(DupeItem *di)
 			}
 		cache_sim_data_free(cd);
 		}
-	g_free(base);
 }
 
 /*

--- a/src/filedata/filedata.cc
+++ b/src/filedata/filedata.cc
@@ -2185,10 +2185,8 @@ gint FileData::file_data_verify_ci(FileData *fd, GList *list)
 
 			if (!metadata_path)
 				{
-				mode_t mode = 0755;
-
-				dest_dir = cache_get_location(CACHE_TYPE_METADATA, fd->path, FALSE, &mode);
-				if (recursive_mkdir_if_not_exists(dest_dir, mode))
+				dest_dir = cache_create_location(CACHE_TYPE_METADATA, fd->path);
+				if (dest_dir)
 					{
 					gchar *filename = g_strconcat(fd->name, options->metadata.save_legacy_format ? GQ_CACHE_EXT_METADATA : GQ_CACHE_EXT_XMP_METADATA, NULL);
 

--- a/src/image-load-libraw.cc
+++ b/src/image-load-libraw.cc
@@ -38,6 +38,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <cstddef>
+
 #include <libraw/libraw.h>
 
 #include "debug.h"

--- a/src/img-view.cc
+++ b/src/img-view.cc
@@ -21,6 +21,8 @@
 
 #include "img-view.h"
 
+#include <array>
+
 #include <gdk/gdk.h>
 #include <glib-object.h>
 #include <gtk/gtk.h>

--- a/src/layout-image.cc
+++ b/src/layout-image.cc
@@ -21,6 +21,7 @@
 
 #include "layout-image.h"
 
+#include <array>
 #include <cstring>
 
 #include <gdk-pixbuf/gdk-pixbuf.h>

--- a/src/main.cc
+++ b/src/main.cc
@@ -21,6 +21,7 @@
 
 #include "main.h"
 
+#include <sys/types.h>
 #include <unistd.h>
 
 #include <clocale>

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -22,6 +22,7 @@
 #include "pan-view.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstring>
 

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 
 #include <config.h>
 

--- a/src/remote.cc
+++ b/src/remote.cc
@@ -32,6 +32,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 
 #include <gtk/gtk.h>
 

--- a/src/search.cc
+++ b/src/search.cc
@@ -21,8 +21,6 @@
 
 #include "search.h"
 
-#include <sys/types.h>
-
 #include <array>
 #include <cmath>
 #include <cstdio>
@@ -1810,22 +1808,18 @@ static void search_file_load_process(SearchData *sd, CacheData *cd)
 		if (options->thumbnails.enable_caching &&
 		    sd->img_loader && image_loader_get_fd(sd->img_loader))
 			{
-			gchar *base;
-			const gchar *path;
-			mode_t mode = 0755;
+			const gchar *path = image_loader_get_fd(sd->img_loader)->path;
 
-			path = image_loader_get_fd(sd->img_loader)->path;
-			base = cache_get_location(CACHE_TYPE_SIM, path, FALSE, &mode);
-			if (recursive_mkdir_if_not_exists(base, mode))
+			g_autofree gchar *base = cache_create_location(CACHE_TYPE_SIM, path);
+			if (base)
 				{
 				g_free(cd->path);
-				cd->path = cache_get_location(CACHE_TYPE_SIM, path, TRUE, nullptr);
+				cd->path = cache_get_location(CACHE_TYPE_SIM, path);
 				if (cache_sim_data_save(cd))
 					{
 					filetime_set(cd->path, filetime(image_loader_get_fd(sd->img_loader)->path));
 					}
 				}
-			g_free(base);
 			}
 		}
 

--- a/src/thumb.cc
+++ b/src/thumb.cc
@@ -21,7 +21,6 @@
 
 #include "thumb.h"
 
-#include <sys/types.h>
 #include <utime.h>
 
 #include <cstdio>
@@ -58,16 +57,13 @@ static GdkPixbuf *get_xv_thumbnail(gchar *thumb_filename, gint max_w, gint max_h
  * or just mark failed thumbnail with 0 byte file (mark_failure = TRUE) */
 static gboolean thumb_loader_save_thumbnail(ThumbLoader *tl, gboolean mark_failure)
 {
-	gchar *cache_dir;
 	gboolean success = FALSE;
-	mode_t mode = 0755;
 
 	if (!tl || !tl->fd) return FALSE;
 	if (!mark_failure && !tl->fd->thumb_pixbuf) return FALSE;
 
-	cache_dir = cache_get_location(CACHE_TYPE_THUMB, tl->fd->path, FALSE, &mode);
-
-	if (recursive_mkdir_if_not_exists(cache_dir, mode))
+	g_autofree gchar *cache_dir = cache_create_location(CACHE_TYPE_THUMB, tl->fd->path);
+	if (cache_dir)
 		{
 		gchar *cache_path;
 		gchar *pathl;
@@ -114,8 +110,6 @@ static gboolean thumb_loader_save_thumbnail(ThumbLoader *tl, gboolean mark_failu
 		g_free(pathl);
 		g_free(cache_path);
 		}
-
-	g_free(cache_dir);
 
 	return success;
 }

--- a/src/toolbar.cc
+++ b/src/toolbar.cc
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <vector>
 
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <glib-object.h>

--- a/src/view-file/view-file.cc
+++ b/src/view-file/view-file.cc
@@ -20,6 +20,8 @@
 
 #include "view-file.h"
 
+#include <array>
+
 #include <gdk/gdk.h>
 #include <glib-object.h>
 


### PR DESCRIPTION
`cache_get_location()` is called for two reasons:
1) get cache directory and immediately create it.
2) get cache filename.

Add `cache_create_location()` for (1).
Add `cache_get_location()` wrapper for (2). This allows to remove `mode_t` from parameters.
Move old `cache_get_location()` implementation to anonymous namespace.
Fix IWYU warnings after removing dependency on `mode_t`.