### PR TITLE
Cleanup GSourceFunc implementations

### DIFF
--- a/src/bar-histogram.cc
+++ b/src/bar-histogram.cc
@@ -91,7 +91,6 @@ static void bar_pane_histogram_update(PaneHistogramData *phd)
 
 static gboolean bar_pane_histogram_update_cb(gpointer data)
 {
-	const HistMap *histmap;
 	auto phd = static_cast<PaneHistogramData *>(data);
 
 	phd->idle_id = 0;
@@ -99,18 +98,21 @@ static gboolean bar_pane_histogram_update_cb(gpointer data)
 
 	gq_gtk_widget_queue_draw_area(GTK_WIDGET(phd->drawing_area), 0, 0, phd->histogram_width, phd->histogram_height);
 
-	if (phd->fd == nullptr) return G_SOURCE_REMOVE;
-	histmap = histmap_get(phd->fd);
-
-	if (!histmap)
+	if (phd->fd != nullptr)
 		{
-		histmap_start_idle(phd->fd);
-		return G_SOURCE_REMOVE;
-		}
+		const HistMap *histmap = histmap_get(phd->fd);
 
-	phd->pixbuf = gdk_pixbuf_new(GDK_COLORSPACE_RGB, FALSE, 8, phd->histogram_width, phd->histogram_height);
-	gdk_pixbuf_fill(phd->pixbuf, 0xffffffff);
-	phd->histogram.draw(histmap, phd->pixbuf, 0, 0, phd->histogram_width, phd->histogram_height);
+		if (histmap)
+			{
+			phd->pixbuf = gdk_pixbuf_new(GDK_COLORSPACE_RGB, FALSE, 8, phd->histogram_width, phd->histogram_height);
+			gdk_pixbuf_fill(phd->pixbuf, 0xffffffff);
+			phd->histogram.draw(histmap, phd->pixbuf, 0, 0, phd->histogram_width, phd->histogram_height);
+			}
+		else
+			{
+			histmap_start_idle(phd->fd);
+			}
+		}
 
 	return G_SOURCE_REMOVE;
 }

--- a/src/cache-maint.cc
+++ b/src/cache-maint.cc
@@ -916,7 +916,7 @@ static void cache_manager_standard_clean_stop_cb(GenericDialog *, gpointer data)
 	cache_manager_standard_clean_done(cd);
 }
 
