### PR TITLE
Use vector for hardcoded window keys

### DIFF
--- a/doc/create-shortcuts-xml.sh
+++ b/doc/create-shortcuts-xml.sh
@@ -25,13 +25,13 @@
 ##
 ## The .xml files are included within ./doc/docbook/GuideReferenceKeyboardShortcuts.xml
 ##
-## For separate windows, source code files are searched for the string "hard_coded_window_keys"  
+## For separate windows, source code files are searched for the string "HardcodedWindowKeyList"
 ## which is an array containing the shortcut key and the menu label.
 ##
 ## For the main window the source file ./src/layout-util.cc is searched for
 ## lines which contain shortcut definitions.
 ##
-## This needs to be run only when the sortcut keys have been changed
+## This needs to be run only when the shortcut keys have been changed
 ##
 
 duplicates_xml="<emphasis role=\"underline\"><link linkend=\"GuideImageSearchFindingDuplicates\">Duplicates window</link></emphasis>"
@@ -83,10 +83,10 @@ awk_window='BEGIN {
 	LINT = "fatal"
 	FS = ","
 	getline
-	while ($0 !~ /^static hard_coded_window_keys/) {getline}
+	while ($0 !~ /^static HardcodedWindowKeyList/) {getline}
 	}
 
-$0~/\{static_cast<GdkModifierType>\(0\), 0/ {exit}
+$0~/\};/ {exit}
 {
 gsub(/\{static_cast<GdkModifierType>\(0\)/, "", $1);
 gsub(/\{static_cast<GdkModifierType>\(GDK_CONTROL_MASK \+ GDK_SHIFT_MASK\)/, "Ctrl + Shift +", $1);

--- a/src/collect-table.cc
+++ b/src/collect-table.cc
@@ -107,9 +107,9 @@ static void collection_table_populate_at_new_size(CollectTable *ct, gint w, gint
  * @link collection_window_keypress @endlink \n
  * @link collection_table_popup_menu @endlink
  *
- * See also @link hard_coded_window_keys @endlink
+ * See also @link HardcodedWindowKey @endlink
  **/
-static hard_coded_window_keys collection_window_keys[] = {
+static HardcodedWindowKeyList collection_window_keys{
 	{GDK_CONTROL_MASK, 'C', N_("Copy")},
 	{GDK_CONTROL_MASK, 'M', N_("Move")},
 	{GDK_CONTROL_MASK, 'R', N_("Rename")},
@@ -136,7 +136,6 @@ static hard_coded_window_keys collection_window_keys[] = {
 	{GDK_SHIFT_MASK, 'P', N_("Print")},
 	{GDK_MOD1_MASK, 'A', N_("Append (Append collection dialog)")},
 	{GDK_MOD1_MASK, 'D', N_("Discard (Close modified collection dialog)")},
-	{static_cast<GdkModifierType>(0), 0, nullptr}
 };
 
 /*
@@ -1005,7 +1004,7 @@ static GtkWidget *collection_table_popup_menu(CollectTable *ct, gboolean over_ic
 	accel_group = gtk_accel_group_new();
 	gtk_menu_set_accel_group(GTK_MENU(menu), accel_group);
 
-	g_object_set_data(G_OBJECT(menu), "window_keys", collection_window_keys);
+	g_object_set_data(G_OBJECT(menu), "window_keys", &collection_window_keys);
 	g_object_set_data(G_OBJECT(menu), "accel_group", accel_group);
 
 	g_signal_connect(G_OBJECT(menu), "destroy",

--- a/src/dupe.cc
+++ b/src/dupe.cc
@@ -166,9 +166,9 @@ static gint dupe_match_link_exists(DupeItem *child, DupeItem *parent);
  *  @link dupe_window_keypress_cb() @endlink \n
  *  @link dupe_menu_popup_main() @endlink
  *
- * See also @link hard_coded_window_keys @endlink
+ * See also @link HardcodedWindowKey @endlink
  **/
-static hard_coded_window_keys dupe_window_keys[] = {
+static HardcodedWindowKeyList dupe_window_keys{
 	{GDK_CONTROL_MASK, 'C', N_("Copy")},
 	{GDK_CONTROL_MASK, 'M', N_("Move")},
 	{GDK_CONTROL_MASK, 'R', N_("Rename")},
@@ -187,7 +187,6 @@ static hard_coded_window_keys dupe_window_keys[] = {
 	{static_cast<GdkModifierType>(0), '0', N_("Select none")},
 	{static_cast<GdkModifierType>(0), '1', N_("Select group 1 duplicates")},
 	{static_cast<GdkModifierType>(0), '2', N_("Select group 2 duplicates")},
-	{static_cast<GdkModifierType>(0), 0, nullptr}
 };
 
 /**
@@ -3350,7 +3349,7 @@ static GtkWidget *dupe_menu_popup_main(DupeWindow *dw, DupeItem *di)
 	accel_group = gtk_accel_group_new();
 	gtk_menu_set_accel_group(GTK_MENU(menu), accel_group);
 
-	g_object_set_data(G_OBJECT(menu), "window_keys", dupe_window_keys);
+	g_object_set_data(G_OBJECT(menu), "window_keys", &dupe_window_keys);
 	g_object_set_data(G_OBJECT(menu), "accel_group", accel_group);
 
 	menu_item_add_sensitive(menu, _("_View"), on_row,
@@ -3679,7 +3678,7 @@ static GtkWidget *dupe_menu_popup_second(DupeWindow *dw, DupeItem *di)
 	accel_group = gtk_accel_group_new();
 	gtk_menu_set_accel_group(GTK_MENU(menu), accel_group);
 
-	g_object_set_data(G_OBJECT(menu), "window_keys", dupe_window_keys);
+	g_object_set_data(G_OBJECT(menu), "window_keys", &dupe_window_keys);
 	g_object_set_data(G_OBJECT(menu), "accel_group", accel_group);
 
 	menu_item_add_sensitive(menu, _("_View"), on_row,

--- a/src/img-view.cc
+++ b/src/img-view.cc
@@ -99,9 +99,9 @@ static void view_window_notify_cb(FileData *fd, NotifyType type, gpointer data);
  *  @link view_popup_menu() @endlink \n
  *  @link view_window_key_press_cb() @endlink
  *
- * See also @link hard_coded_window_keys @endlink
+ * See also @link HardcodedWindowKey @endlink
  **/
-static hard_coded_window_keys image_window_keys[] = {
+static HardcodedWindowKeyList image_window_keys{
 	{GDK_CONTROL_MASK, 'C', N_("Copy")},
 	{GDK_CONTROL_MASK, 'M', N_("Move")},
 	{GDK_CONTROL_MASK, 'R', N_("Rename")},
@@ -149,7 +149,6 @@ static hard_coded_window_keys image_window_keys[] = {
 	{static_cast<GdkModifierType>(0), GDK_KEY_Escape, N_("Close window")},
 	{GDK_SHIFT_MASK, 'G', N_("Desaturate")},
 	{GDK_SHIFT_MASK, 'P', N_("Print")},
-	{static_cast<GdkModifierType>(0), 0, nullptr}
 };
 
 
@@ -1338,7 +1337,7 @@ static GtkWidget *view_popup_menu(ViewWindow *vw)
 	accel_group = gtk_accel_group_new();
 	gtk_menu_set_accel_group(GTK_MENU(menu), accel_group);
 
-	g_object_set_data(G_OBJECT(menu), "window_keys", image_window_keys);
+	g_object_set_data(G_OBJECT(menu), "window_keys", &image_window_keys);
 	g_object_set_data(G_OBJECT(menu), "accel_group", accel_group);
 
 	menu_item_add_icon(menu, _("Zoom _in"), GQ_ICON_ZOOM_IN, G_CALLBACK(view_zoom_in_cb), vw);

--- a/src/layout-image.cc
+++ b/src/layout-image.cc
@@ -780,7 +780,6 @@ static GtkWidget *layout_image_pop_menu(LayoutWindow *lw)
 	accel_group = gtk_accel_group_new();
 	gtk_menu_set_accel_group(GTK_MENU(menu), accel_group);
 
-	g_object_set_data(G_OBJECT(menu), "window_keys", nullptr);
 	g_object_set_data(G_OBJECT(menu), "accel_group", accel_group);
 
 	menu_item_add_icon(menu, _("Zoom _in"), GQ_ICON_ZOOM_IN, G_CALLBACK(li_pop_menu_zoom_in_cb), lw);

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -141,9 +141,9 @@ static void pan_window_dnd_init(PanWindow *pw);
  * @link pan_window_key_press_cb @endlink \n
  * @link pan_popup_menu @endlink
  *
- * See also @link hard_coded_window_keys @endlink
+ * See also @link HardcodedWindowKey @endlink
  **/
-static hard_coded_window_keys pan_view_window_keys[] = {
+static HardcodedWindowKeyList pan_view_window_keys{
 	{GDK_CONTROL_MASK, 'C', N_("Copy")},
 	{GDK_CONTROL_MASK, 'M', N_("Move")},
 	{GDK_CONTROL_MASK, 'R', N_("Rename")},
@@ -181,7 +181,6 @@ static hard_coded_window_keys pan_view_window_keys[] = {
 	{static_cast<GdkModifierType>(0), GDK_KEY_Page_Down, N_("Scroll display half screen down")},
 	{static_cast<GdkModifierType>(0), GDK_KEY_Home, N_("Scroll display half screen left")},
 	{static_cast<GdkModifierType>(0), GDK_KEY_End, N_("Scroll display half screen right")},
-	{static_cast<GdkModifierType>(0), 0, nullptr}
 };
 
 /*
@@ -2302,7 +2301,7 @@ static GtkWidget *pan_popup_menu(PanWindow *pw)
 	accel_group = gtk_accel_group_new();
 	gtk_menu_set_accel_group(GTK_MENU(menu), accel_group);
 
-	g_object_set_data(G_OBJECT(menu), "window_keys", pan_view_window_keys);
+	g_object_set_data(G_OBJECT(menu), "window_keys", &pan_view_window_keys);
 	g_object_set_data(G_OBJECT(menu), "accel_group", accel_group);
 
 	menu_item_add_icon_sensitive(menu, _("_Play"), GQ_ICON_PLAY, video,

--- a/src/search.cc
+++ b/src/search.cc
@@ -496,10 +496,10 @@ static void search_start_cb(GtkWidget *widget, gpointer data);
  * @link search_window_keypress_cb @endlink \n
  * @link search_result_menu @endlink
  *
- * See also @link hard_coded_window_keys @endlink
+ * See also @link HardcodedWindowKey @endlink
  **/
 
-static hard_coded_window_keys search_window_keys[] = {
+static HardcodedWindowKeyList search_window_keys{
 	{GDK_CONTROL_MASK, 'C', N_("Copy")},
 	{GDK_CONTROL_MASK, 'M', N_("Move")},
 	{GDK_CONTROL_MASK, 'R', N_("Rename")},
@@ -516,7 +516,6 @@ static hard_coded_window_keys search_window_keys[] = {
 	{static_cast<GdkModifierType>(0), 'C', N_("Collection from selection")},
 	{GDK_CONTROL_MASK, GDK_KEY_Return, N_("Start/stop search")},
 	{static_cast<GdkModifierType>(0), GDK_KEY_F3, N_("Find duplicates")},
-	{static_cast<GdkModifierType>(0), 0, nullptr}
 };
 /*
  *-------------------------------------------------------------------
@@ -1174,7 +1173,7 @@ static GtkWidget *search_result_menu(SearchData *sd, gboolean on_row, gboolean e
 	accel_group = gtk_accel_group_new();
 	gtk_menu_set_accel_group(GTK_MENU(menu), accel_group);
 
-	g_object_set_data(G_OBJECT(menu), "window_keys", search_window_keys);
+	g_object_set_data(G_OBJECT(menu), "window_keys", &search_window_keys);
 	g_object_set_data(G_OBJECT(menu), "accel_group", accel_group);
 
 	video = (on_row && sd->click_fd && sd->click_fd->format_class == FORMAT_CLASS_VIDEO);

--- a/src/ui-menu.h
+++ b/src/ui-menu.h
@@ -22,13 +22,15 @@
 #ifndef UI_MENU_H
 #define UI_MENU_H
 
+#include <vector>
+
 #include <gdk/gdk.h>
 #include <glib-object.h>
 #include <glib.h>
 #include <gtk/gtk.h>
 
 /**
- * @struct hard_coded_window_keys
+ * @struct HardcodedWindowKey
  * @brief hard coded window shortcut keys
  *
  * Used for two purposes:\n
@@ -36,11 +38,14 @@
  * used by ./doc/create-shortcuts-xml.sh to generate shortcut documentation in the Help files
  *
  */
-struct hard_coded_window_keys {
+struct HardcodedWindowKey
+{
 	GdkModifierType mask; /**< modifier key mask */
 	guint key_value;  /**< GDK_keyval */
-	const gchar *text;  /**< menu item label - NULL if end of list */
+	const gchar *text;  /**< menu item label */
 };
+
+using HardcodedWindowKeyList = std::vector<HardcodedWindowKey>;
 
 GtkWidget *menu_item_add(GtkWidget *menu, const gchar *label,
 			 GCallback func, gpointer data);

--- a/src/view-file/view-file.cc
+++ b/src/view-file/view-file.cc
@@ -724,7 +724,6 @@ GtkWidget *vf_pop_menu(ViewFile *vf)
 	accel_group = gtk_accel_group_new();
 	gtk_menu_set_accel_group(GTK_MENU(menu), accel_group);
 
-	g_object_set_data(G_OBJECT(menu), "window_keys", nullptr);
 	g_object_set_data(G_OBJECT(menu), "accel_group", accel_group);
 
 	g_signal_connect(G_OBJECT(menu), "destroy",


### PR DESCRIPTION
Drop redundant `menu_item_add_accelerator()` calls.
Drop explicit set of `"window_keys"` to `nullptr`.