### PR TITLE
Enable clang-tidy misc-header-include-cycle check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -42,7 +42,6 @@ Checks: >
   -llvm-namespace-comment,
   -llvm-qualified-auto,
   -misc-const-correctness,
-  -misc-header-include-cycle,
   -misc-include-cleaner,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
@@ -62,6 +61,10 @@ Checks: >
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-qualified-auto,
+
+CheckOptions:
+  - key:   misc-header-include-cycle.IgnoredFilesList
+    value: gio.h;glib-object.h;gtk.h;poppler.h
 
 ExtraArgs: [-Wno-unknown-warning-option, -Wno-unused-lambda-capture, -Wno-unused-but-set-variable]
 WarningsAsErrors: "*"


### PR DESCRIPTION
Add third-party headers to ignore list.