### PR TITLE
Fix path to po files in translators.sh

### DIFF
--- a/scripts/translators.sh
+++ b/scripts/translators.sh
@@ -45,7 +45,7 @@ shift
 while [ -n "$1" ]
 do
 	base=$(basename "$1")
-	full_file_path="$source_dir/$1"
+	full_file_path="$source_dir/$base"
 	locale=${base%.po}
 
 	awk -W posix 'BEGIN {LINT = "fatal"} {if ((NF > 0) && ($1 == "'"$locale"'")) {print $0}}' "$locales"


### PR DESCRIPTION
Fixes the following error:

```
[52/196] /build/geeqie-git/src/geeqie/scripts/translators.sh /build/geeqie-git/src/build/po /build/geeqie-git/src/geeqie/po ../geeqie/po/locales.txt ../geeqie/po/ar.po ../geeqie/po/be.po ../geeqie/po/bg.po ../geeqie/po/ca.po ../geeqie/po/cs.po ../geeqie/po/da.po ../geeqie/po/de.po ../geeqie/po/el.po ../geeqie/po/en_GB.po ../geeqie/po/eo.po ../geeqie/po/es.po ../geeqie/po/et.po ../geeqie/po/eu.po ../geeqie/po/fi.po ../geeqie/po/fr.po ../geeqie/po/hu.po ../geeqie/po/id.po ../geeqie/po/it.po ../geeqie/po/ja.po ../geeqie/po/ko.po ../geeqie/po/nb.po ../geeqie/po/nl.po ../geeqie/po/pl.po ../geeqie/po/pt_BR.po ../geeqie/po/ro.po ../geeqie/po/ru.po ../geeqie/po/sk.po ../geeqie/po/sl.po ../geeqie/po/sr@latin.po ../geeqie/po/sr.po ../geeqie/po/sv.po ../geeqie/po/th.po ../geeqie/po/tlh.po ../geeqie/po/tr.po ../geeqie/po/uk.po ../geeqie/po/vi.po ../geeqie/po/zh_CN.po ../geeqie/po/zh_TW.po
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/ar.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/be.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/bg.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/ca.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/cs.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/da.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/de.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/el.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/en_GB.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/eo.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/es.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/et.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/eu.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/fi.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/fr.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/hu.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/id.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/it.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/ja.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/ko.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/nb.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/nl.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/pl.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/pt_BR.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/ro.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/ru.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/sk.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/sl.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/sr@latin.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/sr.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/sv.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/th.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/tlh.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/tr.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/uk.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/vi.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/zh_CN.po' for reading: No such file or directory
awk: cmd. line:1: fatal: cannot open file `/build/geeqie-git/src/geeqie/po/../geeqie/po/zh_TW.po' for reading: No such file or directory
```