### PR TITLE
Cleanup collect-dlg

### DIFF
--- a/src/collect-dlg.h
+++ b/src/collect-dlg.h
@@ -24,11 +24,8 @@
 
 struct CollectionData;
 
-void collection_dialog_save_as(CollectionData *cd);
-void collection_dialog_save_close(CollectionData *cd);
-
+void collection_dialog_save(CollectionData *cd);
 void collection_dialog_append(CollectionData *cd);
-
 
 #endif
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/collect-table.cc
+++ b/src/collect-table.cc
@@ -721,7 +721,7 @@ static void collection_table_popup_save_as_cb(GtkWidget *, gpointer data)
 {
 	auto ct = static_cast<CollectTable *>(data);
 
-	collection_dialog_save_as(ct->cd);
+	collection_dialog_save(ct->cd);
 }
 
 static void collection_table_popup_save_cb(GtkWidget *widget, gpointer data)

--- a/src/collect.cc
+++ b/src/collect.cc
@@ -925,7 +925,7 @@ static gboolean collection_window_keypress(GtkWidget *, GdkEventKey *event, gpoi
 				file_util_delete(nullptr, collection_table_selection_get_list(cw->table), cw->window, TRUE);
 				break;
 			case 'S': case 's':
-				collection_dialog_save_as(cw->cd);
+				collection_dialog_save(cw->cd);
 				break;
 			case 'W': case 'w':
 				collection_window_close(cw);
@@ -950,7 +950,7 @@ static gboolean collection_window_keypress(GtkWidget *, GdkEventKey *event, gpoi
 			case 'S': case 's':
 				if (!cw->cd->path)
 					{
-					collection_dialog_save_as(cw->cd);
+					collection_dialog_save(cw->cd);
 					}
 				else if (!collection_save(cw->cd, cw->cd->path))
 					{
@@ -1116,7 +1116,7 @@ static void collection_close_save_cb(GenericDialog *gd, gpointer data)
 
 	if (!cw->cd->path)
 		{
-		collection_dialog_save_close(cw->cd);
+		collection_dialog_save(cw->cd);
 		return;
 		}
 


### PR DESCRIPTION
Remove unused enum.
Inline `collection_save_confirmed()`.
Reduce code duplication.
Remove unused includes.