### PR TITLE
Avoid logging nullptr path in cache_maint_moved()

### DIFF
--- a/src/cache-maint.cc
+++ b/src/cache-maint.cc
@@ -475,6 +475,9 @@ static void cache_maint_moved(FileData *fd)
 		g_autofree gchar *src_path = cache_find_location(cache_type, src);
 		if (!src_path || !isfile(src_path)) return;
 
+		g_autofree gchar *dest_base = cache_create_location(cache_type, dest);
+		if (!dest_base) return;
+
 		g_autofree gchar *dest_path = cache_get_location(cache_type, dest);
 		if (!dest_path) return;
 
@@ -486,23 +489,9 @@ static void cache_maint_moved(FileData *fd)
 			}
 	};
 
-	g_autofree gchar *dest_base = cache_create_location(CACHE_TYPE_THUMB, dest);
-	if (dest_base)
-		{
-		cache_move(CACHE_TYPE_THUMB);
-		cache_move(CACHE_TYPE_SIM);
-		}
-	else
-		{
-		log_printf("Failed to create cache dir for move %s\n", dest_base);
-		}
-
-	g_free(dest_base);
-	dest_base = cache_create_location(CACHE_TYPE_METADATA, dest);
-	if (dest_base)
-		{
-		cache_move(CACHE_TYPE_METADATA);
-		}
+	cache_move(CACHE_TYPE_THUMB);
+	cache_move(CACHE_TYPE_SIM);
+	cache_move(CACHE_TYPE_METADATA);
 
 	if (options->thumbnails.enable_caching && options->thumbnails.spec_standard)
 		thumb_std_maint_moved(src, dest);

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -633,7 +633,11 @@ gchar *cache_create_location(CacheType cache_type, const gchar *source)
 	mode_t mode = 0755;
 	g_autofree gchar *path = cache_get_location(cache_type, source, FALSE, &mode);
 
-	if (!recursive_mkdir_if_not_exists(path, mode)) return nullptr;
+	if (!recursive_mkdir_if_not_exists(path, mode))
+		{
+		log_printf("Failed to create cache dir %s\n", path);
+		return nullptr;
+		}
 
 	return g_steal_pointer(&path);
 }


### PR DESCRIPTION
Move logging to `cache_create_location()`.
Simplify `cache_maint_moved()`.