### PR TITLE
Fix memory leaks after pixbuf_inline() calls

### DIFF
--- a/src/cache-maint.cc
+++ b/src/cache-maint.cc
@@ -153,7 +153,8 @@ void cache_maintenance(const gchar *path)
 {
 	cache_maintenance_path = g_strdup(path);
 
-	status_icon = gtk_status_icon_new_from_pixbuf(pixbuf_inline(PIXBUF_INLINE_ICON));
+	g_autoptr(GdkPixbuf) pixbuf_icon = pixbuf_inline(PIXBUF_INLINE_ICON);
+	status_icon = gtk_status_icon_new_from_pixbuf(pixbuf_icon);
 	gtk_status_icon_set_tooltip_text(status_icon, _("Geeqie: Cleaning thumbs..."));
 	gtk_status_icon_set_visible(status_icon, TRUE);
 	g_signal_connect(G_OBJECT(status_icon), "activate", G_CALLBACK(cache_maintenance_status_icon_activate_cb), NULL);

--- a/src/pixbuf-util.cc
+++ b/src/pixbuf-util.cc
@@ -255,7 +255,8 @@ void pixbuf_inline_register_stock_icons()
 {
 	for (const PixbufInline &pi : inline_pixbuf_data)
 		{
-		register_stock_icon(pi.key, pixbuf_inline(pi.key));
+		g_autoptr(GdkPixbuf) pixbuf = pixbuf_inline(pi.key);
+		register_stock_icon(pi.key, pixbuf);
 		}
 }
 

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -4194,8 +4194,6 @@ void show_about_window(LayoutWindow *lw)
 	GInputStream *in_stream_authors;
 	GInputStream *in_stream_translators;
 	GString *copyright;
-	GdkPixbuf *pixbuf_icon;
-	GdkPixbuf *pixbuf_logo;
 	ZoneDetect *cd;
 	gchar *artists[2];
 	gchar *author_line;
@@ -4259,24 +4257,24 @@ void show_about_window(LayoutWindow *lw)
 	artists[0] = g_strdup("Néstor Díaz Valencia <nestor@estudionexos.com>");
 	artists[1] = nullptr;
 
-	pixbuf_logo = pixbuf_inline(PIXBUF_INLINE_LOGO);
-	pixbuf_icon = pixbuf_inline(PIXBUF_INLINE_ICON);
+	g_autoptr(GdkPixbuf) pixbuf_icon = pixbuf_inline(PIXBUF_INLINE_ICON);
+
 	gtk_show_about_dialog(GTK_WINDOW(lw->window),
-		"title", _("About Geeqie"),
-		"resizable", TRUE,
-		"program-name", GQ_APPNAME,
-		"version", VERSION,
-		"logo", pixbuf_logo,
-		"icon", pixbuf_icon,
-		"website", GQ_WEBSITE,
-		"website-label", _("Website"),
-		"comments", comment,
-		"artists", artists,
-		"authors", authors,
-		"translator-credits", translators,
-		"wrap-license", TRUE,
-		"license", copyright->str,
-		NULL);
+	                      "title", _("About Geeqie"),
+	                      "resizable", TRUE,
+	                      "program-name", GQ_APPNAME,
+	                      "version", VERSION,
+	                      "logo-icon-name", PIXBUF_INLINE_LOGO,
+	                      "icon", pixbuf_icon,
+	                      "website", GQ_WEBSITE,
+	                      "website-label", _("Website"),
+	                      "comments", comment,
+	                      "artists", artists,
+	                      "authors", authors,
+	                      "translator-credits", translators,
+	                      "wrap-license", TRUE,
+	                      "license", copyright->str,
+	                      NULL);
 
 	g_string_free(copyright, TRUE);
 


### PR DESCRIPTION
Also replace GtkAboutDialog's logo property with logo-icon-name to avoid manual creation of pixbuf.