### PR TITLE
Simplify histogram

### DIFF
--- a/src/histogram.h
+++ b/src/histogram.h
@@ -39,35 +39,38 @@ struct HistMap;
 #define HCHAN_DEFAULT HCHAN_RGB
 
 struct Histogram {
+	struct Grid {
+		guint v; /**< number of vertical divisions, 0 for none */
+		guint h; /**< number of horizontal divisions, 0 for none */
+		struct {
+			guint8 R; /**< red */
+			guint8 G; /**< green */
+			guint8 B; /**< blue */
+			guint8 A; /**< alpha */
+		} color;  /**< grid color */
+	};
+
 	gint histogram_channel; /**< drawing mode for histogram */
 	gint histogram_mode;     /**< logarithmical or not */
-	guint vgrid; /**< number of vertical divisions, 0 for none */
-	guint hgrid; /**< number of horizontal divisions, 0 for none */
-	struct {
-		int R; /**< red */
-		int G; /**< green */
-		int B; /**< blue */
-		int A; /**< alpha */
-	} grid_color;  /**< grid color */
 };
 
 
 Histogram *histogram_new();
 void histogram_free(Histogram *histogram);
-gint histogram_set_channel(Histogram *histogram, gint chan);
-gint histogram_get_channel(Histogram *histogram);
-gint histogram_set_mode(Histogram *histogram, gint mode);
-gint histogram_get_mode(Histogram *histogram);
-gint histogram_toggle_channel(Histogram *histogram);
-gint histogram_toggle_mode(Histogram *histogram);
-const gchar *histogram_label(Histogram *histogram);
+void histogram_set_channel(Histogram *histogram, gint chan);
+gint histogram_get_channel(const Histogram *histogram);
+void histogram_set_mode(Histogram *histogram, gint mode);
+gint histogram_get_mode(const Histogram *histogram);
+void histogram_toggle_channel(Histogram *histogram);
+void histogram_toggle_mode(Histogram *histogram);
+const gchar *histogram_label(const Histogram *histogram);
 
 void histmap_free(HistMap *histmap);
 
 const HistMap *histmap_get(FileData *fd);
 gboolean histmap_start_idle(FileData *fd);
 
-gboolean histogram_draw(Histogram *histogram, const HistMap *histmap, GdkPixbuf *pixbuf, gint x, gint y, gint width, gint height);
+gboolean histogram_draw(const Histogram *histogram, const HistMap *histmap, GdkPixbuf *pixbuf, gint x, gint y, gint width, gint height);
 
 void histogram_notify_cb(FileData *fd, NotifyType type, gpointer data);
 


### PR DESCRIPTION
Move `Histogram` grid to struct, use constant instead of members.
Use `guint8` for grid color components.
Remove return types from `histogram_set` functions.
Make some parameters `const`.