### PR TITLE
Fix memory leaks after gtk_action_group_list_actions() calls

### DIFF
--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -1588,8 +1588,6 @@ static void image_overlay_set_background_color_cb(GtkWidget *widget, gpointer da
 static void accel_store_populate()
 {
 	GList *groups;
-	GList *actions;
-	GtkAction *action;
 	const gchar *accel_path;
 	GtkAccelKey key;
 	GtkTreeIter iter;
@@ -1603,10 +1601,10 @@ static void accel_store_populate()
 	groups = gq_gtk_ui_manager_get_action_groups(lw->ui_manager);
 	while (groups)
 		{
-		actions = gq_gtk_action_group_list_actions(GQ_GTK_ACTION_GROUP(groups->data));
-		while (actions)
+		g_autoptr(GList) actions = gq_gtk_action_group_list_actions(GQ_GTK_ACTION_GROUP(groups->data));
+		for (GList *work = actions; work; work = work->next)
 			{
-			action = GQ_GTK_ACTION(actions->data);
+			GtkAction *action = GQ_GTK_ACTION(work->data);
 			accel_path = gq_gtk_action_get_accel_path(action);
 			if (accel_path && gtk_accel_map_lookup_entry(accel_path, &key))
 				{
@@ -1638,7 +1636,6 @@ static void accel_store_populate()
 					                   -1);
 					}
 				}
-			actions = actions->next;
 			}
 
 		groups = groups->next;

--- a/src/search-and-run.cc
+++ b/src/search-and-run.cc
@@ -58,8 +58,6 @@ static gint sort_iter_compare_func (GtkTreeModel *model, GtkTreeIter *a, GtkTree
 static void command_store_populate(SarData* sar)
 {
 	GList *groups;
-	GList *actions;
-	GtkAction *action;
 	const gchar *accel_path;
 	GtkAccelKey key;
 	GtkTreeIter iter;
@@ -76,10 +74,10 @@ static void command_store_populate(SarData* sar)
 	groups = gq_gtk_ui_manager_get_action_groups(sar->lw->ui_manager);
 	while (groups)
 		{
-		actions = gq_gtk_action_group_list_actions(GQ_GTK_ACTION_GROUP(groups->data));
-		while (actions)
+		g_autoptr(GList) actions = gq_gtk_action_group_list_actions(GQ_GTK_ACTION_GROUP(groups->data));
+		for (GList *work = actions; work; work = work->next)
 			{
-			action = GQ_GTK_ACTION(actions->data);
+			GtkAction *action = GQ_GTK_ACTION(work->data);
 			accel_path = gq_gtk_action_get_accel_path(action);
 			if (accel_path && gtk_accel_map_lookup_entry(accel_path, &key))
 				{
@@ -141,8 +139,8 @@ static void command_store_populate(SarData* sar)
 						}
 					}
 				}
-			actions = actions->next;
 			}
+
 		groups = groups->next;
 		}
 }

--- a/src/ui-menu.cc
+++ b/src/ui-menu.cc
@@ -108,10 +108,7 @@ static gint actions_sort_cb(gconstpointer a, gconstpointer b)
 static void menu_item_add_main_window_accelerator(GtkWidget *menu, GtkAccelGroup *accel_group)
 {
 	GList *groups;
-	GList *actions;
-	GtkAction *action;
 	const gchar *accel_path;
-	GtkAccelKey key;
 
 	const gchar *menu_label = gtk_menu_item_get_label(GTK_MENU_ITEM(menu));
 
@@ -125,14 +122,15 @@ static void menu_item_add_main_window_accelerator(GtkWidget *menu, GtkAccelGroup
 
 	while (groups)
 		{
-		actions = gq_gtk_action_group_list_actions(GQ_GTK_ACTION_GROUP(groups->data));
+		g_autoptr(GList) actions = gq_gtk_action_group_list_actions(GQ_GTK_ACTION_GROUP(groups->data));
 		actions = g_list_sort(actions, actions_sort_cb);
 
-		while (actions)
+		for (GList *work = actions; work; work = work->next)
 			{
-			action = GQ_GTK_ACTION(actions->data);
+			GtkAction *action = GQ_GTK_ACTION(work->data);
 			accel_path = gq_gtk_action_get_accel_path(action);
-			if (accel_path && gtk_accel_map_lookup_entry(accel_path, &key))
+			GtkAccelKey key;
+			if (accel_path && gtk_accel_map_lookup_entry(accel_path, &key) && key.accel_key != 0)
 				{
 				g_autofree gchar *action_label = nullptr;
 				g_object_get(action, "label", &action_label, NULL);
@@ -142,16 +140,12 @@ static void menu_item_add_main_window_accelerator(GtkWidget *menu, GtkAccelGroup
 
 				if (g_strcmp0(action_label_text, menu_label_text) == 0)
 					{
-					if (key.accel_key != 0)
-						{
-						gtk_widget_add_accelerator(menu, "activate", accel_group, key.accel_key, key.accel_mods, GTK_ACCEL_VISIBLE);
-
-						break;
-						}
+					gtk_widget_add_accelerator(menu, "activate", accel_group, key.accel_key, key.accel_mods, GTK_ACCEL_VISIBLE);
+					break;
 					}
 				}
-			actions = actions->next;
 			}
+
 		groups = groups->next;
 		}
 }

--- a/src/ui-misc.cc
+++ b/src/ui-misc.cc
@@ -1332,10 +1332,10 @@ std::vector<ActionItem> get_action_items()
 
 	for (GList *groups = gq_gtk_ui_manager_get_action_groups(lw->ui_manager); groups; groups = groups->next)
 		{
-		GtkActionGroup *action_group = GQ_GTK_ACTION_GROUP(groups->data);
-		for (GList *actions = gq_gtk_action_group_list_actions(action_group); actions; actions = actions->next)
+		g_autoptr(GList) actions = gq_gtk_action_group_list_actions(GQ_GTK_ACTION_GROUP(groups->data));
+		for (GList *work = actions; work; work = work->next)
 			{
-			GtkAction *action = GQ_GTK_ACTION(actions->data);
+			GtkAction *action = GQ_GTK_ACTION(work->data);
 
 			const gchar *accel_path = gq_gtk_action_get_accel_path(action);
 			if (accel_path && gtk_accel_map_lookup_entry(accel_path, nullptr))


### PR DESCRIPTION
Optimize `menu_item_add_main_window_accelerator()` a bit by checking `accel_key` earlier.