### PR TITLE
Fix memory leaks after vf_file_filter_get_filter() calls

### DIFF
--- a/src/search-and-run.cc
+++ b/src/search-and-run.cc
@@ -219,7 +219,6 @@ static gboolean match_func(GtkEntryCompletion *completion, const gchar *key, Gtk
 	GtkTreeModel *model;
 	GtkAction *action;
 	gchar *label;
-	GRegex *reg_exp;
 
 	model = gtk_entry_completion_get_model(completion);
 	gtk_tree_model_get(GTK_TREE_MODEL(model), iter, SAR_LABEL, &label, -1);
@@ -231,7 +230,7 @@ static gboolean match_func(GtkEntryCompletion *completion, const gchar *key, Gtk
 	reg_exp_str = g_string_append(reg_exp_str, key);
 
 	g_autoptr(GError) error = nullptr;
-	reg_exp = g_regex_new(reg_exp_str->str, G_REGEX_CASELESS, static_cast<GRegexMatchFlags>(0), &error);
+	g_autoptr(GRegex) reg_exp = g_regex_new(reg_exp_str->str, G_REGEX_CASELESS, static_cast<GRegexMatchFlags>(0), &error);
 	if (error)
 		{
 		log_printf("Error: could not compile regular expression %s\n%s\n", reg_exp_str->str, error->message);
@@ -245,8 +244,6 @@ static gboolean match_func(GtkEntryCompletion *completion, const gchar *key, Gtk
 		sar->action = action;
 		sar->match_found = TRUE;
 		}
-
-	g_regex_unref(reg_exp);
 
 	return ret;
 }

--- a/src/view-file/view-file-icon.cc
+++ b/src/view-file/view-file-icon.cc
@@ -1744,8 +1744,10 @@ static gboolean vficon_refresh_real(ViewFile *vf, gboolean keep_position)
 		{
 		ret = filelist_read(vf->dir_fd, &new_filelist, nullptr);
 		new_filelist = file_data_filter_marks_list(new_filelist, vf_marks_get_filter(vf));
+
+		g_autoptr(GRegex) filter = vf_file_filter_get_filter(vf);
 		new_filelist = g_list_first(new_filelist);
-		new_filelist = file_data_filter_file_filter_list(new_filelist, vf_file_filter_get_filter(vf));
+		new_filelist = file_data_filter_file_filter_list(new_filelist, filter);
 
 		new_filelist = g_list_first(new_filelist);
 		new_filelist = file_data_filter_class_list(new_filelist, vf_class_get_filter(vf));

--- a/src/view-file/view-file-list.cc
+++ b/src/view-file/view-file-list.cc
@@ -1706,8 +1706,10 @@ gboolean vflist_refresh(ViewFile *vf)
 			}
 
 		vf->list = file_data_filter_marks_list(vf->list, vf_marks_get_filter(vf));
+
+		g_autoptr(GRegex) filter = vf_file_filter_get_filter(vf);
 		vf->list = g_list_first(vf->list);
-		vf->list = file_data_filter_file_filter_list(vf->list, vf_file_filter_get_filter(vf));
+		vf->list = file_data_filter_file_filter_list(vf->list, filter);
 
 		vf->list = g_list_first(vf->list);
 		vf->list = file_data_filter_class_list(vf->list, vf_class_get_filter(vf));

--- a/src/view-file/view-file.cc
+++ b/src/view-file/view-file.cc
@@ -1721,7 +1721,7 @@ GRegex *vf_file_filter_get_filter(ViewFile *vf)
 	if (error)
 		{
 		log_printf("Error: could not compile regular expression %s\n%s\n", file_filter_text, error->message);
-		return g_regex_new("", static_cast<GRegexCompileFlags>(0), static_cast<GRegexMatchFlags>(0), nullptr);
+		ret = g_regex_new("", static_cast<GRegexCompileFlags>(0), static_cast<GRegexMatchFlags>(0), nullptr);
 		}
 
 	return ret;


### PR DESCRIPTION
Use `g_autoptr(GRegex)`.