### PR TITLE
Avoid manual memory management in jpeg-parser

### DIFF
--- a/src/image-load-jpeg.cc
+++ b/src/image-load-jpeg.cc
@@ -260,26 +260,25 @@ gboolean ImageLoaderJpeg::write(const guchar *buf, gsize &chunk_size, gsize coun
 
 	stereo = FALSE;
 
-	MPOData *mpo = jpeg_get_mpo_data(buf, count);
-	if (mpo && mpo->num_images > 1)
+	MPOData mpo = jpeg_get_mpo_data(buf, count);
+	if (mpo.num_images > 1)
 		{
-		guint i;
 		gint idx1 = -1;
 		gint idx2 = -1;
 		guint num2 = 1;
 
-		for (i = 0; i < mpo->num_images; i++)
+		for (guint i = 0; i < mpo.num_images; ++i)
 			{
-			if (mpo->images[i].type_code == 0x20002)
+			if (mpo.images[i].type_code == 0x20002)
 				{
-				if (mpo->images[i].MPIndividualNum == 1)
+				if (mpo.images[i].MPIndividualNum == 1)
 					{
 					idx1 = i;
 					}
-				else if (mpo->images[i].MPIndividualNum > num2)
+				else if (mpo.images[i].MPIndividualNum > num2)
 					{
 					idx2 = i;
-					num2 = mpo->images[i].MPIndividualNum;
+					num2 = mpo.images[i].MPIndividualNum;
 					}
 				}
 			}
@@ -287,13 +286,12 @@ gboolean ImageLoaderJpeg::write(const guchar *buf, gsize &chunk_size, gsize coun
 		if (idx1 >= 0 && idx2 >= 0)
 			{
 			stereo = TRUE;
-			stereo_buf2 = const_cast<unsigned char *>(buf) + mpo->images[idx2].offset;
-			stereo_length = mpo->images[idx2].length;
-			buf = const_cast<unsigned char *>(buf) + mpo->images[idx1].offset;
-			count = mpo->images[idx1].length;
+			stereo_buf2 = const_cast<unsigned char *>(buf) + mpo.images[idx2].offset;
+			stereo_length = mpo.images[idx2].length;
+			buf = const_cast<unsigned char *>(buf) + mpo.images[idx1].offset;
+			count = mpo.images[idx1].length;
 			}
 		}
-	jpeg_mpo_data_free(mpo);
 
 	/* setup error handler */
 	cinfo.err = jpeg_std_error (&jerr.pub);

--- a/src/jpeg-parser.h
+++ b/src/jpeg-parser.h
@@ -22,6 +22,8 @@
 #ifndef JPEG_PARSER_H
 #define JPEG_PARSER_H
 
+#include <vector>
+
 #include <glib.h>
 
 #define JPEG_MARKER		0xFF
@@ -82,11 +84,10 @@ struct MPOData {
 
 	guint version;
 	guint num_images;
-	MPOEntry *images;
+	std::vector<MPOEntry> images;
 };
 
-MPOData* jpeg_get_mpo_data(const guchar *data, guint size);
-void jpeg_mpo_data_free(MPOData *mpo);
+MPOData jpeg_get_mpo_data(const guchar *data, guint size);
 
 #endif
 


### PR DESCRIPTION
Use vector for `MPOData::images`.
Change return type of `jpeg_get_mpo_data()`.