### PR TITLE
Performs a secondary cleanup attempt in `isolate-test.sh` in case the first one fails

### DIFF
--- a/scripts/isolate-test.sh
+++ b/scripts/isolate-test.sh
@@ -48,7 +48,15 @@ fi
 # Automatically clean up the temporary home directory on exit.
 teardown() {
     # echo "Cleaning up temporary homedir $TEST_HOME" >&2
-    rm -rf "$TEST_HOME"
+    if ! rm -rf "$TEST_HOME"; then
+        # Could be a race condition; try sleeping and repeating.
+        echo >&2
+        echo "First cleanup attempt failed; sleeping and retrying..." >&2
+        sleep 2
+
+        # Repeat with verbose listing
+        rm -rfv "$TEST_HOME"
+    fi
 }
 trap teardown EXIT
 


### PR DESCRIPTION
This works around a race condiditon that occurs reliably when the `xdg-desktop-portal` package is installed.

When this triggers, the output looks like:
```
$.../scripts/isolate-test.sh .../scripts/image-test.py .../build/src/geeqie .../build/test-images.p/images/JPG_MINOLTA_RD175.JPG
Variables in isolated environment:
G_DEBUG=fatal-critical
HOME=/tmp/tmp.uCSyUTWVkw
XDG_CONFIG_HOME=/tmp/tmp.uCSyUTWVkw/.config
XDG_RUNTIME_DIR=/tmp/tmp.uCSyUTWVkw/.runtime
DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/dbus-Nou8YYvYti,guid=9de5a10c77563265a7e1c9b167214161

[...]
Warning: Failed to convert Exif.Photo.DateTimeOriginal to Xmp.photoshop.DateCreated, unable to parse '19ff:1f:3f 3f:7f:00'
Warning: Failed to convert Exif.Photo.DateTimeDigitized to Xmp.xmp.CreateDate, unable to parse '19ff:1f:3f 3f:7f:00'
rm: cannot remove '/tmp/tmp.uCSyUTWVkw/.runtime/doc': Is a directory

First cleanup attempt failed; sleeping and retrying...
removed directory '/tmp/tmp.uCSyUTWVkw/.runtime/doc'
removed directory '/tmp/tmp.uCSyUTWVkw/.runtime'
removed directory '/tmp/tmp.uCSyUTWVkw'
```

Fixes #1532 