### PR TITLE
Check wkhtmltopdf dependency for help.pdf build

### DIFF
--- a/.github/workflows/appimage-aarch64.yml
+++ b/.github/workflows/appimage-aarch64.yml
@@ -50,7 +50,7 @@ jobs:
             yes | sudo apt-get install meson
             yes | sudo apt-get install pandoc
             yes | sudo apt-get install python3 python3-pip python3-setuptools python3-wheel ninja-build
-            yes | sudo apt-get install yelp-tools
+            yes | sudo apt-get install wkhtmltopdf yelp-tools
             mkdir -p $GITHUB_WORKSPACE/AppDir
             mkdir -p $GITHUB_WORKSPACE/AppDir/usr
             meson setup -Ddoxygen=disabled -Dyelp-build=disabled -Dprefix=$GITHUB_WORKSPACE/AppDir/usr build

--- a/.github/workflows/appimage-x86_64.yml
+++ b/.github/workflows/appimage-x86_64.yml
@@ -25,7 +25,7 @@ jobs:
     - run: sudo apt-get install libwebp-dev
     - run: sudo apt-get install libwebp7
     - run: sudo apt-get install pandoc
-    - run: sudo apt-get install yelp-tools
+    - run: sudo apt-get install wkhtmltopdf yelp-tools
 
     - uses: actions/checkout@v4
     - run: git fetch --tags --force

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -49,13 +49,16 @@ if running_from_git
     endif
 endif
 
-help_pdf_sh = find_program('help-html-to-pdf.sh', dirs : scriptsdir, required : false)
-if help_pdf_sh.found()
-    htmldir = join_paths(meson.project_build_root(), 'doc', 'html')
-    help_pdf = custom_target(
-        'help.pdf',
-        output: 'help.pdf',
-        command: [help_pdf_sh, htmldir, meson.project_build_root(), '@OUTPUT@'],
-        install: true,
-        install_dir: helpdir)
+wkhtmltopdf = find_program('wkhtmltopdf', required : false)
+if wkhtmltopdf.found()
+    help_pdf_sh = find_program('help-html-to-pdf.sh', dirs : scriptsdir, required : false)
+    if help_pdf_sh.found()
+        htmldir = join_paths(meson.project_build_root(), 'doc', 'html')
+        help_pdf = custom_target(
+            'help.pdf',
+            output: 'help.pdf',
+            command: [help_pdf_sh, htmldir, meson.project_build_root(), '@OUTPUT@'],
+            install: true,
+            install_dir: helpdir)
+    endif
 endif


### PR DESCRIPTION
Note: wkhtmltopdf is archived and no longer maintained.