### PR TITLE
Drop unused indent parameter from write_*_option() functions

### DIFF
--- a/src/bar-comment.cc
+++ b/src/bar-comment.cc
@@ -206,8 +206,8 @@ static void bar_pane_comment_write_config(GtkWidget *pane, GString *outstr, gint
 		}
 
 	WRITE_NL(); WRITE_STRING("<pane_comment ");
-	write_char_option(outstr, indent, "id", pcd->pane.id);
-	write_char_option(outstr, indent, "title", gtk_label_get_text(GTK_LABEL(pcd->pane.title)));
+	write_char_option(outstr, "id", pcd->pane.id);
+	write_char_option(outstr, "title", gtk_label_get_text(GTK_LABEL(pcd->pane.title)));
 	WRITE_BOOL(pcd->pane, expanded);
 	WRITE_CHAR(*pcd, key);
 	WRITE_INT(*pcd, height);

--- a/src/bar-exif.cc
+++ b/src/bar-exif.cc
@@ -731,8 +731,8 @@ void bar_pane_exif_write_config(GtkWidget *pane, GString *outstr, gint indent)
 	if (!ped) return;
 
 	WRITE_NL(); WRITE_STRING("<pane_exif ");
-	write_char_option(outstr, indent, "id", ped->pane.id);
-	write_char_option(outstr, indent, "title", gtk_label_get_text(GTK_LABEL(ped->pane.title)));
+	write_char_option(outstr, "id", ped->pane.id);
+	write_char_option(outstr, "title", gtk_label_get_text(GTK_LABEL(ped->pane.title)));
 	WRITE_BOOL(ped->pane, expanded);
 	WRITE_BOOL(*ped, show_all);
 	WRITE_STRING(">");

--- a/src/bar-gps.cc
+++ b/src/bar-gps.cc
@@ -672,8 +672,8 @@ void bar_pane_gps_write_config(GtkWidget *pane, GString *outstr, gint indent)
 
 	WRITE_NL();
 	WRITE_STRING("<pane_gps ");
-	write_char_option(outstr, indent, "id", pgd->pane.id);
-	write_char_option(outstr, indent, "title", gtk_label_get_text(GTK_LABEL(pgd->pane.title)));
+	write_char_option(outstr, "id", pgd->pane.id);
+	write_char_option(outstr, "title", gtk_label_get_text(GTK_LABEL(pgd->pane.title)));
 	WRITE_BOOL(pgd->pane, expanded);
 
 	gint w;
@@ -683,12 +683,12 @@ void bar_pane_gps_write_config(GtkWidget *pane, GString *outstr, gint indent)
 
 	const gchar *map_id = bar_pane_gps_get_map_id(pgd);
 	WRITE_NL();
-	write_char_option(outstr, indent, "map-id", map_id);
+	write_char_option(outstr, "map-id", map_id);
 
 	gint zoom;
 	g_object_get(G_OBJECT(pgd->gps_view), "zoom-level", &zoom, NULL);
 	WRITE_NL();
-	write_int_option(outstr, indent, "zoom-level", zoom);
+	write_int_option(outstr, "zoom-level", zoom);
 
 	const auto write_lat_long_option = [pgd, outstr, indent](const gchar *option)
 	{
@@ -696,7 +696,7 @@ void bar_pane_gps_write_config(GtkWidget *pane, GString *outstr, gint indent)
 		g_object_get(G_OBJECT(pgd->gps_view), option, &position, NULL);
 		const gint int_position = position * 1000000;
 		WRITE_NL();
-		write_int_option(outstr, indent, option, int_position);
+		write_int_option(outstr, option, int_position);
 	};
 	write_lat_long_option("latitude");
 	write_lat_long_option("longitude");