-static gint cache_manager_standard_clean_clear_cb(gpointer data)
+static gboolean cache_manager_standard_clean_clear_cb(gpointer data)
 {
 	auto cd = static_cast<CacheOpsData *>(data);
 

--- a/src/collect-table.cc
+++ b/src/collect-table.cc
@@ -639,12 +639,14 @@ static gboolean tip_schedule_cb(gpointer data)
 {
 	auto ct = static_cast<CollectTable *>(data);
 
-	if (!ct->tip_delay_id) return FALSE;
+	if (ct->tip_delay_id)
+		{
+		tip_show(ct);
 
-	tip_show(ct);
+		ct->tip_delay_id = 0;
+		}
 
-	ct->tip_delay_id = 0;
-	return FALSE;
+	return G_SOURCE_REMOVE;
 }
 
 static void tip_schedule(CollectTable *ct)
@@ -1539,17 +1541,19 @@ static gboolean collection_table_auto_scroll_idle_cb(gpointer data)
 {
 	auto ct = static_cast<CollectTable *>(data);
 
-	if (!ct->drop_idle_id) return G_SOURCE_REMOVE;
-
-	GdkWindow *window = gtk_widget_get_window(ct->listview);
-
-	GdkPoint pos;
-	if (window_get_pointer_position(window, pos))
+	if (ct->drop_idle_id)
 		{
-		collection_table_motion_update(ct, pos.x, pos.y, TRUE);
+		GdkWindow *window = gtk_widget_get_window(ct->listview);
+
+		GdkPoint pos;
+		if (window_get_pointer_position(window, pos))
+			{
+			collection_table_motion_update(ct, pos.x, pos.y, TRUE);
+			}
+
+		ct->drop_idle_id = 0;
 		}
 
-	ct->drop_idle_id = 0;
 	return G_SOURCE_REMOVE;
 }
 
@@ -1893,11 +1897,14 @@ static gboolean collection_table_sync_idle_cb(gpointer data)
 {
 	auto ct = static_cast<CollectTable *>(data);
 
-	if (!ct->sync_idle_id) return G_SOURCE_REMOVE;
-	g_source_remove(ct->sync_idle_id);
-	ct->sync_idle_id = 0;
+	if (ct->sync_idle_id)
+		{
+		g_source_remove(ct->sync_idle_id);
+		ct->sync_idle_id = 0;
 
-	collection_table_sync(ct);
+		collection_table_sync(ct);
+		}
+
 	return G_SOURCE_REMOVE;
 }
 

--- a/src/command-line-handling.cc
+++ b/src/command-line-handling.cc
@@ -116,9 +116,7 @@ gchar *set_cwd(gchar *filename, GApplicationCommandLine *app_command_line)
 
 gboolean close_window_cb(gpointer)
 {
-	if (!layout_valid(&lw_id)) return FALSE;
-
-	layout_menu_close_cb(nullptr, lw_id);
+	if (layout_valid(&lw_id)) layout_menu_close_cb(nullptr, lw_id);
 
 	return G_SOURCE_REMOVE;
 }
@@ -310,7 +308,7 @@ void gq_cache_thumbs(GtkApplication *app, GApplicationCommandLine *, GVariantDic
 
 void gq_close_window(GtkApplication *, GApplicationCommandLine *, GVariantDict *, GList *)
 {
-	g_idle_add((close_window_cb), nullptr);
+	g_idle_add(close_window_cb, nullptr);
 }
 
 void gq_config_load(GtkApplication *, GApplicationCommandLine *app_command_line, GVariantDict *command_line_options_dict, GList *)

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -52,7 +52,7 @@ static gboolean log_msg_cb(gpointer data)
 	auto buf = static_cast<gchar *>(data);
 	log_window_append(buf, LOG_MSG);
 	g_free(buf);
-	return FALSE;
+	return G_SOURCE_REMOVE;
 }
 
 /**
@@ -84,7 +84,7 @@ static gboolean log_normal_cb(gpointer data)
 		}
 
 	g_free(buf);
-	return FALSE;
+	return G_SOURCE_REMOVE;
 }
 
 static void log_domain_print_message(const gchar *domain, const gchar *buf)

--- a/src/filedata/filedata.cc
+++ b/src/filedata/filedata.cc
@@ -2699,9 +2699,9 @@ static void realtime_monitor_check_cb(gpointer key, gpointer, gpointer)
 
 static gboolean realtime_monitor_cb(gpointer)
 {
-	if (!options->update_on_time_change) return TRUE;
-	g_hash_table_foreach(file_data_monitor_pool, realtime_monitor_check_cb, nullptr);
-	return TRUE;
+	if (options->update_on_time_change)
+		g_hash_table_foreach(file_data_monitor_pool, realtime_monitor_check_cb, nullptr);
+	return G_SOURCE_CONTINUE;
 }
 
 gboolean FileData::file_data_register_real_time_monitor(FileData *fd)

--- a/src/image-load.cc
+++ b/src/image-load.cc
@@ -1101,15 +1101,15 @@ void image_loader_delay_area_ready(ImageLoader *il, gboolean enable)
 
 static gboolean image_loader_idle_cb(gpointer data)
 {
-	gboolean ret = G_SOURCE_REMOVE;
 	auto il = static_cast<ImageLoader *>(data);
 
+	gboolean ret = G_SOURCE_REMOVE;
 	if (il->idle_id)
 		{
 		ret = image_loader_continue(il);
 		}
 
-	if (!ret)
+	if (ret == G_SOURCE_REMOVE)
 		{
 		image_loader_stop_source(il);
 		}

--- a/src/image-overlay.cc
+++ b/src/image-overlay.cc
@@ -739,10 +739,10 @@ static gboolean image_osd_timer_cb(gpointer data)
 	if (done)
 		{
 		osd->timer_id = 0;
-		return FALSE;
+		return G_SOURCE_REMOVE;
 		}
 
-	return TRUE;
+	return G_SOURCE_CONTINUE;
 }
 
 static void image_osd_timer_schedule(OverlayStateData *osd)

--- a/src/layout-image.cc
+++ b/src/layout-image.cc
@@ -328,7 +328,7 @@ static gboolean show_next_frame(gpointer data)
 	if(animation_should_continue(fd)==FALSE)
 		{
 		image_animation_data_free(fd);
-		return FALSE;
+		return G_SOURCE_REMOVE;
 		}
 
 	PixbufRenderer *pr = PIXBUF_RENDERER(fd->iw->pr);
@@ -351,16 +351,16 @@ static gboolean show_next_frame(gpointer data)
 		if (delay>0) /* Current frame not static. */
 			{
 			fd->delay=delay;
-			g_timeout_add(delay,show_next_frame,fd);
+			g_timeout_add(delay, show_next_frame, fd);
 			}
 		else
 			{
 			image_animation_data_free(fd);
 			}
-		return FALSE;
+		return G_SOURCE_REMOVE;
 		}
 
