### PR TITLE
Fix crash on drag-and-drop if source has directory

### DIFF
--- a/src/dupe.cc
+++ b/src/dupe.cc
@@ -4808,17 +4808,14 @@ static void dupe_dnd_data_get(GtkWidget *widget, GdkDragContext *context,
 			      guint, gpointer data)
 {
 	auto dw = static_cast<DupeWindow *>(data);
-	GtkWidget *source;
-	GList *work;
 
 	if (dw->add_files_queue_id > 0)
 		{
 		warning_dialog(_("Find duplicates"), _("Please wait for the current file selection to be loaded."), GQ_ICON_DIALOG_INFO, dw->window);
-
 		return;
 		}
 
-	source = gtk_drag_get_source_widget(context);
+	GtkWidget *source = gtk_drag_get_source_widget(context);
 	if (source == dw->listview || source == dw->second_listview) return;
 
 	dw->second_drop = (dw->second_set && widget == dw->second_listview);
@@ -4831,22 +4828,14 @@ static void dupe_dnd_data_get(GtkWidget *widget, GdkDragContext *context,
 			break;
 		case TARGET_URI_LIST:
 			list = uri_filelist_from_gtk_selection_data(selection_data);
-			work = list;
-			while (work)
+			if (file_data_list_has_dir(list))
 				{
-				auto fd = static_cast<FileData *>(work->data);
-				if (isdir(fd->path))
-					{
-					GtkWidget *menu;
-					menu = dupe_confirm_dir_list(dw, list);
-					gtk_menu_popup_at_pointer(GTK_MENU(menu), nullptr);
-					return;
-					}
-				work = work->next;
+				GtkWidget *menu = dupe_confirm_dir_list(dw, g_steal_pointer(&list));
+				gtk_menu_popup_at_pointer(GTK_MENU(menu), nullptr);
+				return;
 				}
 			break;
 		default:
-			list = nullptr;
 			break;
 		}
 

--- a/src/filedata.cc
+++ b/src/filedata.cc
@@ -200,6 +200,11 @@ GList *filelist_to_path_list(GList *list)
 }
 
 
+bool file_data_list_has_dir(FileDataList *list)
+{
+	return FileData::FileList::has_dir(list);
+}
+
 GList *filelist_filter(GList *list, gboolean is_dir_list)
 {
 	return FileData::FileList::filter(list, is_dir_list);

--- a/src/filedata.h
+++ b/src/filedata.h
@@ -384,6 +384,7 @@ class FileData::FileList
 	static GList *from_path_list(GList *list);
 	static GList *to_path_list(GList *list);
 
+	static bool has_dir(GList *list);
 	static GList *filter(GList *list, gboolean is_dir_list);
 
 	static GList *sort_path(GList *list);
@@ -468,6 +469,7 @@ GList *filelist_copy(GList *list);
 GList *filelist_from_path_list(GList *list);
 GList *filelist_to_path_list(GList *list);
 
+bool file_data_list_has_dir(FileDataList *list);
 GList *filelist_filter(GList *list, gboolean is_dir_list);
 
 GList *filelist_sort_path(GList *list);

--- a/src/filedata/filelist.cc
+++ b/src/filedata/filelist.cc
@@ -394,6 +394,17 @@ GList *FileData::FileList::to_path_list(GList *list)
 	return g_list_reverse(new_list);
 }
 
+bool FileData::FileList::has_dir(GList *list)
+{
+	static const auto fd_path_is_dir = [](gconstpointer data, gconstpointer)
+	{
+		const auto *fd = static_cast<const FileData *>(data);
+		return isdir(fd->path) ? 0 : 1;
+	};
+
+	return g_list_find_custom(list, nullptr, fd_path_is_dir) != nullptr;
+}
+
 GList *FileData::FileList::filter(GList *list, gboolean is_dir_list)
 {
 	GList *work;

--- a/src/img-view.cc
+++ b/src/img-view.cc
@@ -1595,22 +1595,13 @@ static void view_window_get_dnd_data(GtkWidget *, GdkDragContext *context,
 
 		if (info == TARGET_URI_LIST)
 			{
-			GList *work;
-
 			list = uri_filelist_from_gtk_selection_data(selection_data);
 
-			work = list;
-			while (work)
+			if (file_data_list_has_dir(list))
 				{
-				auto fd = static_cast<FileData *>(work->data);
-				if (isdir(fd->path))
-					{
-					GtkWidget *menu;
-					menu = view_confirm_dir_list(vw, list);
-					gtk_menu_popup_at_pointer(GTK_MENU(menu), nullptr);
-					return;
-					}
-				work = work->next;
+				GtkWidget *menu = view_confirm_dir_list(vw, g_steal_pointer(&list));
+				gtk_menu_popup_at_pointer(GTK_MENU(menu), nullptr);
+				return;
 				}
 
 			list = filelist_filter(list, FALSE);


### PR DESCRIPTION
Deduplicate check if `FileDataList` has directory element.

See https://github.com/BestImageViewer/geeqie/pull/1753#issuecomment-3049447351.