### PR TITLE
Remove unused and read-only members of CommandLine struct

### DIFF
--- a/src/command-line-handling.cc
+++ b/src/command-line-handling.cc
@@ -861,14 +861,11 @@ void gq_last(GtkApplication *, GApplicationCommandLine *, GVariantDict *, GList 
 
 void gq_log_file(GtkApplication *, GApplicationCommandLine *, GVariantDict *command_line_options_dict, GList *)
 {
-	gchar *text;
+	const gchar *text;
 	g_variant_dict_lookup(command_line_options_dict, "log-file", "&s", &text);
 
-	gchar *pathl;
-	gchar *path = g_strdup(text);
-
-	pathl = path_from_utf8(path);
-	command_line->ssi = secure_open(pathl);
+	g_autofree gchar *pathl = path_from_utf8(text);
+	command_line->log_file_ssi = secure_open(pathl);
 }
 
 #if HAVE_LUA // @todo Use [[maybe_unused]] for command_line_options_dict since C++17 and merge declarations

--- a/src/compat-deprecated.h
+++ b/src/compat-deprecated.h
@@ -95,7 +95,6 @@ const auto gq_gtk_widget_get_requisition = gtk_widget_get_requisition;
 const auto gq_gtk_widget_get_style = gtk_widget_get_style;
 const auto gq_gtk_widget_set_double_buffered = gtk_widget_set_double_buffered;
 const auto gq_gtk_widget_size_request = gtk_widget_size_request;
-const auto gq_gtk_window_parse_geometry = gtk_window_parse_geometry;
 G_GNUC_END_IGNORE_DEPRECATIONS
 
 #endif /* COMPAT_DEPRECATED_H */

--- a/src/layout.cc
+++ b/src/layout.cc
@@ -37,7 +37,6 @@
 
 #include "bar-sort.h"
 #include "bar.h"
-#include "compat-deprecated.h"
 #include "compat.h"
 #include "filedata.h"
 #include "histogram.h"
@@ -2553,7 +2552,7 @@ static gboolean move_window_to_workspace_cb(gpointer data)
 	return G_SOURCE_REMOVE;
 }
 
-static LayoutWindow *layout_new(const LayoutOptions &lop, const gchar *geometry)
+static LayoutWindow *layout_new(const LayoutOptions &lop)
 {
 	LayoutWindow *lw;
 	GdkGeometry hint;
@@ -2647,14 +2646,6 @@ static LayoutWindow *layout_new(const LayoutOptions &lop, const gchar *geometry)
 	/** @FIXME the zoom value set here is the value, which is then copied again and again
 	   in 'Leave Zoom at previous setting' mode. This is not ideal.  */
 	image_change_pixbuf(lw->image, pixbuf, 0.0, FALSE);
-
-	if (geometry)
-		{
-		if (!gq_gtk_window_parse_geometry(GTK_WINDOW(lw->window), geometry))
-			{
-			log_printf("%s", _("Invalid geometry\n"));
-			}
-		}
 
 	layout_tools_hide(lw, lw->options.tools_hidden);
 
@@ -2920,20 +2911,7 @@ static void layout_config_startup_path(LayoutOptions *lop, gchar **path)
 
 static void layout_config_commandline(LayoutOptions *lop, gchar **path)
 {
-
-	if (command_line->startup_blank)
-		{
-		*path = nullptr;
-		}
-	else if (command_line->file)
-		{
-		*path = g_strdup(command_line->file);
-		}
-	else if (command_line->path)
-		{
-		*path = g_strdup(command_line->path);
-		}
-	else layout_config_startup_path(lop, path);
+	layout_config_startup_path(lop, path);
 
 	if (isdir(*path))
 		{
@@ -2942,16 +2920,6 @@ static void layout_config_commandline(LayoutOptions *lop, gchar **path)
 			{
 			std::swap(*path, last_image);
 			}
-		}
-
-	if (command_line->tools_show)
-		{
-		lop->tools_float = FALSE;
-		lop->tools_hidden = FALSE;
-		}
-	else if (command_line->tools_hide)
-		{
-		lop->tools_hidden = TRUE;
 		}
 }
 
@@ -2979,15 +2947,11 @@ LayoutWindow *layout_new_from_config(const gchar **attribute_names, const gchar 
 		layout_config_startup_path(&lop, &path);
 		}
 
-	LayoutWindow *lw = layout_new(lop, use_commandline ? command_line->geometry : nullptr);
+	LayoutWindow *lw = layout_new(lop);
 	layout_sort_set_files(lw, lw->options.file_view_list_sort.method, lw->options.file_view_list_sort.ascend, lw->options.file_view_list_sort.case_sensitive);
 
 
 	layout_set_path(lw, path);
-
-	if (use_commandline && command_line->startup_full_screen) layout_image_full_screen_start(lw);
-	if (use_commandline && command_line->startup_in_slideshow) layout_image_slideshow_start(lw);
-	if (use_commandline && command_line->log_window_show) log_window_new(lw);
 
 	free_layout_options_content(&lop);
 	return lw;

--- a/src/main.cc
+++ b/src/main.cc
@@ -593,7 +593,7 @@ void exit_program_final()
 		g_object_unref(archive_file);
 		}
 
-	secure_close(command_line->ssi);
+	secure_close(command_line->log_file_ssi);
 
 	exit(EXIT_SUCCESS);
 }

--- a/src/options.h
+++ b/src/options.h
@@ -424,24 +424,7 @@ struct ConfOptions
 
 struct CommandLine
 {
-	int argc;
-	gchar **argv;
-	gboolean startup_blank;
-	gboolean startup_full_screen;
-	gboolean startup_in_slideshow;
-	gboolean startup_command_line_collection;
-	gboolean tools_hide;
-	gboolean tools_show;
-	gboolean log_window_show;
-	gchar *path;
-	gchar *file;
-	GList *cmd_list;
-	GList *collection_list;
-	gchar *geometry;
-	gchar *regexp;
-	gchar *log_file;
-	SecureSaveInfo *ssi;
-	gboolean new_instance;
+	SecureSaveInfo *log_file_ssi;
 };
 
 extern ConfOptions *options;

--- a/src/ui-fileops.cc
+++ b/src/ui-fileops.cc
@@ -69,9 +69,9 @@ void print_term(gboolean err, const gchar *text_utf8)
 
 	fputs(text, err ? stderr : stdout);
 
-	if(command_line && command_line->ssi)
+	if(command_line && command_line->log_file_ssi)
 		{
-		secure_fputs(command_line->ssi, text);
+		secure_fputs(command_line->log_file_ssi, text);
 		}
 }
 


### PR DESCRIPTION
Rename `ssi` to `log_file_ssi`.
Simplify related code and fix memory leak.