### PR TITLE
Move print_term() to debug

### DIFF
--- a/src/debug.cc
+++ b/src/debug.cc
@@ -18,6 +18,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include "debug.h"
 
 #include <sys/time.h>
 
@@ -39,7 +40,7 @@
 #include "main.h"
 #include "misc.h"
 #include "options.h"
-#include "ui-fileops.h"
+#include "secure-save.h"
 
 /*
  * Logging functions
@@ -97,7 +98,7 @@ static void log_domain_print_message(const gchar *domain, const gchar *buf)
 		return;
 		}
 
-	print_term(FALSE, buf_nl);
+	print_term(false, buf_nl);
 
 	if (strcmp(domain, DOMAIN_INFO) == 0)
 		g_idle_add(log_normal_cb, buf_nl);
@@ -136,6 +137,19 @@ void log_domain_printf(const gchar *domain, const gchar *format, ...)
 	va_end(ap);
 
 	log_domain_print_message(domain, buf);
+}
+
+void print_term(bool err, const gchar *text_utf8)
+{
+	g_autofree gchar *text_l = g_locale_from_utf8(text_utf8, -1, nullptr, nullptr, nullptr);
+	const gchar *text = text_l ? text_l : text_utf8;
+
+	fputs(text, err ? stderr : stdout);
+
+	if(command_line && command_line->log_file_ssi)
+		{
+		secure_fputs(command_line->log_file_ssi, text);
+		}
 }
 
 /*

--- a/src/debug.h
+++ b/src/debug.h
@@ -28,26 +28,35 @@
 #define DOMAIN_DEBUG "debug"
 #define DOMAIN_INFO  "info"
 
-void log_domain_printf(const gchar *domain, const gchar *format, ...) G_GNUC_PRINTF(2, 3);
 void log_domain_print_debug(const gchar *domain, const gchar *file_name, int line_number, const gchar *function_name, const gchar *format, ...) G_GNUC_PRINTF(5, 6);
-void log_print_file_data_dump(const gchar *file, gint line_number, const gchar *function_name);
-void log_print_backtrace(const gchar *file, gint line_number, const gchar *function_name);
+void log_domain_printf(const gchar *domain, const gchar *format, ...) G_GNUC_PRINTF(2, 3);
+void print_term(bool err, const gchar *text_utf8);
 
 #define log_printf(...) log_domain_printf(DOMAIN_INFO, __VA_ARGS__)
+
+#define printf_term(err, ...) \
+	G_STMT_START \
+		{ \
+		g_autofree gchar *msg = g_strdup_printf(__VA_ARGS__); \
+		print_term(err, msg); \
+		} \
+	G_STMT_END
 
 #ifdef DEBUG
 
 #define DEBUG_LEVEL_MIN 0
 #define DEBUG_LEVEL_MAX 4
 
-void set_regexp(const gchar *regexp);
-gchar *get_regexp();
 gint get_debug_level();
 void set_debug_level(gint new_level);
 void debug_level_add(gint delta);
 gint required_debug_level(gint level);
 const gchar *get_exec_time();
 void init_exec_time();
+void set_regexp(const gchar *regexp);
+gchar *get_regexp();
+void log_print_backtrace(const gchar *file, gint line_number, const gchar *function_name);
+void log_print_file_data_dump(const gchar *file, gint line_number, const gchar *function_name);
 
 #define DEBUG_N(n, ...) \
 	G_STMT_START \
@@ -99,14 +108,14 @@ void init_exec_time();
 	G_STMT_END
 #else /* DEBUG */
 
-#define get_regexp() (0)
-#define set_regexp(regexp) G_STMT_START { } G_STMT_END
 #define get_debug_level() (0)
 #define set_debug_level(new_level) G_STMT_START { } G_STMT_END
 #define debug_level_add(delta) G_STMT_START { } G_STMT_END
 #define required_debug_level(level) (0)
 #define get_exec_time() ""
 #define init_exec_time() G_STMT_START { } G_STMT_END
+#define set_regexp(regexp) G_STMT_START { } G_STMT_END
+#define get_regexp() (0)
 
 #define DEBUG_N(n, ...) G_STMT_START { } G_STMT_END
 
@@ -121,7 +130,6 @@ void init_exec_time();
 #define DEBUG_2(...) DEBUG_N(2, __VA_ARGS__)
 #define DEBUG_3(...) DEBUG_N(3, __VA_ARGS__)
 #define DEBUG_4(...) DEBUG_N(4, __VA_ARGS__)
-
 
 #endif /* _DEBUG_H */
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/ui-fileops.cc
+++ b/src/ui-fileops.cc
@@ -42,8 +42,6 @@
 #include "layout.h"
 #include "main-defines.h"
 #include "md5-util.h"
-#include "options.h"
-#include "secure-save.h"
 #include "typedefs.h"
 #include "ui-utildlg.h"
 #include "utilops.h"
@@ -60,22 +58,7 @@ namespace
 using FileDescriptor = int;
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(FileDescriptor, close, -1) // NOLINT(readability-non-const-parameter)
 
-} // namespace
-
-void print_term(gboolean err, const gchar *text_utf8)
-{
-	g_autofree gchar *text_l = g_locale_from_utf8(text_utf8, -1, nullptr, nullptr, nullptr);
-	const gchar *text = text_l ? text_l : text_utf8;
-
-	fputs(text, err ? stderr : stdout);
-
-	if(command_line && command_line->log_file_ssi)
-		{
-		secure_fputs(command_line->log_file_ssi, text);
-		}
-}
-
-static void encoding_dialog(const gchar *path)
+void encoding_dialog(const gchar *path)
 {
 	static gboolean warned_user = FALSE;
 	GenericDialog *gd;
@@ -120,6 +103,8 @@ static void encoding_dialog(const gchar *path)
 
 	gtk_widget_show(gd->dialog);
 }
+
+} // namespace
 
 #if GQ_DEBUG_PATH_UTF8
 gchar *path_to_utf8_debug(const gchar *path, const gchar *file, gint line)

--- a/src/ui-fileops.h
+++ b/src/ui-fileops.h
@@ -35,16 +35,6 @@
 #define GQ_DEBUG_PATH_UTF8 1
 #endif
 
-void print_term(gboolean err, const gchar *text_utf8);
-
-#define printf_term(err, ...) \
-	G_STMT_START \
-		{ \
-		g_autofree gchar *msg = g_strdup_printf(__VA_ARGS__); \
-		print_term(err, msg); \
-		} \
-	G_STMT_END
-
 #if GQ_DEBUG_PATH_UTF8
 #define path_to_utf8(path) path_to_utf8_debug(path, __FILE__, __LINE__)
 #define path_from_utf8(utf8) path_from_utf8_debug(utf8, __FILE__, __LINE__)


### PR DESCRIPTION
Where all logging functions are.
Also move `log_print_*` declarations under `DEBUG`.