### PR TITLE
Fix build on NetBSD with gcc 14.

### DIFF
--- a/src/command-line-handling.cc
+++ b/src/command-line-handling.cc
@@ -20,6 +20,7 @@
 
 #include "command-line-handling.h"
 
+#include <cmath>
 #include <cstdlib>
 #include <vector>
 


### PR DESCRIPTION
error: 'abs' is not a member of 'std'; did you mean 'abs'?

```
../src/command-line-handling.cc: In function 'void {anonymous}::gq_get_rectangle(GtkApplication*, GApplicationCommandLine*, GVariantDict*, GList*)':
../src/command-line-handling.cc:818:65: error: 'abs' is not a member of 'std'; did you mean 'abs'?
  818 |                                                            std::abs(x1 - x2),
      |                                                                 ^~~
```
