### PR TITLE
Add G_GNUC_PRINTF to secure_fprintf()

### DIFF
--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -452,7 +452,7 @@ static gboolean metadata_file_write(gchar *path, const GList *keywords, const gc
 	secure_fputc(ssi, '\n');
 
 	secure_fprintf(ssi, "[comment]\n");
-	secure_fprintf(ssi, "%s\n", (comment) ? comment : "");
+	secure_fprintf(ssi, "%s\n", comment ? comment : "");
 
 	secure_fprintf(ssi, "#end\n");
 

--- a/src/secure-save.h
+++ b/src/secure-save.h
@@ -63,7 +63,7 @@ gint secure_close(SecureSaveInfo *);
 gint secure_fputs(SecureSaveInfo *, const gchar *);
 gint secure_fputc(SecureSaveInfo *, gint);
 
-gint secure_fprintf(SecureSaveInfo *, const gchar *, ...);
+gint secure_fprintf(SecureSaveInfo *, const gchar *, ...) G_GNUC_PRINTF(2, 3);
 size_t secure_fwrite(gconstpointer ptr, size_t size, size_t nmemb, SecureSaveInfo *ssi);
 
 gchar *secsave_strerror(SecureSaveErrno);


### PR DESCRIPTION
Simplify `secure_fprintf()` calls and fix memory leak.