### PR TITLE
Drop unused layout_new()

### DIFF
--- a/src/layout.h
+++ b/src/layout.h
@@ -151,9 +151,6 @@ struct LayoutWindow
 	GtkWidget *log_window;
 };
 
-LayoutWindow *layout_new(FileData *dir_fd, LayoutOptions *lop);
-LayoutWindow *layout_new_with_geometry(FileData *dir_fd, LayoutOptions *lop,
-				       const gchar *geometry);
 LayoutWindow *layout_new_from_config(const gchar **attribute_names, const gchar **attribute_values, gboolean use_commandline);
 void layout_update_from_config(LayoutWindow *lw, const gchar **attribute_names, const gchar **attribute_values);
 LayoutWindow *layout_new_from_default();

--- a/src/main.cc
+++ b/src/main.cc
@@ -910,7 +910,7 @@ void activate_cb(GtkApplication *, gpointer)
 	 * The startup signal is issued before the command_line signal, therefore
 	 * the window layout processing is done before the command line processing.
 	 *
-	 * Function layout_new_with_geometry() does not execute a gtk_window_show()
+	 * Function layout_new() does not execute a gtk_window_show()
 	 * if this is the first window - i.e. Geeqie is not yet fully running.
 	 *
 	 * The activate signal is issued in command_line_cb() after the


### PR DESCRIPTION
Rename `layout_new_with_geometry()` to `layout_new()` and make static.
Simplify new `layout_new()` parameters.