-	return TRUE;
+	return G_SOURCE_CONTINUE;
 }
 
 static gboolean layout_image_animate_check(LayoutWindow *lw)

--- a/src/layout-util.cc
+++ b/src/layout-util.cc
@@ -3238,36 +3238,33 @@ static gboolean layout_editors_reload_idle_cb(gpointer)
 	g_free(layout_editors_desktop_files->data);
 	layout_editors_desktop_files = g_list_delete_link(layout_editors_desktop_files, layout_editors_desktop_files);
 
+	if (layout_editors_desktop_files) return G_SOURCE_CONTINUE;
 
-	if (!layout_editors_desktop_files)
-		{
-		DEBUG_1("%s layout_editors_reload_idle_cb: setup_editors", get_exec_time());
-		editor_table_finish();
+	DEBUG_1("%s layout_editors_reload_idle_cb: setup_editors", get_exec_time());
+	editor_table_finish();
 
-		layout_window_foreach([](LayoutWindow *lw)
-		{
-			layout_actions_setup_editors(lw);
-			if (lw->bar_sort_enabled)
-				{
-				layout_bar_sort_toggle(lw);
-				}
-		});
+	layout_window_foreach([](LayoutWindow *lw)
+	{
+		layout_actions_setup_editors(lw);
+		if (lw->bar_sort_enabled)
+			{
+			layout_bar_sort_toggle(lw);
+			}
+	});
 
-		DEBUG_1("%s layout_editors_reload_idle_cb: setup_editors done", get_exec_time());
+	DEBUG_1("%s layout_editors_reload_idle_cb: setup_editors done", get_exec_time());
 
-		/* The toolbars need to be regenerated in case they contain a plugin */
-		LayoutWindow *lw = get_current_layout();
+	/* The toolbars need to be regenerated in case they contain a plugin */
+	LayoutWindow *lw = get_current_layout();
 
-		toolbar_select_new(lw, TOOLBAR_MAIN);
-		toolbar_apply(TOOLBAR_MAIN);
+	toolbar_select_new(lw, TOOLBAR_MAIN);
+	toolbar_apply(TOOLBAR_MAIN);
 
-		toolbar_select_new(lw, TOOLBAR_STATUS);
-		toolbar_apply(TOOLBAR_STATUS);
+	toolbar_select_new(lw, TOOLBAR_STATUS);
+	toolbar_apply(TOOLBAR_STATUS);
 
-		layout_editors_reload_idle_id = -1;
-		return G_SOURCE_REMOVE;
-		}
-	return G_SOURCE_CONTINUE;
+	layout_editors_reload_idle_id = -1;
+	return G_SOURCE_REMOVE;
 }
 
 void layout_editors_reload_start()

