### PR TITLE
Pass cheap-to-copy arguments by copy

### DIFF
--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -249,7 +249,7 @@ gboolean histmap_start_idle(FileData *fd)
 }
 
 
-static void histogram_vgrid(Histogram *histogram, GdkPixbuf *pixbuf, const GdkRectangle &rect)
+static void histogram_vgrid(Histogram *histogram, GdkPixbuf *pixbuf, GdkRectangle rect)
 {
 	if (histogram->vgrid == 0) return;
 
@@ -267,7 +267,7 @@ static void histogram_vgrid(Histogram *histogram, GdkPixbuf *pixbuf, const GdkRe
 		}
 }
 
-static void histogram_hgrid(Histogram *histogram, GdkPixbuf *pixbuf, const GdkRectangle &rect)
+static void histogram_hgrid(Histogram *histogram, GdkPixbuf *pixbuf, GdkRectangle rect)
 {
 	if (histogram->hgrid == 0) return;
 

--- a/src/pan-view/pan-item.cc
+++ b/src/pan-view/pan-item.cc
@@ -131,7 +131,7 @@ void pan_item_size_coordinates(PanItem *pi, gint border, gint &w, gint &h)
  */
 
 PanItem *pan_item_box_new(PanWindow *pw, FileData *fd, gint x, gint y, gint width, gint height,
-                          gint border_size, const PanColor &base, const PanColor &bord)
+                          gint border_size, PanColor base, PanColor bord)
 {
 	PanItem *pi;
 
@@ -216,7 +216,7 @@ gboolean pan_item_box_draw(PanWindow *, PanItem *pi, GdkPixbuf *pixbuf, PixbufRe
 		}
 
 	const GdkRectangle request_rect{x, y, width, height};
-	const auto draw_rect_if_intersect = [pixbuf, &request_rect, x, y](const GdkRectangle &box_rect, const PanColor &color)
+	const auto draw_rect_if_intersect = [pixbuf, &request_rect, x, y](GdkRectangle box_rect, PanColor color)
 	{
 		GdkRectangle r;
 		if (!gdk_rectangle_intersect(&request_rect, &box_rect, &r)) return;
@@ -244,9 +244,9 @@ gboolean pan_item_box_draw(PanWindow *, PanItem *pi, GdkPixbuf *pixbuf, PixbufRe
  */
 
 PanItem *pan_item_tri_new(PanWindow *pw,
-                          const GdkPoint &c1, const GdkPoint &c2, const GdkPoint &c3,
-                          const PanColor &color,
-                          gint borders, const PanColor &border_color)
+                          GdkPoint c1, GdkPoint c2, GdkPoint c3,
+                          PanColor color,
+                          gint borders, PanColor border_color)
 {
 	GdkRectangle tri_rect = util_triangle_bounding_box(c1, c2, c3);
 
@@ -291,7 +291,7 @@ gboolean pan_item_tri_draw(PanWindow *, PanItem *pi, GdkPixbuf *pixbuf, PixbufRe
 		                     {coord[2].x - x, coord[2].y - y},
 		                     pi->color.r, pi->color.g, pi->color.b, pi->color.a);
 
-		const auto draw_line = [pixbuf, &r, x, y, &color = pi->color2](const GdkPoint &start, const GdkPoint &end)
+		const auto draw_line = [pixbuf, &r, x, y, &color = pi->color2](GdkPoint start, GdkPoint end)
 		{
 			pixbuf_draw_line(pixbuf, r,
 			                 start.x - x, start.y - y,
@@ -370,7 +370,7 @@ static void pan_item_text_compute_size(PanItem *pi, GtkWidget *widget)
 }
 
 PanItem *pan_item_text_new(PanWindow *pw, gint x, gint y, const gchar *text,
-                           PanTextAttrType attr, PanBorderType border, const PanColor &color)
+                           PanTextAttrType attr, PanBorderType border, PanColor color)
 {
 	PanItem *pi;
 
@@ -491,7 +491,7 @@ gboolean pan_item_thumb_draw(PanWindow *pw, PanItem *pi, GdkPixbuf *pixbuf, Pixb
 					     255);
 			}
 
-		const auto draw_rect_if_intersect = [pixbuf, &request_rect, x, y](const GdkRectangle &thumb_rect, const PanColor &color)
+		const auto draw_rect_if_intersect = [pixbuf, &request_rect, x, y](GdkRectangle thumb_rect, PanColor color)
 		{
 			GdkRectangle r;
 			if (!gdk_rectangle_intersect(&request_rect, &thumb_rect, &r)) return;

--- a/src/pan-view/pan-item.h
+++ b/src/pan-view/pan-item.h
@@ -54,22 +54,22 @@ PanItem *pan_item_find_by_coord(PanWindow *pw, PanItemType type,
 
 // Item box type
 PanItem *pan_item_box_new(PanWindow *pw, FileData *fd, gint x, gint y, gint width, gint height,
-                          gint border_size, const PanColor &base, const PanColor &bord);
+                          gint border_size, PanColor base, PanColor bord);
 void pan_item_box_shadow(PanItem *pi, gint offset, gint fade);
 gboolean pan_item_box_draw(PanWindow *pw, PanItem *pi, GdkPixbuf *pixbuf, PixbufRenderer *pr,
                            gint x, gint y, gint width, gint height);
 
 // Item triangle type
 PanItem *pan_item_tri_new(PanWindow *pw,
-                          const GdkPoint &c1, const GdkPoint &c2, const GdkPoint &c3,
-                          const PanColor &color,
-                          gint borders, const PanColor &border_color);
+                          GdkPoint c1, GdkPoint c2, GdkPoint c3,
+                          PanColor color,
+                          gint borders, PanColor border_color);
 gboolean pan_item_tri_draw(PanWindow *pw, PanItem *pi, GdkPixbuf *pixbuf, PixbufRenderer *pr,
                            gint x, gint y, gint width, gint height);
 
 // Item text type
 PanItem *pan_item_text_new(PanWindow *pw, gint x, gint y, const gchar *text,
-                           PanTextAttrType attr, PanBorderType border, const PanColor &color);
+                           PanTextAttrType attr, PanBorderType border, PanColor color);
 gboolean pan_item_text_draw(PanWindow *pw, PanItem *pi, GdkPixbuf *pixbuf, PixbufRenderer *pr,
                             gint x, gint y, gint width, gint height);
 

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -389,7 +389,7 @@ static gboolean pan_window_request_tile_cb(PixbufRenderer *pr, gint x, gint y,
 			     0, 0, width, height,
 			     PAN_BACKGROUND_COLOR);
 
-	const auto draw_rect_if_intersect = [pixbuf, &request_rect, x, y](const GdkRectangle &pan_grid_rect)
+	const auto draw_rect_if_intersect = [pixbuf, &request_rect, x, y](GdkRectangle pan_grid_rect)
 	{
 		GdkRectangle r;
 		if (!gdk_rectangle_intersect(&request_rect, &pan_grid_rect, &r)) return;
@@ -981,7 +981,7 @@ static void pan_layout_compute(PanWindow *pw, FileData *dir_fd,
 }
 
 static GList *pan_layout_intersect_l(GList *list, GList *item_list,
-                                     const GdkRectangle &rect)
+                                     GdkRectangle rect)
 {
 	for (GList *work = item_list; work; work = work->next)
 		{

--- a/src/pixbuf-renderer.cc
+++ b/src/pixbuf-renderer.cc
@@ -1366,7 +1366,7 @@ void pr_tile_coords_map_orientation(gint orientation,
 }
 
 GdkRectangle pr_tile_region_map_orientation(gint orientation,
-                                            const GdkRectangle &area, /* coordinates of the area inside tile */
+                                            GdkRectangle area, /* coordinates of the area inside tile */
                                             gint tile_w, gint tile_h)
 {
 	GdkRectangle res = area;
@@ -1424,7 +1424,7 @@ GdkRectangle pr_tile_region_map_orientation(gint orientation,
 }
 
 GdkRectangle pr_coords_map_orientation_reverse(gint orientation,
-                                               const GdkRectangle &area,
+                                               GdkRectangle area,
                                                gint tile_w, gint tile_h)
 {
 	GdkRectangle res = area;

--- a/src/pixbuf-renderer.h
+++ b/src/pixbuf-renderer.h
@@ -91,7 +91,7 @@ enum OverlayRendererFlags {
 struct RendererFuncs
 {
 	void (*area_changed)(void *renderer, gint src_x, gint src_y, gint src_w, gint src_h); /**< pixbuf area changed */
-	void (*invalidate_region)(void *renderer, const GdkRectangle &region);
+	void (*invalidate_region)(void *renderer, GdkRectangle region);
 	void (*scroll)(void *renderer, gint x_off, gint y_off); /**< scroll */
 	void (*update_viewport)(void *renderer); /**< window / wiewport / border color has changed */
 	void (*update_pixbuf)(void *renderer, gboolean lazy); /**< pixbuf has changed */
@@ -343,10 +343,10 @@ void pr_tile_coords_map_orientation(gint orientation,
                                     gdouble tile_w, gdouble tile_h,
                                     gdouble &res_x, gdouble &res_y);
 GdkRectangle pr_tile_region_map_orientation(gint orientation,
-                                            const GdkRectangle &area, /**< coordinates of the area inside tile */
+                                            GdkRectangle area, /**< coordinates of the area inside tile */
                                             gint tile_w, gint tile_h);
 GdkRectangle pr_coords_map_orientation_reverse(gint orientation,
-                                               const GdkRectangle &area,
+                                               GdkRectangle area,
                                                gint tile_w, gint tile_h);
 void pr_scale_region(GdkRectangle &region, gdouble scale);
 

--- a/src/pixbuf-util.cc
+++ b/src/pixbuf-util.cc
@@ -102,7 +102,7 @@ constexpr gint ROTATE_BUFFER_WIDTH = 48;
 constexpr gint ROTATE_BUFFER_HEIGHT = 48;
 
 // Intersects the clip region with the pixbuf. r is that intersecting region.
-gboolean pixbuf_clip_region(const GdkPixbuf *pb, const GdkRectangle &clip, GdkRectangle &r)
+gboolean pixbuf_clip_region(const GdkPixbuf *pb, GdkRectangle clip, GdkRectangle &r)
 {
 	gint pw = gdk_pixbuf_get_width(pb);
 	gint ph = gdk_pixbuf_get_height(pb);
@@ -118,7 +118,7 @@ gboolean pixbuf_clip_region(const GdkPixbuf *pb, const GdkRectangle &clip, GdkRe
  * applying alpha (a) from `get_alpha` function.
  */
 void pixbuf_draw_rect_fill(guchar *p_pix, gint prs, gboolean has_alpha,
-                           const GdkRectangle &rect,
+                           GdkRectangle rect,
                            guint8 r, guint8 g, guint8 b,
                            const GetAlpha &get_alpha)
 {
@@ -685,7 +685,7 @@ GdkPixbuf *pixbuf_apply_orientation(GdkPixbuf *pixbuf, gint orientation)
  *          color).  a=0 is tranparent (fully the original contents).
  */
 void pixbuf_draw_rect_fill(GdkPixbuf *pb,
-                           const GdkRectangle &rect,
+                           GdkRectangle rect,
                            gint r, gint g, gint b, gint a)
 {
 	gboolean has_alpha;
@@ -982,7 +982,7 @@ void pixbuf_draw_layout(GdkPixbuf *pixbuf, PangoLayout *layout,
  * @param[in] c3 Coordinates of the third corner of the triangle.
  * @return The computed bounding box.
  */
-GdkRectangle util_triangle_bounding_box(const GdkPoint &c1, const GdkPoint &c2, const GdkPoint &c3)
+GdkRectangle util_triangle_bounding_box(GdkPoint c1, GdkPoint c2, GdkPoint c3)
 {
 	GdkRectangle bounding_box;
 
@@ -1007,8 +1007,8 @@ GdkRectangle util_triangle_bounding_box(const GdkPoint &c1, const GdkPoint &c2, 
  * @param c3 Coordinates of the third corner of the triangle.
  * @param r,g,b,a Color and alpha.
  */
-void pixbuf_draw_triangle(GdkPixbuf *pb, const GdkRectangle &clip,
-                          const GdkPoint &c1, const GdkPoint &c2, const GdkPoint &c3,
+void pixbuf_draw_triangle(GdkPixbuf *pb, GdkRectangle clip,
+                          GdkPoint c1, GdkPoint c2, GdkPoint c3,
                           guint8 r, guint8 g, guint8 b, guint8 a)
 {
 	gboolean has_alpha;
@@ -1045,7 +1045,7 @@ void pixbuf_draw_triangle(GdkPixbuf *pb, const GdkRectangle &clip,
 	std::vector<GdkPoint> v{c1, c2, c3};
 	std::sort(v.begin(), v.end(), [](const GdkPoint &l, const GdkPoint &r){ return l.y < r.y; });
 
-	const auto get_slope = [](const GdkPoint &start, const GdkPoint &end)
+	const auto get_slope = [](GdkPoint start, GdkPoint end)
 	{
 		gdouble slope = end.y - start.y;
 		if (slope) slope = static_cast<gdouble>(end.x - start.x) / slope;
@@ -1229,7 +1229,7 @@ static gboolean util_clip_line(gdouble clip_x, gdouble clip_y, gdouble clip_w, g
  * @param x2,y2 Coordinates of the second point of the line segment.
  * @param r,g,b,a Color and alpha.
  */
-void pixbuf_draw_line(GdkPixbuf *pb, const GdkRectangle &clip,
+void pixbuf_draw_line(GdkPixbuf *pb, GdkRectangle clip,
                       gint x1, gint y1, gint x2, gint y2,
                       guint8 r, guint8 g, guint8 b, guint8 a)
 {
@@ -1342,7 +1342,7 @@ void pixbuf_draw_line(GdkPixbuf *pb, const GdkRectangle &clip,
  */
 static void pixbuf_draw_fade_linear(guchar *p_pix, gint prs, gboolean has_alpha,
                                     gint s, gboolean vertical, gint border,
-                                    const GdkRectangle &fade_rect,
+                                    GdkRectangle fade_rect,
                                     guint8 r, guint8 g, guint8 b, guint8 a)
 {
 	const auto get_a = [s, vertical, border, a](gint x, gint y)
@@ -1371,7 +1371,7 @@ static void pixbuf_draw_fade_linear(guchar *p_pix, gint prs, gboolean has_alpha,
  */
 static void pixbuf_draw_fade_radius(guchar *p_pix, gint prs, gboolean has_alpha,
                                     gint sx, gint sy, gint border,
-                                    const GdkRectangle &fade_rect,
+                                    GdkRectangle fade_rect,
                                     guint8 r, guint8 g, guint8 b, guint8 a)
 {
 	const auto get_a = [sx, sy, border, a](gint x, gint y)
@@ -1397,7 +1397,7 @@ static void pixbuf_draw_fade_radius(guchar *p_pix, gint prs, gboolean has_alpha,
  * @param a The max shadow composition fraction.  Note that any alpha value of the
  *          original pixel will remain untouched.
  */
-void pixbuf_draw_shadow(GdkPixbuf *pb, const GdkRectangle &clip,
+void pixbuf_draw_shadow(GdkPixbuf *pb, GdkRectangle clip,
                         gint x, gint y, gint w, gint h, gint border,
                         guint8 r, guint8 g, guint8 b, guint8 a)
 {
@@ -1427,7 +1427,7 @@ void pixbuf_draw_shadow(GdkPixbuf *pb, const GdkRectangle &clip,
 	if (border < 1) return;
 
 	// Draws linear gradients along each of the 4 edges.
-	const auto draw_fade_linear_if_intersect = [&pb_rect, p_pix, prs, has_alpha, border, r, g, b, a](const GdkRectangle &rect, gint s, gboolean vertical)
+	const auto draw_fade_linear_if_intersect = [&pb_rect, p_pix, prs, has_alpha, border, r, g, b, a](GdkRectangle rect, gint s, gboolean vertical)
 	{
 		GdkRectangle fade_rect;
 		if (!gdk_rectangle_intersect(&rect, &pb_rect, &fade_rect)) return;
@@ -1444,7 +1444,7 @@ void pixbuf_draw_shadow(GdkPixbuf *pb, const GdkRectangle &clip,
 	draw_fade_linear_if_intersect({x + border, y + h - border, w - border * 2, border}, y + h - border, FALSE);
 
 	// Draws radial gradients at each of the 4 corners.
-	const auto draw_fade_radius_if_intersect = [&pb_rect, p_pix, prs, has_alpha, border, r, g, b, a](const GdkRectangle &rect, gint sx, gint sy)
+	const auto draw_fade_radius_if_intersect = [&pb_rect, p_pix, prs, has_alpha, border, r, g, b, a](GdkRectangle rect, gint sx, gint sy)
 	{
 		GdkRectangle fade_rect;
 		if (!gdk_rectangle_intersect(&rect, &pb_rect, &fade_rect)) return;

--- a/src/pixbuf-util.h
+++ b/src/pixbuf-util.h
@@ -83,7 +83,7 @@ GdkPixbuf *pixbuf_copy_mirror(GdkPixbuf *src, gboolean mirror, gboolean flip);
 GdkPixbuf* pixbuf_apply_orientation(GdkPixbuf *pixbuf, gint orientation);
 
 void pixbuf_draw_rect_fill(GdkPixbuf *pb,
-                           const GdkRectangle &rect,
+                           GdkRectangle rect,
                            gint r, gint g, gint b, gint a);
 
 void pixbuf_set_rect_fill(GdkPixbuf *pb,
@@ -102,15 +102,15 @@ void pixbuf_draw_layout(GdkPixbuf *pixbuf, PangoLayout *layout,
                         gint x, gint y,
                         guint8 r, guint8 g, guint8 b, guint8 a);
 
-void pixbuf_draw_triangle(GdkPixbuf *pb, const GdkRectangle &clip,
-                          const GdkPoint &c1, const GdkPoint &c2, const GdkPoint &c3,
+void pixbuf_draw_triangle(GdkPixbuf *pb, GdkRectangle clip,
+                          GdkPoint c1, GdkPoint c2, GdkPoint c3,
                           guint8 r, guint8 g, guint8 b, guint8 a);
 
-void pixbuf_draw_line(GdkPixbuf *pb, const GdkRectangle &clip,
+void pixbuf_draw_line(GdkPixbuf *pb, GdkRectangle clip,
                       gint x1, gint y1, gint x2, gint y2,
                       guint8 r, guint8 g, guint8 b, guint8 a);
 
-void pixbuf_draw_shadow(GdkPixbuf *pb, const GdkRectangle &clip,
+void pixbuf_draw_shadow(GdkPixbuf *pb, GdkRectangle clip,
                         gint x, gint y, gint w, gint h, gint border,
                         guint8 r, guint8 g, guint8 b, guint8 a);
 
@@ -125,7 +125,7 @@ void pixbuf_ignore_alpha_rect(GdkPixbuf *pb,
 
 /* clipping utils */
 
-GdkRectangle util_triangle_bounding_box(const GdkPoint &c1, const GdkPoint &c2, const GdkPoint &c3);
+GdkRectangle util_triangle_bounding_box(GdkPoint c1, GdkPoint c2, GdkPoint c3);
 
 
 #endif

--- a/src/renderer-tiles.cc
+++ b/src/renderer-tiles.cc
@@ -165,7 +165,7 @@ inline gint get_left_pixbuf_offset(RendererTiles *rt)
 }
 
 
-void rt_overlay_draw(RendererTiles *rt, const GdkRectangle &request_rect, ImageTile *it);
+void rt_overlay_draw(RendererTiles *rt, GdkRectangle request_rect, ImageTile *it);
 
 gboolean rt_tile_is_visible(RendererTiles *rt, ImageTile *it);
 void rt_queue_merge(QueueData *parent, QueueData *qd);
@@ -194,7 +194,7 @@ void rt_sync_scroll(RendererTiles *rt)
  *-------------------------------------------------------------------
  */
 
-void rt_border_draw(RendererTiles *rt, const GdkRectangle &border_rect)
+void rt_border_draw(RendererTiles *rt, GdkRectangle border_rect)
 {
 	PixbufRenderer *pr = rt->pr;
 	GtkWidget *box;
@@ -208,7 +208,7 @@ void rt_border_draw(RendererTiles *rt, const GdkRectangle &border_rect)
 
 	cr = cairo_create(rt->surface);
 
-	auto draw_if_intersect = [&border_rect, rt, pr, cr](const GdkRectangle &rect)
+	auto draw_if_intersect = [&border_rect, rt, pr, cr](GdkRectangle rect)
 	{
 		GdkRectangle r;
 		if (!gdk_rectangle_intersect(&border_rect, &rect, &r)) return;
@@ -397,7 +397,7 @@ void rt_tile_invalidate_all(RendererTiles *rt)
 		}
 }
 
-void rt_tile_invalidate_region(RendererTiles *rt, const GdkRectangle &region)
+void rt_tile_invalidate_region(RendererTiles *rt, GdkRectangle region)
 {
 	gint x1 = ROUND_DOWN(region.x, rt->tile_width);
 	gint x2 = ROUND_UP(region.x + region.width, rt->tile_width);
@@ -542,7 +542,7 @@ void rt_overlay_init_window(RendererTiles *rt, OverlayData *od)
 	gdk_window_show(od->window);
 }
 
-void rt_overlay_draw(RendererTiles *rt, const GdkRectangle &request_rect, ImageTile *it)
+void rt_overlay_draw(RendererTiles *rt, GdkRectangle request_rect, ImageTile *it)
 {
 	for (GList *work = rt->overlay_list; work; work = work->next)
 		{
@@ -562,7 +562,7 @@ void rt_overlay_draw(RendererTiles *rt, const GdkRectangle &request_rect, ImageT
 				                                                       rt->tile_width, rt->tile_height);
 				}
 
-			const auto draw = [rt, od, &od_rect](const GdkRectangle &r, const std::function<void(cairo_t *)> &set_source)
+			const auto draw = [rt, od, &od_rect](GdkRectangle r, const std::function<void(cairo_t *)> &set_source)
 			{
 				cairo_t *cr = cairo_create(rt->overlay_buffer);
 				set_source(cr);
@@ -1216,7 +1216,7 @@ gboolean rt_source_tile_render(RendererTiles *rt, ImageTile *it,
  */
 void rt_tile_get_region(gboolean has_alpha, gboolean ignore_alpha,
                         const GdkPixbuf *src, GdkPixbuf *dest,
-                        const GdkRectangle &pb_rect,
+                        GdkRectangle pb_rect,
                         double offset_x, double offset_y, double scale_x, double scale_y,
                         GdkInterpType interp_type,
                         int check_x, int check_y, gboolean wide_image)
@@ -2029,7 +2029,7 @@ void renderer_update_zoom(void *renderer, gboolean lazy)
 	rt_border_clear(rt);
 }
 
-void renderer_invalidate_region(void *renderer, const GdkRectangle &region)
+void renderer_invalidate_region(void *renderer, GdkRectangle region)
 {
 	rt_tile_invalidate_region(static_cast<RendererTiles *>(renderer), region);
 }


### PR DESCRIPTION
`GdkPoint`, `GdkRectangle`, `PanColor` sizes are not exceed 16 bytes.
See https://pvs-studio.com/en/docs/warnings/v835/ for the rationale.