### PR TITLE
Replace some unlink() calls

### DIFF
--- a/src/image-load-collection.cc
+++ b/src/image-load-collection.cc
@@ -20,8 +20,6 @@
 
 #include "image-load-collection.h"
 
-#include <unistd.h>
-
 #include <cstdio>
 
 #include <gdk-pixbuf/gdk-pixbuf.h>
@@ -104,7 +102,7 @@ gboolean ImageLoaderCOLLECTION::write(const guchar *, gsize &chunk_size, gsize c
 					area_updated_cb(nullptr, 0, 0, gdk_pixbuf_get_width(pixbuf), gdk_pixbuf_get_height(pixbuf), data);
 					}
 
-				unlink(randname);
+				std::remove(randname);
 
 				ret = TRUE;
 				}

--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -21,8 +21,6 @@
 
 #include "metadata.h"
 
-#include <unistd.h>
-
 #include <algorithm>
 #include <array>
 #include <clocale>
@@ -588,8 +586,7 @@ static void metadata_legacy_delete(FileData *fd, const gchar *except)
 	g_autofree gchar *metadata_path = cache_find_location(CACHE_TYPE_METADATA, fd->path);
 	if (metadata_path && (!except || strcmp(metadata_path, except) != 0))
 		{
-		g_autofree gchar *metadata_pathl = path_from_utf8(metadata_path);
-		unlink(metadata_pathl);
+		unlink_file(metadata_path);
 		}
 
 #if HAVE_EXIV2
@@ -598,8 +595,7 @@ static void metadata_legacy_delete(FileData *fd, const gchar *except)
 	g_autofree gchar *xmp_metadata_path = cache_find_location(CACHE_TYPE_XMP_METADATA, fd->path);
 	if (xmp_metadata_path && (!except || strcmp(xmp_metadata_path, except) != 0))
 		{
-		g_autofree gchar *xmp_metadata_pathl = path_from_utf8(xmp_metadata_path);
-		unlink(xmp_metadata_pathl);
+		unlink_file(xmp_metadata_path);
 		}
 #endif
 }

--- a/src/secure-save.cc
+++ b/src/secure-save.cc
@@ -105,7 +105,7 @@ secure_open_umask(const gchar *file_name)
 
 	ssi->secure_save = TRUE;
 	ssi->preserve_perms = TRUE;
-	ssi->unlink_on_error = TRUE;
+	ssi->remove_on_error = TRUE;
 
 	ssi->file_name = g_strdup(file_name);
 	if (!ssi->file_name) {
@@ -232,7 +232,7 @@ secure_close(SecureSaveInfo *ssi)
 	{
 		if (ssi->tmp_file_name)
 			{
-			if (ret && ssi->unlink_on_error) unlink(ssi->tmp_file_name);
+			if (ret && ssi->remove_on_error) std::remove(ssi->tmp_file_name);
 			g_free(ssi->tmp_file_name);
 			}
 		g_free(ssi->file_name);

--- a/src/secure-save.h
+++ b/src/secure-save.h
@@ -51,7 +51,7 @@ struct SecureSaveInfo {
 	gboolean secure_save; /**< use secure save for this file, internal use only */
 	gboolean preserve_perms; /**< whether to preserve perms, TRUE by default */
 	gboolean preserve_mtime; /**< whether to preserve mtime, FALSE by default */
-	gboolean unlink_on_error; /**< whether to remove temporary file on save failure, TRUE by default */
+	gboolean remove_on_error; /**< whether to remove temporary file on save failure, TRUE by default */
 };
 
 SecureSaveInfo *secure_open(const gchar *);


### PR DESCRIPTION
Use `std::remove()` or `unlink_file()`.
This allows to reduce dependency on `unistd.h`.