### PR TITLE
Fix memory leaks after metadata_read_list() calls

### DIFF
--- a/src/metadata.cc
+++ b/src/metadata.cc
@@ -953,30 +953,26 @@ GList *string_to_keywords_list(const gchar *text)
 gboolean meta_data_get_keyword_mark(FileData *fd, gint, gpointer data)
 {
 	/** @FIXME do not use global keyword_tree */
-	auto path = static_cast<GList *>(data);
-	GList *keywords;
-	gboolean found = FALSE;
-	keywords = metadata_read_list(fd, KEYWORD_KEY, METADATA_PLAIN);
-	if (keywords)
-		{
-		GtkTreeIter iter;
-		if (keyword_tree_get_iter(GTK_TREE_MODEL(keyword_tree), &iter, path) &&
-		    keyword_tree_is_set(GTK_TREE_MODEL(keyword_tree), &iter, keywords))
-			found = TRUE;
+	GList *keywords = metadata_read_list(fd, KEYWORD_KEY, METADATA_PLAIN);
+	if (!keywords) return FALSE;
 
-		}
+	auto path = static_cast<GList *>(data);
+	GtkTreeIter iter;
+	gboolean found = (keyword_tree_get_iter(GTK_TREE_MODEL(keyword_tree), &iter, path) &&
+	                  keyword_tree_is_set(GTK_TREE_MODEL(keyword_tree), &iter, keywords));
+
+	g_list_free_full(keywords, g_free);
 	return found;
 }
 
 gboolean meta_data_set_keyword_mark(FileData *fd, gint, gboolean value, gpointer data)
 {
 	auto path = static_cast<GList *>(data);
-	GList *keywords = nullptr;
 	GtkTreeIter iter;
 
 	if (!keyword_tree_get_iter(GTK_TREE_MODEL(keyword_tree), &iter, path)) return FALSE;
 
-	keywords = metadata_read_list(fd, KEYWORD_KEY, METADATA_PLAIN);
+	GList *keywords = metadata_read_list(fd, KEYWORD_KEY, METADATA_PLAIN);
 
 	if (!!keyword_tree_is_set(GTK_TREE_MODEL(keyword_tree), &iter, keywords) != !!value)
 		{

--- a/src/osd.cc
+++ b/src/osd.cc
@@ -177,24 +177,19 @@ gchar *get_osd_name(const gchar *start, const gchar *end, guint &limit, gchar **
 	return g_strndup(start + 1, (trunc ? trunc : end) - start - 1);
 }
 
-gchar *keywords_to_string(FileData *fd)
-{
-	g_assert(fd);
-
-	GList *keywords = metadata_read_list(fd, KEYWORD_KEY, METADATA_PLAIN);
-
-	GString *kwstr = string_list_join(keywords, ", ");
-
-	g_list_free_full(keywords, g_free);
-
-	return g_string_free(kwstr, FALSE);
-}
-
 gchar *get_osd_data(gchar *name, FileData *fd, const OsdTemplate &vars)
 {
 	if (strcmp(name, "keywords") == 0)
 		{
-		return keywords_to_string(fd);
+		g_assert(fd);
+
+		GList *keywords = metadata_read_list(fd, KEYWORD_KEY, METADATA_PLAIN);
+
+		GString *kwstr = string_list_join(keywords, ", ");
+
+		g_list_free_full(keywords, g_free);
+
+		return g_string_free(kwstr, FALSE);
 		}
 
 	if (strcmp(name, "comment") == 0)

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -3044,9 +3044,6 @@ static void keywords_find_stop_cb(GenericDialog *, gpointer data)
 static gboolean keywords_find_file(gpointer data)
 {
 	auto kfd = static_cast<KeywordFindData *>(data);
-	GtkTextIter iter;
-	GtkTextBuffer *buffer;
-	GList *keywords;
 
 	if (kfd->list)
 		{
@@ -3055,15 +3052,15 @@ static gboolean keywords_find_file(gpointer data)
 		fd = static_cast<FileData *>(kfd->list->data);
 		kfd->list = g_list_remove(kfd->list, fd);
 
-		keywords = metadata_read_list(fd, KEYWORD_KEY, METADATA_PLAIN);
-		buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(keyword_text));
+		GList *keywords = metadata_read_list(fd, KEYWORD_KEY, METADATA_PLAIN);
+		GtkTextBuffer *buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(keyword_text));
+		GtkTextIter iter;
 
-		while (keywords)
+		for (GList *work = keywords; work; work = work->next)
 			{
 			gtk_text_buffer_get_end_iter(buffer, &iter);
-			g_autofree gchar *tmp = g_strconcat(static_cast<const gchar *>(keywords->data), "\n", NULL);
+			g_autofree gchar *tmp = g_strconcat(static_cast<gchar *>(work->data), "\n", NULL);
 			gtk_text_buffer_insert(buffer, &iter, tmp, -1);
-			keywords = keywords->next;
 			}
 
 		gq_gtk_entry_set_text(GTK_ENTRY(kfd->progress), fd->path);


### PR DESCRIPTION
Also inline `keywords_to_string()`.