### PR TITLE
Inline trivial free-and-copy functions from image-overlay

### DIFF
--- a/src/image-overlay.cc
+++ b/src/image-overlay.cc
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <string>
 
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <glib-object.h>
@@ -107,28 +108,6 @@ constexpr gint IMAGE_OSD_DEFAULT_DURATION = 30;
 } // namespace
 
 static void image_osd_timer_schedule(OverlayStateData *osd);
-
-void set_image_overlay_template_string(gchar **template_string, const gchar *value)
-{
-	g_assert(template_string);
-
-	g_free(*template_string);
-	*template_string = g_strdup(value);
-}
-
-
-void set_default_image_overlay_template_string(gchar **template_string)
-{
-	set_image_overlay_template_string(template_string, DEFAULT_OVERLAY_INFO);
-}
-
-void set_image_overlay_font_string(gchar **font_string, const gchar *value)
-{
-	g_assert(font_string);
-
-	g_free(*font_string);
-	*font_string = g_strdup(value);
-}
 
 static OverlayStateData *image_get_osd_data(ImageWindow *imd)
 {

--- a/src/image-overlay.h
+++ b/src/image-overlay.h
@@ -45,10 +45,6 @@ enum OsdShowFlags {
 	OSD_SHOW_HISTOGRAM	= 1 << 2
 };
 
-void set_image_overlay_template_string(gchar **template_string, const gchar *value);
-void set_default_image_overlay_template_string(gchar **template_string);
-void set_image_overlay_font_string(gchar **font_string, const gchar *value);
-
 void image_osd_set(ImageWindow *imd, OsdShowFlags show);
 OsdShowFlags image_osd_get(ImageWindow *imd);
 

--- a/src/options.cc
+++ b/src/options.cc
@@ -274,7 +274,7 @@ void setup_default_options(ConfOptions *options)
 		options->color_profile.input_name[i] = nullptr;
 		}
 
-	set_default_image_overlay_template_string(&options->image_overlay.template_string);
+	set_default_image_overlay_template_string(options);
 	options->sidecar.ext = g_strdup(".jpg;%raw;.gqv;.xmp;%unknown");
 
 	options->shell.path = g_strdup(GQ_DEFAULT_SHELL_PATH);
@@ -392,5 +392,11 @@ gboolean load_options(ConfOptions *)
 	success = load_config_from_file(rc_path, TRUE);
 	DEBUG_1("Loading options from %s ... %s", rc_path, success ? "done" : "failed");
 	return success;
+}
+
+void set_default_image_overlay_template_string(ConfOptions *options)
+{
+	g_free(options->image_overlay.template_string);
+	options->image_overlay.template_string = g_strdup(DEFAULT_OVERLAY_INFO);
 }
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/options.h
+++ b/src/options.h
@@ -455,6 +455,7 @@ ConfOptions *init_options(ConfOptions *options);
 void setup_default_options(ConfOptions *options);
 void save_options(ConfOptions *options);
 gboolean load_options(ConfOptions *options);
+void set_default_image_overlay_template_string(ConfOptions *options);
 
 
 enum StartUpPath {

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -58,7 +58,6 @@
 #include "filedata.h"
 #include "filefilter.h"
 #include "fullscreen.h"
-#include "image-overlay.h"
 #include "image.h"
 #include "img-view.h"
 #include "intl.h"
@@ -416,11 +415,15 @@ static void config_window_apply()
 	options->fullscreen.disable_saver = c_options->fullscreen.disable_saver;
 	options->fullscreen.above = c_options->fullscreen.above;
 	if (c_options->image_overlay.template_string)
-		set_image_overlay_template_string(&options->image_overlay.template_string,
-						  c_options->image_overlay.template_string);
+		{
+		g_free(options->image_overlay.template_string);
+		options->image_overlay.template_string = g_strdup(c_options->image_overlay.template_string);
+		}
 	if (c_options->image_overlay.font)
-		set_image_overlay_font_string(&options->image_overlay.font,
-						  c_options->image_overlay.font);
+		{
+		g_free(options->image_overlay.font);
+		options->image_overlay.font = g_strdup(c_options->image_overlay.font);
+		}
 	options->image_overlay.text_red = c_options->image_overlay.text_red;
 	options->image_overlay.text_green = c_options->image_overlay.text_green;
 	options->image_overlay.text_blue = c_options->image_overlay.text_blue;
@@ -1432,8 +1435,8 @@ static void image_overlay_template_view_changed_cb(GtkWidget *, gpointer data)
 	gtk_text_buffer_get_start_iter(pTextBuffer, &iStart);
 	gtk_text_buffer_get_end_iter(pTextBuffer, &iEnd);
 
-	set_image_overlay_template_string(&c_options->image_overlay.template_string,
-					  gtk_text_buffer_get_text(pTextBuffer, &iStart, &iEnd, TRUE));
+	g_free(c_options->image_overlay.template_string);
+	c_options->image_overlay.template_string = g_strdup(gtk_text_buffer_get_text(pTextBuffer, &iStart, &iEnd, TRUE));
 }
 
 static void image_overlay_default_template_ok_cb(GenericDialog *, gpointer data)
@@ -1441,7 +1444,7 @@ static void image_overlay_default_template_ok_cb(GenericDialog *, gpointer data)
 	auto text_view = static_cast<GtkTextView *>(data);
 	GtkTextBuffer *buffer;
 
-	set_default_image_overlay_template_string(&options->image_overlay.template_string);
+	set_default_image_overlay_template_string(options);
 	if (!configwindow) return;
 
 	buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(text_view));


### PR DESCRIPTION
Move `set_default_image_overlay_template_string()` to options.