### PR TITLE
Simplify code related to ViewFile stars

### DIFF
--- a/src/view-file.h
+++ b/src/view-file.h
@@ -156,7 +156,6 @@ void vf_file_filter_set(ViewFile *vf, gboolean enable);
 GRegex *vf_file_filter_get_filter(ViewFile *vf);
 
 void vf_star_update(ViewFile *vf);
-gboolean vf_stars_cb(gpointer data);
 void vf_star_stop(ViewFile *vf);
 void vf_star_cleanup(ViewFile *vf);
 

--- a/src/view-file/view-file-icon.cc
+++ b/src/view-file/view-file-icon.cc
@@ -1676,18 +1676,11 @@ FileData *vficon_star_next_fd(ViewFile *vf)
 			GList *list;
 			gtk_tree_model_get(store, &iter, FILE_COLUMN_POINTER, &list, -1);
 
-			for (; list; list = list->next)
+			for (GList *work = list; work; work = work->next)
 				{
-				auto fd = static_cast<FileData *>(list->data);
+				auto *fd = static_cast<FileData *>(work->data);
 				if (fd && fd->rating == STAR_RATING_NOT_READ)
 					{
-					vf->stars_filedata = fd;
-
-					if (vf->stars_id == 0)
-						{
-						vf->stars_id = g_idle_add_full(G_PRIORITY_LOW, vf_stars_cb, vf, nullptr);
-						}
-
 					return fd;
 					}
 				}
@@ -1698,20 +1691,12 @@ FileData *vficon_star_next_fd(ViewFile *vf)
 
 	/* Then iterate through the entire list to load all of them. */
 
-	GList *work;
-	for (work = vf->list; work; work = work->next)
+	for (GList *work = vf->list; work; work = work->next)
 		{
-		auto fd = static_cast<FileData *>(work->data);
+		auto *fd = static_cast<FileData *>(work->data);
 
 		if (fd && fd->rating == STAR_RATING_NOT_READ)
 			{
-			vf->stars_filedata = fd;
-
-			if (vf->stars_id == 0)
-				{
-				vf->stars_id = g_idle_add_full(G_PRIORITY_LOW, vf_stars_cb, vf, nullptr);
-				}
-
 			return fd;
 			}
 		}


### PR DESCRIPTION
Move common code to `vf_star_next()`.
Make `vf_stars_cb()` local static and flatten a bit.
Drop redundant `vf_star_do()`.