### PR TITLE
per-image information text in the collection window

### DIFF
--- a/src/collect-table.h
+++ b/src/collect-table.h
@@ -66,6 +66,7 @@ struct CollectTable
 
 	gboolean show_text;
 	gboolean show_stars;
+	gboolean show_infotext;
 
 	GList *editmenu_fd_list; /**< file list for edit menu */
 };

--- a/src/collect.h
+++ b/src/collect.h
@@ -38,6 +38,7 @@ struct CollectInfo
 	FileData *fd;
 	GdkPixbuf *pixbuf;
 	guint flag_mask;
+	gchar *infotext;
 };
 
 CollectInfo *collection_info_new(FileData *fd, struct stat *st, GdkPixbuf *pixbuf);
@@ -108,7 +109,7 @@ void collection_set_update_info_func(CollectionData *cd,
 				     void (*func)(CollectionData *, CollectInfo *, gpointer), gpointer data);
 
 gboolean collection_add(CollectionData *cd, FileData *fd, gboolean sorted);
-gboolean collection_add_check(CollectionData *cd, FileData *fd, gboolean sorted, gboolean must_exist);
+gboolean collection_add_check(CollectionData *cd, FileData *fd, gboolean sorted, gboolean must_exist, const gchar *infotext);
 gboolean collection_insert(CollectionData *cd, FileData *fd, CollectInfo *insert_ci, gboolean sorted);
 gboolean collection_remove(CollectionData *cd, FileData *fd);
 void collection_remove_by_info_list(CollectionData *cd, GList *list);

--- a/src/options.cc
+++ b/src/options.cc
@@ -199,6 +199,7 @@ ConfOptions *init_options(ConfOptions *options)
 
 	options->show_icon_names = TRUE;
 	options->show_star_rating = FALSE;
+	options->show_collection_infotext = FALSE;
 	options->show_predefined_keyword_tree = TRUE;
 	options->expand_menu_toolbar = FALSE;
 	options->hamburger_menu = FALSE;

--- a/src/options.h
+++ b/src/options.h
@@ -75,6 +75,7 @@ struct ConfOptions
 	gchar *image_l_click_video_editor;
 	gboolean show_icon_names;
 	gboolean show_star_rating;
+	gboolean show_collection_infotext;
 	gboolean draw_rectangle;
 	gboolean show_predefined_keyword_tree;
 	gboolean overunderexposed;

--- a/src/rcfile.cc
+++ b/src/rcfile.cc
@@ -406,6 +406,7 @@ static void write_global_attributes(GString *outstr, gint indent)
 	/* General Options */
 	WRITE_NL(); WRITE_BOOL(*options, show_icon_names);
 	WRITE_NL(); WRITE_BOOL(*options, show_star_rating);
+	WRITE_NL(); WRITE_BOOL(*options, show_collection_infotext);
 	WRITE_NL(); WRITE_BOOL(*options, show_predefined_keyword_tree);
 	WRITE_SEPARATOR();
 
@@ -909,6 +910,7 @@ static gboolean load_global_params(const gchar **attribute_names, const gchar **
 		/* General options */
 		if (READ_BOOL(*options, show_icon_names)) continue;
 		if (READ_BOOL(*options, show_star_rating)) continue;
+		if (READ_BOOL(*options, show_collection_infotext)) continue;
 		if (READ_BOOL(*options, show_predefined_keyword_tree)) continue;
 
 		if (READ_BOOL(*options, tree_descend_subdirs)) continue;


### PR DESCRIPTION
In another project i create lists of similar images, sorted by a sharpness measure (it's a culling helper).
This value i want to show in the geeqie collection window.

This patch implements this by 
1) adding a new comment line type in the .gqv file:
#i some information
"/whereever/image.jpg"
#i another info
"/whereever/image.bla"

This information line is loaded and saved. In case there are multiple #i lines for one image the last one wins.

2) showing that information in the collection window, with a menu entry and a keyboard shortcut.

3) adding a new configuration option for persistance.

./scripts/test-all.sh ran through with this result:
```
Ok:                 1104
Expected Fail:      1   
Fail:               0   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0   
```