--- a/src/layout.cc
+++ b/src/layout.cc
@@ -2670,18 +2670,15 @@ static gboolean move_window_to_workspace_cb(gpointer data)
 {
 #ifdef GDK_WINDOWING_X11
 	auto lw = static_cast<LayoutWindow *>(data);
-	GdkWindow *window;
-	GdkDisplay *display;
 
 	if (options->save_window_workspace)
 		{
-		display = gdk_display_get_default();
-
+		GdkDisplay *display = gdk_display_get_default();
 		if (GDK_IS_X11_DISPLAY(display))
 			{
 			if (lw->options.workspace != -1)
 				{
-				window = gtk_widget_get_window(GTK_WIDGET(lw->window));
+				GdkWindow *window = gtk_widget_get_window(GTK_WIDGET(lw->window));
 				gdk_x11_window_move_to_desktop(window, lw->options.workspace);
 				}
 			}

--- a/src/pixbuf-renderer.cc
+++ b/src/pixbuf-renderer.cc
@@ -798,7 +798,7 @@ static gboolean pr_scroller_update_cb(gpointer data)
 
 	pixbuf_renderer_scroll(pr, xinc, yinc);
 
-	return TRUE;
+	return G_SOURCE_CONTINUE;
 }
 
 static void pr_scroller_timer_set(PixbufRenderer *pr, gboolean start)

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -1279,7 +1279,7 @@ static gboolean filter_add_scroll(gpointer data)
 	gtk_tree_path_free(path);
 	g_list_free(list_cells);
 
-	return(G_SOURCE_REMOVE);
+	return G_SOURCE_REMOVE;
 }
 
 static void filter_add_cb(GtkWidget *, gpointer data)
@@ -1287,7 +1287,7 @@ static void filter_add_cb(GtkWidget *, gpointer data)
 	filter_add_unique("description", ".new", FORMAT_CLASS_IMAGE, TRUE, FALSE, TRUE);
 	filter_store_populate();
 
-	g_idle_add(static_cast<GSourceFunc>(filter_add_scroll), data);
+	g_idle_add(filter_add_scroll, data);
 }
 
 static void filter_remove_cb(GtkWidget *, gpointer data)
@@ -2299,11 +2299,9 @@ static void save_default_window_layout_cb(GtkWidget *, gpointer)
 
 static gboolean popover_cb(gpointer data)
 {
-	auto popover = static_cast<GtkPopover *>(data);
+	gtk_popover_popdown(GTK_POPOVER(data));
 
-	gtk_popover_popdown(popover);
-
-	return FALSE;
+	return G_SOURCE_REMOVE;
 }
 
 static void default_layout_changed_cb(GtkWidget *, GtkPopover *popover)
@@ -3033,7 +3031,7 @@ static gboolean keywords_find_file(gpointer data)
 		file_data_unref(fd);
 		g_list_free_full(keywords, g_free);
 
-		return (G_SOURCE_CONTINUE);
+		return G_SOURCE_CONTINUE;
 		}
 
 	if (kfd->list_dir)

--- a/src/renderer-tiles.cc
+++ b/src/renderer-tiles.cc
@@ -1590,7 +1590,6 @@ gboolean rt_queue_draw_idle_cb(gpointer data)
 	QueueData *qd;
 	gboolean fast;
 
-
 	if ((!pr->pixbuf && !pr->source_tiles_enabled) ||
 	    (!rt->draw_queue && !rt->draw_queue_2pass) ||
 	    !rt->draw_idle_id)
@@ -1673,7 +1672,7 @@ gboolean rt_queue_draw_idle_cb(gpointer data)
 		return G_SOURCE_REMOVE;
 		}
 
