### PR TITLE
Drop redundant HAVE_LCMS2 flag

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -86,9 +86,6 @@
 /* color profiles with lcms */
 #mesondefine HAVE_LCMS
 
-/* Define to enable use of lcms2 */
-#mesondefine HAVE_LCMS2
-
 /* Define to enable use of maps */
 #mesondefine HAVE_LIBCHAMPLAIN
 

--- a/doxygen.conf
+++ b/doxygen.conf
@@ -2433,7 +2433,6 @@ PREDEFINED             = DEBUG=1 \
                          HAVE_JPEG=1 \
                          HAVE_JPEGXL=1 \
                          HAVE_LCMS=1 \
-                         HAVE_LCMS2=1 \
                          HAVE_LIBCHAMPLAIN=1 \
                          HAVE_LIBCHAMPLAIN_GTK=1 \
                          HAVE_LUA=1 \

--- a/meson.build
+++ b/meson.build
@@ -225,7 +225,6 @@ else
 endif
 
 conf_data.set('HAVE_LCMS', 0)
-conf_data.set('HAVE_LCMS2', 0)
 lcms_dep = []
 req_version = '>=2.0'
 option = get_option('cms')
@@ -233,7 +232,6 @@ if not option.disabled()
     lcms_dep = dependency('lcms2', version : req_version, required : get_option('cms'))
     if lcms_dep.found()
         conf_data.set('HAVE_LCMS', 1)
-        conf_data.set('HAVE_LCMS2', 1)
         summary({'cms' : ['color management supported:', true]}, section : 'Configuration', bool_yn : true)
     else
         summary({'cms' : ['lcms2' + req_version + ' not found - color management supported:', false]}, section : 'Configuration', bool_yn : true)

--- a/scripts/geeqie.cppcheck
+++ b/scripts/geeqie.cppcheck
@@ -30,7 +30,6 @@
         <define name="HAVE_JPEG"/>
         <define name="HAVE_JPEGXL"/>
         <define name="HAVE_LCMS"/>
-        <define name="HAVE_LCMS2"/>
         <define name="HAVE_LIBCHAMPLAIN"/>
         <define name="HAVE_LIBCHAMPLAIN_GTK"/>
         <define name="HAVE_LUA"/>

--- a/src/color-man-heif.cc
+++ b/src/color-man-heif.cc
@@ -32,13 +32,7 @@
 #include <vector>
 
 #include <glib-object.h>
-
-#if HAVE_LCMS2
-#  include <lcms2.h>
-#else
-#  include <lcms.h>
-#endif
-
+#include <lcms2.h>
 #include <libheif/heif_cxx.h>
 
 namespace

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -39,11 +39,7 @@
 #endif
 
 #if HAVE_LCMS
-#if HAVE_LCMS2
-#include <lcms2.h>
-#else
-#include <lcms.h>
-#endif
+#  include <lcms2.h>
 #endif
 
 #include <pango/pango.h>
@@ -302,9 +298,6 @@ static gboolean accel_apply_cb(GtkTreeModel *model, GtkTreePath *, GtkTreeIter *
 static void config_window_apply()
 {
 	gboolean refresh = FALSE;
-#if HAVE_LCMS2
-	int i = 0;
-#endif
 
 	config_entry_to_option(safe_delete_path_entry, &options->file_ops.safe_delete_path, remove_trailing_slash);
 
@@ -525,7 +518,7 @@ static void config_window_apply()
 #endif
 
 #if HAVE_LCMS
-	for (i = 0; i < COLOR_PROFILE_INPUTS; i++)
+	for (int i = 0; i < COLOR_PROFILE_INPUTS; i++)
 		{
 		config_entry_to_option(color_profile_input_name_entry[i], &options->color_profile.input_name[i], nullptr);
 		config_entry_to_option(color_profile_input_file_entry[i], &options->color_profile.input_file[i], nullptr);


### PR DESCRIPTION
lcms required version is >=2.0.
Remove obsolete `color_man_lib_init()`.