### PR TITLE
Simplifies isolate-test while retaining DBUS support

### DIFF
--- a/scripts/isolate-test.sh
+++ b/scripts/isolate-test.sh
@@ -30,6 +30,8 @@
 ## $3 Path to file to test
 ##
 
+#~ FAKE NO-OP CHANGE
+
 set -e
 
 TEST_HOME=$(mktemp -d)


### PR DESCRIPTION
Also shows the environment that each isolated test will be run with, to facilitate debugging.

Note that this currently relaxes `G_DEBUG="fatal-warnings"` to `G_DEBUG="fatal-critical"` to allow tests to run without triggering SIGTRAP immediately.  TBD why this behavior changed with the GTK4 updates.

Sample run output:
```
 1/55 geeqie:functional / Basic test                                                         OK               0.43s
――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――
stdout:
Creating Geeqie dir:/tmp/tmp.KXuWSqblYM/.config/geeqie

Creating Geeqie dir:/tmp/tmp.KXuWSqblYM/.local/share/geeqie/collections

Creating Geeqie dir:/tmp/tmp.KXuWSqblYM/.cache/geeqie/thumbnails

Creating Geeqie dir:/tmp/tmp.KXuWSqblYM/.local/share/geeqie/metadata

Creating Geeqie dir:/tmp/tmp.KXuWSqblYM/.config/geeqie/layouts

Geeqie 2.5 GTK3
stderr:
Variables in isolated environment:
G_DEBUG=fatal-critical
HOME=/tmp/tmp.KXuWSqblYM
XDG_CONFIG_HOME=/tmp/tmp.KXuWSqblYM/.config
XDG_RUNTIME_DIR=/tmp/tmp.KXuWSqblYM/.runtime
DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/dbus-fDzY1Y2eq3,guid=943eba8e6f3d1b6e01e8bfba671dabbb

MESA: error: ZINK: vkCreateInstance failed (VK_ERROR_INCOMPATIBLE_DRIVER)
glx: failed to create drisw screen
failed to load driver: zink

(geeqie:831550): dbind-WARNING **: 02:55:56.126: AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
```