-		return rt_queue_schedule_next_draw(rt, FALSE);
+	return rt_queue_schedule_next_draw(rt, FALSE);
 }
 
 void rt_queue_data_free(gpointer data)

--- a/src/search-and-run.cc
+++ b/src/search-and-run.cc
@@ -207,7 +207,7 @@ static gboolean match_selected_cb(GtkEntryCompletion *, GtkTreeModel *model, Gtk
 		gq_gtk_action_activate(sar->action);
 		}
 
-	g_idle_add(static_cast<GSourceFunc>(search_and_run_destroy), sar);
+	g_idle_add(search_and_run_destroy, sar);
 
 	return TRUE;
 }

--- a/src/slideshow.cc
+++ b/src/slideshow.cc
@@ -302,19 +302,19 @@ static gboolean slideshow_loop_cb(gpointer data)
 {
 	auto ss = static_cast<SlideShowData *>(data);
 
-	if (ss->paused) return TRUE;
+	if (ss->paused) return G_SOURCE_CONTINUE;
 
-	if (!slideshow_step(ss, TRUE))
+	if (slideshow_step(ss, TRUE))
 		{
-		ss->timeout_id = 0;
-		slideshow_free(ss);
-		return FALSE;
+		/* Check if the user has changed the timer interval */
+		slideshow_timer_reset(ss);
+
+		return G_SOURCE_CONTINUE;
 		}
 
-	/* Check if the user has changed the timer interval */
-	slideshow_timer_reset(ss);
-
-	return TRUE;
+	ss->timeout_id = 0;
+	slideshow_free(ss);
+	return G_SOURCE_REMOVE;
 }
 
 static void slideshow_timer_stop(SlideShowData *ss)

--- a/src/thumb-standard.cc
+++ b/src/thumb-standard.cc
@@ -1060,21 +1060,20 @@ static void thumb_std_maint_move_step(TMaintMove *tm)
 
 static gboolean thumb_std_maint_move_idle(gpointer)
 {
-	TMaintMove *tm;
+	if (thumb_std_maint_move_list)
+		{
+		auto *tm = static_cast<TMaintMove *>(thumb_std_maint_move_list->data);
 
-	if (!thumb_std_maint_move_list) return G_SOURCE_REMOVE;
+		thumb_std_maint_move_list = g_list_remove(thumb_std_maint_move_list, tm);
+		if (!thumb_std_maint_move_list) thumb_std_maint_move_tail = nullptr;
 
-	tm = static_cast<TMaintMove *>(thumb_std_maint_move_list->data);
+		g_autofree gchar *pathl = path_from_utf8(tm->source);
+		tm->source_uri = g_filename_to_uri(pathl, nullptr, nullptr);
 
-	thumb_std_maint_move_list = g_list_remove(thumb_std_maint_move_list, tm);
-	if (!thumb_std_maint_move_list) thumb_std_maint_move_tail = nullptr;
+		tm->pass = 0;
 
-	g_autofree gchar *pathl = path_from_utf8(tm->source);
-	tm->source_uri = g_filename_to_uri(pathl, nullptr, nullptr);
-
-	tm->pass = 0;
-
-	thumb_std_maint_move_step(tm);
+		thumb_std_maint_move_step(tm);
+		}
 
 	return G_SOURCE_REMOVE;
 }

--- a/src/ui-tree-edit.cc
+++ b/src/ui-tree-edit.cc
@@ -483,7 +483,7 @@ static gboolean widget_auto_scroll_cb(gpointer data)
 		{
 		sd->timer_id = 0;
 		widget_auto_scroll_stop(sd->widget);
-		return FALSE;
+		return G_SOURCE_REMOVE;
 		}
 
 	gint h = gdk_window_get_height(window);