--- a/src/bar-histogram.cc
+++ b/src/bar-histogram.cc
@@ -137,8 +137,8 @@ static void bar_pane_histogram_write_config(GtkWidget *pane, GString *outstr, gi
 	if (!phd) return;
 
 	WRITE_NL(); WRITE_STRING("<pane_histogram ");
-	write_char_option(outstr, indent, "id", phd->pane.id);
-	write_char_option(outstr, indent, "title", gtk_label_get_text(GTK_LABEL(phd->pane.title)));
+	write_char_option(outstr, "id", phd->pane.id);
+	write_char_option(outstr, "title", gtk_label_get_text(GTK_LABEL(phd->pane.title)));
 	WRITE_BOOL(phd->pane, expanded);
 	WRITE_INT(phd->histogram, histogram_channel);
 	WRITE_INT(phd->histogram, histogram_mode);

--- a/src/bar-keywords.cc
+++ b/src/bar-keywords.cc
@@ -301,8 +301,8 @@ void bar_pane_keywords_write_config(GtkWidget *pane, GString *outstr, gint inden
 	pkd->height = h;
 
 	WRITE_NL(); WRITE_STRING("<pane_keywords ");
-	write_char_option(outstr, indent, "id", pkd->pane.id);
-	write_char_option(outstr, indent, "title", gtk_label_get_text(GTK_LABEL(pkd->pane.title)));
+	write_char_option(outstr, "id", pkd->pane.id);
+	write_char_option(outstr, "title", gtk_label_get_text(GTK_LABEL(pkd->pane.title)));
 	WRITE_BOOL(pkd->pane, expanded);
 	WRITE_CHAR(*pkd, key);
 	WRITE_INT(*pkd, height);

--- a/src/bar-rating.cc
+++ b/src/bar-rating.cc
@@ -85,8 +85,8 @@ static void bar_pane_rating_write_config(GtkWidget *pane, GString *outstr, gint 
 
 	WRITE_NL();
 	WRITE_STRING("<pane_rating ");
-	write_char_option(outstr, indent, "id", prd->pane.id);
-	write_char_option(outstr, indent, "title", gtk_label_get_text(GTK_LABEL(prd->pane.title)));
+	write_char_option(outstr, "id", prd->pane.id);
+	write_char_option(outstr, "title", gtk_label_get_text(GTK_LABEL(prd->pane.title)));
 	WRITE_BOOL(prd->pane, expanded);
 	WRITE_STRING("/>");
 }

--- a/src/bar-sort.cc
+++ b/src/bar-sort.cc
@@ -850,7 +850,7 @@ void bar_sort_write_config(GtkWidget *bar, GString *outstr, gint indent)
 	if (!sd) return;
 
 	WRITE_NL(); WRITE_STRING("<bar_sort ");
-	write_bool_option(outstr, indent, "enabled", gtk_widget_get_visible(bar));
+	write_bool_option(outstr, "enabled", gtk_widget_get_visible(bar));
 	WRITE_INT(*sd, mode);
 	WRITE_INT(*sd, action);
 	WRITE_INT(*sd, selection);

--- a/src/bar.cc
+++ b/src/bar.cc
@@ -623,8 +623,8 @@ void bar_write_config(GtkWidget *bar, GString *outstr, gint indent)
 	if (!bd) return;
 
 	WRITE_NL(); WRITE_STRING("<bar ");
-	write_bool_option(outstr, indent, "enabled", gtk_widget_get_visible(bar));
-	write_uint_option(outstr, indent, "width", bd->width);
+	write_bool_option(outstr, "enabled", gtk_widget_get_visible(bar));
+	write_uint_option(outstr, "width", bd->width);
 	WRITE_STRING(">");
 
 	indent++;

--- a/src/layout-util.cc
+++ b/src/layout-util.cc
@@ -3608,7 +3608,7 @@ void layout_toolbar_write_config(LayoutWindow *lw, ToolbarType type, GString *ou
 		auto action = static_cast<gchar *>(work->data);
 		work = work->next;
 		WRITE_NL(); WRITE_STRING("<toolitem ");
-		write_char_option(outstr, indent + 1, "action", action);
+		write_char_option(outstr, "action", action);
 		WRITE_STRING("/>");
 		}
 	indent--;

--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -1672,12 +1672,12 @@ static void keyword_tree_node_write_config(GtkTreeModel *keyword_tree, GtkTreeIt
 
 		WRITE_NL(); WRITE_STRING("<keyword ");
 		g_autofree gchar *name = keyword_get_name(keyword_tree, &iter);
-		write_char_option(outstr, indent, "name", name);
-		write_bool_option(outstr, indent, "kw", keyword_get_is_keyword(keyword_tree, &iter));
+		write_char_option(outstr, "name", name);
+		write_bool_option(outstr, "kw", keyword_get_is_keyword(keyword_tree, &iter));
 		g_autofree gchar *mark_str = keyword_get_mark(keyword_tree, &iter);
 		if (mark_str && mark_str[0])
 			{
-			write_char_option(outstr, indent, "mark", mark_str);
+			write_char_option(outstr, "mark", mark_str);
 			}
 
 		if (gtk_tree_model_iter_children(keyword_tree, &children, &iter))

--- a/src/rcfile.cc
+++ b/src/rcfile.cc
@@ -142,7 +142,7 @@ void write_indent(GString *str, gint indent)
 	g_string_append_printf(str, "\n%*s", indent * 4, "");
 }
 
-void write_char_option(GString *str, gint, const gchar *label, const gchar *text)
+void write_char_option(GString *str, const gchar *label, const gchar *text)
 {
 	/* this is needed for overlay string, because g_markup_escape_text does not handle \n and such,
 	   ideas for improvement are welcome
@@ -187,16 +187,16 @@ gboolean read_char_option(const gchar *option, const gchar *label, const gchar *
 	return TRUE;
 }
 
-void write_color_option(GString *str, gint indent, const gchar *label, GdkRGBA *color)
+void write_color_option(GString *str, const gchar *label, const GdkRGBA *color)
 {
 	if (color)
 		{
 		g_autofree gchar *colorstring = gdk_rgba_to_string(color);
 
-		write_char_option(str, indent, label, colorstring);
+		write_char_option(str, label, colorstring);
 		}
 	else
-		write_char_option(str, indent, label, "");
+		write_char_option(str, label, "");
 }
 
 /**
@@ -237,7 +237,7 @@ gboolean read_color_option(const gchar *option, const gchar *label, const gchar 
 	return TRUE;
 }
 
-void write_int_option(GString *str, gint, const gchar *label, gint n)
+void write_int_option(GString *str, const gchar *label, gint n)
 {
 	g_string_append_printf(str, "%s = \"%d\" ", label, n);
 }
@@ -282,7 +282,7 @@ gboolean read_ushort_option(const gchar *option, const gchar *label, const gchar
 	return TRUE;
 }
 
-void write_uint_option(GString *str, gint, const gchar *label, guint n)
+void write_uint_option(GString *str, const gchar *label, guint n)
 {
 	g_string_append_printf(str, "%s = \"%u\" ", label, n);
 }
@@ -328,7 +328,7 @@ gboolean read_int_option_clamp(const gchar *option, const gchar *label, const gc
 	return ret;
 }
 
-void write_int_unit_option(GString *str, gint, const gchar *label, gint n, gint subunits)
+void write_int_unit_option(GString *str, const gchar *label, gint n, gint subunits)
 {
 	gint l;
 	gint r;
@@ -378,9 +378,9 @@ gboolean read_int_unit_option(const gchar *option, const gchar *label, const gch
 	return TRUE;
 }
 
-void write_bool_option(GString *str, gint, const gchar *label, gint n)
+void write_bool_option(GString *str, const gchar *label, gboolean value)
 {
-	g_string_append_printf(str, "%s = \"%s\" ", label, n ? "true" : "false");
+	g_string_append_printf(str, "%s = \"%s\" ", label, value ? "true" : "false");
 }
 
 gboolean read_bool_option(const gchar *option, const gchar *label, const gchar *value, gint *n)
@@ -671,8 +671,8 @@ static void write_color_profile(GString *outstr, gint indent)
 	for (i = 0; i < COLOR_PROFILE_INPUTS; i++)
 		{
 		WRITE_NL(); WRITE_STRING("<profile ");
-		write_char_option(outstr, indent, "input_file", options->color_profile.input_file[i]);
-		write_char_option(outstr, indent, "input_name", options->color_profile.input_name[i]);
+		write_char_option(outstr, "input_file", options->color_profile.input_file[i]);
+		write_char_option(outstr, "input_name", options->color_profile.input_name[i]);
 		WRITE_STRING("/>");
 		}
 	indent--;
@@ -688,7 +688,7 @@ static void write_marks_tooltips(GString *outstr, gint indent)
 	for (i = 0; i < FILEDATA_MARKS_SIZE; i++)
 		{
 		WRITE_NL();
-		write_char_option(outstr, indent, "<tooltip text", options->marks_tooltips[i]);
+		write_char_option(outstr, "<tooltip text", options->marks_tooltips[i]);
 		WRITE_STRING("/>");
 		}
 	indent--;
@@ -704,8 +704,8 @@ static void write_class_filter(GString *outstr, gint indent)
 	for (i = 0; i < FILE_FORMAT_CLASSES; i++)
 		{
 		WRITE_NL(); WRITE_STRING("<filter_type ");
-		write_char_option(outstr, indent, "filter", format_class_list[i]);
-		write_bool_option(outstr, indent, "enabled", options->class_filter[i]);
+		write_char_option(outstr, "filter", format_class_list[i]);
+		write_bool_option(outstr, "enabled", options->class_filter[i]);
 		WRITE_STRING("/>");
 		}
 	indent--;
@@ -733,7 +733,7 @@ static void write_disabled_plugins(GString *outstr, gint indent)
 				g_autofree gchar *desktop_path = nullptr;
 				gtk_tree_model_get(GTK_TREE_MODEL(desktop_file_list), &iter, DESKTOP_FILE_COLUMN_PATH, &desktop_path, -1);
 				WRITE_NL();
-				write_char_option(outstr, indent, "<plugin path", desktop_path);
+				write_char_option(outstr, "<plugin path", desktop_path);
 				WRITE_STRING("/>");
 				}
 			valid = gtk_tree_model_iter_next(GTK_TREE_MODEL(desktop_file_list), &iter);

--- a/src/rcfile.h
+++ b/src/rcfile.h
@@ -29,31 +29,31 @@ struct ConfOptions;
 struct LayoutWindow;
 
 void write_indent(GString *str, gint indent);
-void write_char_option(GString *str, gint indent, const gchar *label, const gchar *text);
+void write_char_option(GString *str, const gchar *label, const gchar *text);
 gboolean read_dummy_option(const gchar *option, const gchar *label, const gchar *message);
 gboolean read_char_option(const gchar *option, const gchar *label, const gchar *value, gchar **text);
-void write_color_option(GString *str, gint indent, const gchar *label, GdkRGBA *color);
+void write_color_option(GString *str, const gchar *label, const GdkRGBA *color);
 gboolean read_color_option(const gchar *option, const gchar *label, const gchar *value, GdkRGBA *color);
-void write_int_option(GString *str, gint indent, const gchar *label, gint n);
+void write_int_option(GString *str, const gchar *label, gint n);
 gboolean read_int_option(const gchar *option, const gchar *label, const gchar *value, gint *n);
 gboolean read_ushort_option(const gchar *option, const gchar *label, const gchar *value, guint16 *n);
-void write_uint_option(GString *str, gint indent, const gchar *label, guint n);
+void write_uint_option(GString *str, const gchar *label, guint n);
 gboolean read_uint_option(const gchar *option, const gchar *label, const gchar *value, guint *n);
 gboolean read_uint_option_clamp(const gchar *option, const gchar *label, const gchar *value, guint *n, guint min, guint max);
 gboolean read_int_option_clamp(const gchar *option, const gchar *label, const gchar *value, gint *n, gint min, gint max);
-void write_int_unit_option(GString *str, gint indent, const gchar *label, gint n, gint subunits);
+void write_int_unit_option(GString *str, const gchar *label, gint n, gint subunits);
 gboolean read_int_unit_option(const gchar *option, const gchar *label, const gchar *value, gint *n, gint subunits);
-void write_bool_option(GString *str, gint indent, const gchar *label, gint n);
+void write_bool_option(GString *str, const gchar *label, gboolean value);
 gboolean read_bool_option(const gchar *option, const gchar *label, const gchar *value, gint *n);
 
-#define WRITE_BOOL(_source_, _name_) write_bool_option(outstr, indent, #_name_, (_source_)._name_)
-#define WRITE_INT(_source_, _name_) write_int_option(outstr, indent, #_name_, (_source_)._name_)
-#define WRITE_UINT(_source_, _name_) write_uint_option(outstr, indent, #_name_, (_source_)._name_)
-#define WRITE_INT_UNIT(_source_, _name_, _unit_) write_int_unit_option(outstr, indent, #_name_, (_source_)._name_, _unit_)
-#define WRITE_CHAR(_source_, _name_) write_char_option(outstr, indent, #_name_, (_source_)._name_)
-#define WRITE_COLOR(_source_, _name_) write_color_option(outstr, indent, #_name_, &(_source_)._name_)
+#define WRITE_BOOL(_source_, _name_) write_bool_option(outstr, #_name_, (_source_)._name_)
+#define WRITE_INT(_source_, _name_) write_int_option(outstr, #_name_, (_source_)._name_)
+#define WRITE_UINT(_source_, _name_) write_uint_option(outstr, #_name_, (_source_)._name_)
+#define WRITE_INT_UNIT(_source_, _name_, _unit_) write_int_unit_option(outstr, #_name_, (_source_)._name_, _unit_)
+#define WRITE_CHAR(_source_, _name_) write_char_option(outstr, #_name_, (_source_)._name_)
+#define WRITE_COLOR(_source_, _name_) write_color_option(outstr, #_name_, &(_source_)._name_)
 
-#define WRITE_INT_FULL(_name_, _source_) write_int_option(outstr, indent, _name_, _source_)
+#define WRITE_INT_FULL(_name_, _source_) write_int_option(outstr, _name_, _source_)
 
 #define WRITE_NL() write_indent(outstr, indent)
 #define WRITE_SEPARATOR() g_string_append(outstr, "\n")

--- a/src/ui-utildlg.cc
+++ b/src/ui-utildlg.cc
@@ -345,12 +345,12 @@ void generic_dialog_windows_write_config(GString *outstr, gint indent)
 	for (const DialogWindow *dw : dialog_windows)
 		{
 		WRITE_NL(); WRITE_STRING("<window ");
-		write_char_option(outstr, indent + 1, "title", dw->title);
-		write_char_option(outstr, indent + 1, "role", dw->role);
+		write_char_option(outstr, "title", dw->title);
+		write_char_option(outstr, "role", dw->role);
 		WRITE_INT(dw->rect, x);
 		WRITE_INT(dw->rect, y);
-		write_int_option(outstr, indent, "w", dw->rect.width);
-		write_int_option(outstr, indent, "h", dw->rect.height);
+		write_int_option(outstr, "w", dw->rect.width);
+		write_int_option(outstr, "h", dw->rect.height);
 		WRITE_STRING("/>");
 		}
 


### PR DESCRIPTION
Change `write_bool_option()` parameter to `gboolean`.
Add `const` to `write_color_option()` parameter.