### PR TITLE
Simplify submenu_add_edit() a bit

### DIFF
--- a/src/collect-table.cc
+++ b/src/collect-table.cc
@@ -754,12 +754,10 @@ static GList *collection_table_popup_file_list(CollectTable *ct)
 
 static void collection_table_popup_edit_cb(GtkWidget *widget, gpointer data)
 {
-	CollectTable *ct;
-	auto key = static_cast<const gchar *>(data);
-
-	ct = static_cast<CollectTable *>(submenu_item_get_data(widget));
-
+	auto *ct = static_cast<CollectTable *>(submenu_item_get_data(widget));
 	if (!ct) return;
+
+	auto *key = static_cast<const gchar *>(data);
 
 	file_util_start_editor_from_filelist(key, collection_table_popup_file_list(ct), nullptr, ct->listview);
 }
@@ -1041,9 +1039,8 @@ static GtkWidget *collection_table_popup_menu(CollectTable *ct, gboolean over_ic
 
 
 	ct->editmenu_fd_list = collection_table_selection_get_list(ct);
-	submenu_add_edit(menu, &item,
-			G_CALLBACK(collection_table_popup_edit_cb), ct, ct->editmenu_fd_list);
-	gtk_widget_set_sensitive(item, over_icon);
+	submenu_add_edit(menu, over_icon, ct->editmenu_fd_list,
+	                 G_CALLBACK(collection_table_popup_edit_cb), ct);
 
 	menu_item_add_divider(menu);
 	menu_item_add_icon_sensitive(menu, _("_Copy..."), GQ_ICON_COPY, over_icon,

--- a/src/dupe.cc
+++ b/src/dupe.cc
@@ -3228,11 +3228,10 @@ static void dupe_menu_select_dupes_cb(GtkWidget *, gpointer data)
 
 static void dupe_menu_edit_cb(GtkWidget *widget, gpointer data)
 {
-	DupeWindow *dw;
-	auto key = static_cast<const gchar *>(data);
-
-	dw = static_cast<DupeWindow *>(submenu_item_get_data(widget));
+	auto *dw = static_cast<DupeWindow *>(submenu_item_get_data(widget));
 	if (!dw) return;
+
+	auto *key = static_cast<const gchar *>(data);
 
 	dupe_window_edit_selected(dw, key);
 }
@@ -3368,8 +3367,7 @@ static GtkWidget *dupe_menu_popup_main(DupeWindow *dw, DupeItem *di)
 	editmenu_fd_list = dupe_window_get_fd_list(dw);
 	g_signal_connect_swapped(G_OBJECT(menu), "destroy",
 	                         G_CALLBACK(file_data_list_free), editmenu_fd_list);
-	submenu_add_edit(menu, &item, G_CALLBACK(dupe_menu_edit_cb), dw, editmenu_fd_list);
-	if (!on_row) gtk_widget_set_sensitive(item, FALSE);
+	submenu_add_edit(menu, on_row, editmenu_fd_list, G_CALLBACK(dupe_menu_edit_cb), dw);
 
 	submenu_add_collections(menu, &item,
 								G_CALLBACK(dupe_pop_menu_collections_cb), dw);

--- a/src/img-view.cc
+++ b/src/img-view.cc
@@ -1120,19 +1120,17 @@ static void view_new_window_cb(GtkWidget *, gpointer data)
 
 static void view_edit_cb(GtkWidget *widget, gpointer data)
 {
-	ViewWindow *vw;
-	ImageWindow *imd;
-	auto key = static_cast<const gchar *>(data);
-
-	vw = static_cast<ViewWindow *>(submenu_item_get_data(widget));
+	auto *vw = static_cast<ViewWindow *>(submenu_item_get_data(widget));
 	if (!vw) return;
+
+	auto *key = static_cast<const gchar *>(data);
 
 	if (!editor_window_flag_set(key))
 		{
 		view_fullscreen_toggle(vw, TRUE);
 		}
 
-	imd = view_window_active_image(vw);
+	ImageWindow *imd = view_window_active_image(vw);
 	file_util_start_editor_from_file(key, image_get_fd(imd), imd->widget);
 }
 
@@ -1349,7 +1347,7 @@ static GtkWidget *view_popup_menu(ViewWindow *vw)
  	editmenu_fd_list = view_window_get_fd_list(vw);
 	g_signal_connect_swapped(G_OBJECT(menu), "destroy",
 	                         G_CALLBACK(file_data_list_free), editmenu_fd_list);
-	item = submenu_add_edit(menu, nullptr, G_CALLBACK(view_edit_cb), vw, editmenu_fd_list);
+	item = submenu_add_edit(menu, TRUE, editmenu_fd_list, G_CALLBACK(view_edit_cb), vw);
 	menu_item_add_divider(item);
 
 	submenu_add_alter(menu, G_CALLBACK(view_alter_cb), vw);

--- a/src/layout-image.cc
+++ b/src/layout-image.cc
@@ -791,8 +791,7 @@ static GtkWidget *layout_image_pop_menu(LayoutWindow *lw)
 	editmenu_fd_list = layout_image_get_fd_list(lw);
 	g_signal_connect_swapped(G_OBJECT(menu), "destroy",
 	                         G_CALLBACK(file_data_list_free), editmenu_fd_list);
-	submenu = submenu_add_edit(menu, &item, G_CALLBACK(li_pop_menu_edit_cb), lw, editmenu_fd_list);
-	if (!path) gtk_widget_set_sensitive(item, FALSE);
+	submenu = submenu_add_edit(menu, !!path, editmenu_fd_list, G_CALLBACK(li_pop_menu_edit_cb), lw);
 	menu_item_add_divider(submenu);
 	item = submenu_add_alter(menu, G_CALLBACK(li_pop_menu_alter_cb), lw);
 

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -48,10 +48,6 @@ gpointer submenu_item_get_data(GtkWidget *submenu_item)
  * edit menu
  *-----------------------------------------------------------------------------
  */
-static void edit_item_destroy_cb(GtkWidget *, gpointer data)
-{
-	g_free(data);
-}
 
 static void add_edit_items(GtkWidget *menu, GCallback func, GList *fd_list)
 {
@@ -70,18 +66,16 @@ static void add_edit_items(GtkWidget *menu, GCallback func, GList *fd_list)
 			}
 
 		GtkWidget *item = menu_item_add_stock(menu, editor->name, stock_id, func, key);
-		g_signal_connect(G_OBJECT(item), "destroy", G_CALLBACK(edit_item_destroy_cb), key);
+		g_signal_connect_swapped(G_OBJECT(item), "destroy", G_CALLBACK(g_free), key);
 		}
 }
 