@@ -516,7 +516,7 @@ static gboolean widget_auto_scroll_cb(gpointer data)
 				{
 				sd->timer_id = 0;
 				widget_auto_scroll_stop(sd->widget);
-				return FALSE;
+				return G_SOURCE_REMOVE;
 				}
 
 			gtk_adjustment_set_value(sd->adj,
@@ -524,7 +524,7 @@ static gboolean widget_auto_scroll_cb(gpointer data)
 			}
 		}
 
-	return TRUE;
+	return G_SOURCE_CONTINUE;
 }
 
 /**

--- a/src/view-dir-tree.cc
+++ b/src/view-dir-tree.cc
@@ -205,7 +205,7 @@ static gboolean vdtree_dnd_drop_expand_cb(gpointer data)
 		}
 
 	VDTREE(vd)->drop_expand_id = 0;
-	return FALSE;
+	return G_SOURCE_REMOVE;
 }
 
 static void vdtree_dnd_drop_expand_cancel(ViewDir *vd)

--- a/src/view-file/view-file-icon.cc
+++ b/src/view-file/view-file-icon.cc
@@ -356,21 +356,22 @@ static void tip_hide(ViewFile *vf)
 
 static gboolean tip_schedule_cb(gpointer data)
 {
-	auto vf = static_cast<ViewFile *>(data);
-	GtkWidget *window;
+	auto *vf = static_cast<ViewFile *>(data);
 
-	if (!VFICON(vf)->tip_delay_id) return FALSE;
-
-	window = gtk_widget_get_toplevel(vf->listview);
-
-	if (gtk_widget_get_sensitive(window) &&
-	    gtk_window_has_toplevel_focus(GTK_WINDOW(window)))
+	if (VFICON(vf)->tip_delay_id)
 		{
-		tip_show(vf);
+		GtkWidget *window = gtk_widget_get_toplevel(vf->listview);
+
+		if (gtk_widget_get_sensitive(window) &&
+		    gtk_window_has_toplevel_focus(GTK_WINDOW(window)))
+			{
+			tip_show(vf);
+			}
+
+		VFICON(vf)->tip_delay_id = 0;
 		}
 
-	VFICON(vf)->tip_delay_id = 0;
-	return FALSE;
+	return G_SOURCE_REMOVE;
 }
 
 static void tip_schedule(ViewFile *vf)

--- a/src/view-file/view-file-list.cc
+++ b/src/view-file/view-file-list.cc
@@ -633,18 +633,15 @@ static gboolean vflist_select_idle_cb(gpointer data)
 {
 	auto vf = static_cast<ViewFile *>(data);
 
-	if (!vf->layout)
+	if (vf->layout)
 		{
-		VFLIST(vf)->select_idle_id = 0;
-		return G_SOURCE_REMOVE;
-		}
+		vf_send_update(vf);
 
-	vf_send_update(vf);
-
-	if (VFLIST(vf)->select_fd)
-		{
-		vflist_select_image(vf, VFLIST(vf)->select_fd);
-		VFLIST(vf)->select_fd = nullptr;
+		if (VFLIST(vf)->select_fd)
+			{
+			vflist_select_image(vf, VFLIST(vf)->select_fd);
+			VFLIST(vf)->select_fd = nullptr;
+			}
 		}
 
 	VFLIST(vf)->select_idle_id = 0;

--- a/src/view-file/view-file.cc
+++ b/src/view-file/view-file.cc
@@ -1638,8 +1638,8 @@ static gboolean vf_star_next(ViewFile *vf)
 static gboolean vf_stars_cb(gpointer data)
 {
 	auto vf = static_cast<ViewFile *>(data);
-	FileData *fd = vf->stars_filedata;
 
+	FileData *fd = vf->stars_filedata;
 	if (!fd) return G_SOURCE_REMOVE;
 
 	read_rating_data(fd);


### PR DESCRIPTION
Remove redundant casts.
Use `G_SOURCE_CONTINUE`/`G_SOURCE_REMOVE` instead of `TRUE`/`FALSE`.
Make `metadata_write_idle_id` local static variable.
Reduce code duplication.