-GtkWidget *submenu_add_edit(GtkWidget *menu, GtkWidget **menu_item, GCallback func, gpointer data, GList *fd_list)
+GtkWidget *submenu_add_edit(GtkWidget *menu, gboolean sensitive, GList *fd_list, GCallback func, gpointer data)
 {
-	GtkWidget *item;
 	GtkWidget *submenu;
 	GtkAccelGroup *accel_group;
 
 	accel_group = gtk_accel_group_new();
-	item = menu_item_add(menu, _("_Plugins"), nullptr, nullptr);
 
 	submenu = gtk_menu_new();
 	g_object_set_data(G_OBJECT(submenu), "submenu_data", data);
@@ -90,9 +84,9 @@ GtkWidget *submenu_add_edit(GtkWidget *menu, GtkWidget **menu_item, GCallback fu
 
 	add_edit_items(submenu, func, fd_list);
 
+	GtkWidget *item = menu_item_add(menu, _("_Plugins"), nullptr, nullptr);
 	gtk_menu_item_set_submenu(GTK_MENU_ITEM(item), submenu);
-
-	if (menu_item) *menu_item = item;
+	gtk_widget_set_sensitive(item, sensitive);
 
 	return submenu;
 }

--- a/src/menu.h
+++ b/src/menu.h
@@ -30,7 +30,7 @@
 
 gpointer submenu_item_get_data(GtkWidget *submenu_item);
 
-GtkWidget *submenu_add_edit(GtkWidget *menu, GtkWidget **menu_item, GCallback func, gpointer data, GList *fd_list);
+GtkWidget *submenu_add_edit(GtkWidget *menu, gboolean sensitive, GList *fd_list, GCallback func, gpointer data);
 
 gchar *sort_type_get_text(SortType method);
 bool sort_type_requires_metadata(SortType method);

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -2129,22 +2129,20 @@ static void pan_go_to_original_cb(GtkWidget *, gpointer data)
 
 static void pan_edit_cb(GtkWidget *widget, gpointer data)
 {
-	PanWindow *pw;
-	FileData *fd;
-	auto key = static_cast<const gchar *>(data);
-
-	pw = static_cast<PanWindow *>(submenu_item_get_data(widget));
+	auto *pw = static_cast<PanWindow *>(submenu_item_get_data(widget));
 	if (!pw) return;
 
-	fd = pan_menu_click_fd(pw);
-	if (fd)
+	FileData *fd = pan_menu_click_fd(pw);
+	if (!fd) return;
+
+	auto *key = static_cast<const gchar *>(data);
+
+	if (!editor_window_flag_set(key))
 		{
-		if (!editor_window_flag_set(key))
-			{
-			pan_fullscreen_toggle(pw, TRUE);
-			}
-		file_util_start_editor_from_file(key, fd, pw->imd->widget);
+		pan_fullscreen_toggle(pw, TRUE);
 		}
+
+	file_util_start_editor_from_file(key, fd, pw->imd->widget);
 }
 
 static void pan_zoom_in_cb(GtkWidget *, gpointer data)
@@ -2321,8 +2319,7 @@ static GtkWidget *pan_popup_menu(PanWindow *pw)
 	g_signal_connect_swapped(G_OBJECT(menu), "destroy",
 	                         G_CALLBACK(file_data_list_free), editmenu_fd_list);
 
-	submenu_add_edit(menu, &item, G_CALLBACK(pan_edit_cb), pw, editmenu_fd_list);
-	gtk_widget_set_sensitive(item, active);
+	submenu_add_edit(menu, active, editmenu_fd_list, G_CALLBACK(pan_edit_cb), pw);
 
 	menu_item_add_icon_sensitive(menu, _("View in _new window"), GQ_ICON_NEW, active,
 				      G_CALLBACK(pan_new_window_cb), pw);

--- a/src/search.cc
+++ b/src/search.cc
@@ -1083,11 +1083,10 @@ static void sr_menu_select_none_cb(GtkWidget *, gpointer data)
 
 static void sr_menu_edit_cb(GtkWidget *widget, gpointer data)
 {
-	SearchData *sd;
-	auto key = static_cast<const gchar *>(data);
-
-	sd = static_cast<SearchData *>(submenu_item_get_data(widget));
+	auto *sd = static_cast<SearchData *>(submenu_item_get_data(widget));
 	if (!sd) return;
+
+	auto *key = static_cast<const gchar *>(data);
 
 	search_result_edit_selected(sd, key);
 }
@@ -1191,8 +1190,7 @@ static GtkWidget *search_result_menu(SearchData *sd, gboolean on_row, gboolean e
 	editmenu_fd_list = search_result_selection_list(sd);
 	g_signal_connect_swapped(G_OBJECT(menu), "destroy",
 	                         G_CALLBACK(file_data_list_free), editmenu_fd_list);
-	submenu_add_edit(menu, &item, G_CALLBACK(sr_menu_edit_cb), sd, editmenu_fd_list);
-	if (!on_row) gtk_widget_set_sensitive(item, FALSE);
+	submenu_add_edit(menu, on_row, editmenu_fd_list, G_CALLBACK(sr_menu_edit_cb), sd);
 
 	submenu_add_collections(menu, &item,
 				G_CALLBACK(search_pop_menu_collections_cb), sd);

--- a/src/view-file/view-file.cc
+++ b/src/view-file/view-file.cc
@@ -457,12 +457,10 @@ GList *vf_selection_get_one(ViewFile *vf, FileData *fd)
 
 static void vf_pop_menu_edit_cb(GtkWidget *widget, gpointer data)
 {
-	ViewFile *vf;
-	auto key = static_cast<const gchar *>(data);
-
-	vf = static_cast<ViewFile *>(submenu_item_get_data(widget));
-
+	auto *vf = static_cast<ViewFile *>(submenu_item_get_data(widget));
 	if (!vf) return;
+
+	auto *key = static_cast<const gchar *>(data);
 
 	file_util_start_editor_from_filelist(key, vf_pop_menu_file_list(vf), vf->dir_fd->path, vf->listview);
 }
@@ -770,8 +768,7 @@ GtkWidget *vf_pop_menu(ViewFile *vf)
 		}
 
 	vf->editmenu_fd_list = vf_pop_menu_file_list(vf);
-	submenu_add_edit(menu, &item, G_CALLBACK(vf_pop_menu_edit_cb), vf, vf->editmenu_fd_list);
-	gtk_widget_set_sensitive(item, active);
+	submenu_add_edit(menu, active, vf->editmenu_fd_list, G_CALLBACK(vf_pop_menu_edit_cb), vf);
 
 	menu_item_add_icon_sensitive(menu, _("View in _new window"), GQ_ICON_NEW, active,
 				      G_CALLBACK(vf_pop_menu_view_cb), vf);


### PR DESCRIPTION
Use `sensitive` flag and call `gtk_widget_set_sensitive()` instead of out `item` parameter. Also make callback and data last parameters.
Use `g_signal_connect_swapped`, drop `edit_item_destroy_cb()`.
Simplify related callbacks.