### PR TITLE
Move MouseButton enum to ui-misc

### DIFF
--- a/src/bar-exif.cc
+++ b/src/bar-exif.cc
@@ -650,7 +650,7 @@ void bar_pane_exif_menu_popup(GtkWidget *widget, PaneExifData *ped)
 gboolean bar_pane_exif_menu_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer data)
 {
 	auto ped = static_cast<PaneExifData *>(data);
-	if (bevent->button == MOUSE_BUTTON_RIGHT)
+	if (bevent->button == GDK_BUTTON_SECONDARY)
 		{
 		bar_pane_exif_menu_popup(widget, ped);
 		return TRUE;
@@ -671,7 +671,7 @@ gboolean bar_pane_exif_copy_cb(GtkWidget *widget, GdkEventButton *bevent, gpoint
 	GtkClipboard *clipboard;
 	ExifEntry *ee;
 
-	if (bevent->button == MOUSE_BUTTON_LEFT)
+	if (bevent->button == GDK_BUTTON_PRIMARY)
 		{
 		ee = static_cast<ExifEntry *>(g_object_get_data(G_OBJECT(widget), "entry_data"));
 		value = gtk_label_get_text(GTK_LABEL(ee->value_widget));

--- a/src/bar-gps.cc
+++ b/src/bar-gps.cc
@@ -310,7 +310,7 @@ gboolean bar_pane_gps_marker_keypress_cb(GtkWidget *widget, ClutterButtonEvent *
 	GdkPixbufRotation rotate;
 	ThumbLoader *tl;
 
-	if (bevent->button == MOUSE_BUTTON_LEFT)
+	if (bevent->button == GDK_BUTTON_PRIMARY)
 		{
 		label_marker = CLUTTER_ACTOR(widget);
 		fd = static_cast<FileData *>(g_object_get_data(G_OBJECT(label_marker), "file_fd"));
@@ -814,20 +814,20 @@ gboolean bar_pane_gps_map_keypress_cb(GtkWidget *, GdkEventButton *bevent, gpoin
 	GtkWidget *menu;
 	GtkClipboard *clipboard;
 
-	if (bevent->button == MOUSE_BUTTON_RIGHT)
+	if (bevent->button == GDK_BUTTON_SECONDARY)
 		{
 		menu = bar_pane_gps_menu(pgd);
 		gtk_menu_popup_at_pointer(GTK_MENU(menu), nullptr);
 		return TRUE;
 		}
 
-	if (bevent->button == MOUSE_BUTTON_MIDDLE)
+	if (bevent->button == GDK_BUTTON_MIDDLE)
 		{
 		bar_pane_gps_map_centreing(pgd);
 		return TRUE;
 		}
 
-	if (bevent->button == MOUSE_BUTTON_LEFT)
+	if (bevent->button == GDK_BUTTON_PRIMARY)
 		{
 		clipboard = gtk_clipboard_get(GDK_SELECTION_PRIMARY);
 		g_autofree gchar *geo_coords = g_strdup_printf("%f %f",

--- a/src/bar-histogram.cc
+++ b/src/bar-histogram.cc
@@ -21,11 +21,12 @@
 
 #include "bar-histogram.h"
 
+#include <string>
+
 #include <cairo.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gdk/gdk.h>
 #include <glib-object.h>
-#include <string>
 
 #include <config.h>
 
@@ -35,7 +36,6 @@
 #include "histogram.h"
 #include "intl.h"
 #include "rcfile.h"
-#include "typedefs.h"
 #include "ui-menu.h"
 #include "ui-misc.h"
 
@@ -302,7 +302,7 @@ static GtkWidget *bar_pane_histogram_new(const gchar *id, const gchar *title, gi
 #else
 	gesture = gtk_gesture_multi_press_new(phd->drawing_area);
 #endif
-	gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(gesture), MOUSE_BUTTON_RIGHT);
+	gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(gesture), GDK_BUTTON_SECONDARY);
 	g_signal_connect(gesture, "pressed", G_CALLBACK(bar_pane_histogram_press_cb), phd);
 
 	gtk_widget_show(phd->widget);

--- a/src/bar-keywords.cc
+++ b/src/bar-keywords.cc
@@ -1333,7 +1333,7 @@ void bar_pane_keywords_menu_popup(GtkWidget *, PaneKeywordsData *pkd, gint x, gi
 gboolean bar_pane_keywords_menu_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer data)
 {
 	auto pkd = static_cast<PaneKeywordsData *>(data);
-	if (bevent->button == MOUSE_BUTTON_RIGHT)
+	if (bevent->button == GDK_BUTTON_SECONDARY)
 		{
 		bar_pane_keywords_menu_popup(widget, pkd, bevent->x, bevent->y);
 		return TRUE;

--- a/src/bar-sort.cc
+++ b/src/bar-sort.cc
@@ -37,7 +37,6 @@
 #include "layout.h"
 #include "main-defines.h"
 #include "rcfile.h"
-#include "typedefs.h"
 #include "ui-bookmark.h"
 #include "ui-file-chooser.h"
 #include "ui-fileops.h"
@@ -374,7 +373,7 @@ static void bar_filter_help_dialog()
 
 static gboolean bar_filter_message_cb(GtkWidget *, GdkEventButton *event, gpointer)
 {
-	if (event->button != MOUSE_BUTTON_RIGHT) return FALSE;
+	if (event->button != GDK_BUTTON_SECONDARY) return FALSE;
 
 	bar_filter_help_dialog();
 

--- a/src/bar.cc
+++ b/src/bar.cc
@@ -36,7 +36,6 @@
 #include "menu.h"
 #include "metadata.h"
 #include "rcfile.h"
-#include "typedefs.h"
 #include "ui-menu.h"
 #include "ui-misc.h"
 
@@ -353,7 +352,7 @@ static void bar_menu_popup(GtkWidget *widget)
 
 static gboolean bar_menu_expander_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer)
 {
-	if (bevent->button == MOUSE_BUTTON_RIGHT)
+	if (bevent->button == GDK_BUTTON_SECONDARY)
 		{
 		bar_menu_popup(widget);
 		return TRUE;

--- a/src/collect-table.cc
+++ b/src/collect-table.cc
@@ -1574,7 +1574,7 @@ static gboolean collection_table_press_cb(GtkWidget *, GdkEventButton *bevent, g
 
 	switch (bevent->button)
 		{
-		case MOUSE_BUTTON_LEFT:
+		case GDK_BUTTON_PRIMARY:
 			if (bevent->type == GDK_2BUTTON_PRESS)
 				{
 				if (info)
@@ -1587,7 +1587,7 @@ static gboolean collection_table_press_cb(GtkWidget *, GdkEventButton *bevent, g
 				gtk_widget_grab_focus(ct->listview);
 				}
 			break;
-		case MOUSE_BUTTON_RIGHT:
+		case GDK_BUTTON_SECONDARY:
 			ct->popup = collection_table_popup_menu(ct, (info != nullptr));
 			gtk_menu_popup_at_pointer(GTK_MENU(ct->popup), nullptr);
 			break;
@@ -1616,7 +1616,7 @@ static gboolean collection_table_release_cb(GtkWidget *, GdkEventButton *bevent,
 		collection_table_selection_remove(ct, ct->click_info, SELECTION_PRELIGHT, nullptr);
 		}
 
-	if (bevent->button == MOUSE_BUTTON_LEFT &&
+	if (bevent->button == GDK_BUTTON_PRIMARY &&
 	    info && ct->click_info == info)
 		{
 		collection_table_set_focus(ct, info);
@@ -1649,7 +1649,7 @@ static gboolean collection_table_release_cb(GtkWidget *, GdkEventButton *bevent,
 				}
 			}
 		}
-	else if (bevent->button == MOUSE_BUTTON_MIDDLE &&
+	else if (bevent->button == GDK_BUTTON_MIDDLE &&
 		 info && ct->click_info == info)
 		{
 		collection_table_select_util(ct, info, !info_selected(info));

--- a/src/dupe.cc
+++ b/src/dupe.cc
@@ -54,7 +54,6 @@
 #include "print.h"
 #include "similar.h"
 #include "thumb.h"
-#include "typedefs.h"
 #include "ui-file-chooser.h"
 #include "ui-fileops.h"
 #include "ui-menu.h"
@@ -3329,7 +3328,7 @@ static gboolean dupe_listview_press_cb(GtkWidget *widget, GdkEventButton *bevent
 
 	dw->click_item = di;
 
-	if (bevent->button == MOUSE_BUTTON_RIGHT)
+	if (bevent->button == GDK_BUTTON_SECONDARY)
 		{
 		/* right click menu */
 		GtkWidget *menu;
@@ -3352,15 +3351,15 @@ static gboolean dupe_listview_press_cb(GtkWidget *widget, GdkEventButton *bevent
 
 	if (!di) return FALSE;
 
-	if (bevent->button == MOUSE_BUTTON_LEFT &&
+	if (bevent->button == GDK_BUTTON_PRIMARY &&
 	    bevent->type == GDK_2BUTTON_PRESS)
 		{
 		dupe_menu_view(di, widget, FALSE);
 		}
 
-	if (bevent->button == MOUSE_BUTTON_MIDDLE) return TRUE;
+	if (bevent->button == GDK_BUTTON_MIDDLE) return TRUE;
 
-	if (bevent->button == MOUSE_BUTTON_RIGHT)
+	if (bevent->button == GDK_BUTTON_SECONDARY)
 		{
 		if (!dupe_listview_item_is_selected(di, widget))
 			{
@@ -3378,7 +3377,7 @@ static gboolean dupe_listview_press_cb(GtkWidget *widget, GdkEventButton *bevent
 		return TRUE;
 		}
 
-	if (bevent->button == MOUSE_BUTTON_LEFT &&
+	if (bevent->button == GDK_BUTTON_PRIMARY &&
 	    bevent->type == GDK_BUTTON_PRESS &&
 	    !(bevent->state & GDK_SHIFT_MASK ) &&
 	    !(bevent->state & GDK_CONTROL_MASK ) &&
@@ -3400,7 +3399,7 @@ static gboolean dupe_listview_release_cb(GtkWidget *widget, GdkEventButton *beve
 	GtkTreeIter iter;
 	DupeItem *di = nullptr;
 
-	if (bevent->button != MOUSE_BUTTON_LEFT && bevent->button != MOUSE_BUTTON_MIDDLE) return TRUE;
+	if (bevent->button != GDK_BUTTON_PRIMARY && bevent->button != GDK_BUTTON_MIDDLE) return TRUE;
 
 	store = gtk_tree_view_get_model(GTK_TREE_VIEW(widget));
 
@@ -3413,7 +3412,7 @@ static gboolean dupe_listview_release_cb(GtkWidget *widget, GdkEventButton *beve
 		gtk_tree_path_free(tpath);
 		}
 
-	if (bevent->button == MOUSE_BUTTON_MIDDLE)
+	if (bevent->button == GDK_BUTTON_MIDDLE)
 		{
 		if (di && dw->click_item == di)
 			{

--- a/src/image.cc
+++ b/src/image.cc
@@ -130,7 +130,7 @@ static void image_cache_set(ImageWindow *imd, FileData *fd);
 static void image_click_cb(PixbufRenderer *, GdkEventButton *event, gpointer data)
 {
 	auto imd = static_cast<ImageWindow *>(data);
-	if (!options->image_lm_click_nav && event->button == MOUSE_BUTTON_MIDDLE)
+	if (!options->image_lm_click_nav && event->button == GDK_BUTTON_MIDDLE)
 		{
 		imd->mouse_wheel_mode = !imd->mouse_wheel_mode;
 		}
@@ -232,7 +232,7 @@ static void image_press_cb(PixbufRenderer *pr, GdkEventButton *event, gpointer d
 		lw = get_current_layout();
 		}
 
-	if (lw && event->button == MOUSE_BUTTON_LEFT && event->type == GDK_2BUTTON_PRESS
+	if (lw && event->button == GDK_BUTTON_PRIMARY && event->type == GDK_2BUTTON_PRESS
 												&& !options->image_lm_click_nav)
 		{
 		layout_image_full_screen_toggle(lw);

--- a/src/img-view.cc
+++ b/src/img-view.cc
@@ -387,7 +387,7 @@ static void view_window_press_cb(GtkWidget *, GdkEventButton *bevent, gpointer d
 
 	switch (bevent->button)
 		{
-		case MOUSE_BUTTON_LEFT:
+		case GDK_BUTTON_PRIMARY:
 			if (bevent->type == GDK_2BUTTON_PRESS)
 				{
 				view_fullscreen_toggle(vw, TRUE);
@@ -646,7 +646,7 @@ static void button_cb(ImageWindow *imd, GdkEventButton *event, gpointer data)
 
 	switch (event->button)
 		{
-		case MOUSE_BUTTON_LEFT:
+		case GDK_BUTTON_PRIMARY:
 			if (options->image_l_click_archive && imd->image_fd->format_class == FORMAT_CLASS_ARCHIVE)
 				{
 				g_autofree gchar *dest_dir = open_archive(imd->image_fd);
@@ -667,11 +667,11 @@ static void button_cb(ImageWindow *imd, GdkEventButton *event, gpointer data)
 			else if (options->image_lm_click_nav)
 				view_step_next(vw);
 			break;
-		case MOUSE_BUTTON_MIDDLE:
+		case GDK_BUTTON_MIDDLE:
 			if (options->image_lm_click_nav)
 				view_step_prev(vw);
 			break;
-		case MOUSE_BUTTON_RIGHT:
+		case GDK_BUTTON_SECONDARY:
 			menu = view_popup_menu(vw);
 			gtk_menu_popup_at_pointer(GTK_MENU(menu), nullptr);
 			break;

--- a/src/layout-image.cc
+++ b/src/layout-image.cc
@@ -1744,7 +1744,7 @@ static void layout_image_button_cb(ImageWindow *imd, GdkEventButton *event, gpoi
 
 	switch (event->button)
 		{
-		case MOUSE_BUTTON_LEFT:
+		case GDK_BUTTON_PRIMARY:
 			if (event->type == GDK_2BUTTON_PRESS)
 				{
 				layout_image_full_screen_toggle(lw);
@@ -1770,11 +1770,11 @@ static void layout_image_button_cb(ImageWindow *imd, GdkEventButton *event, gpoi
 			else if (options->image_lm_click_nav && lw->split_mode == SPLIT_NONE)
 				layout_image_next(lw);
 			break;
-		case MOUSE_BUTTON_MIDDLE:
+		case GDK_BUTTON_MIDDLE:
 			if (options->image_lm_click_nav && lw->split_mode == SPLIT_NONE)
 				layout_image_prev(lw);
 			break;
-		case MOUSE_BUTTON_RIGHT:
+		case GDK_BUTTON_SECONDARY:
 			menu = layout_image_pop_menu(lw);
 			if (imd == lw->image)
 				{
@@ -1909,7 +1909,7 @@ static void layout_image_button_inactive_cb(ImageWindow *imd, GdkEventButton *ev
 
 	switch (event->button)
 		{
-		case MOUSE_BUTTON_RIGHT:
+		case GDK_BUTTON_SECONDARY:
 			menu = layout_image_pop_menu(lw);
 			if (imd == lw->image)
 				{

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -1556,7 +1556,7 @@ static void button_cb(PixbufRenderer *pr, GdkEventButton *event, gpointer data)
 		}
 
 	pi = pan_item_find_by_coord(pw, PAN_ITEM_BOX, rx, ry, "info");
-	if (pi && event->button == MOUSE_BUTTON_LEFT)
+	if (pi && event->button == GDK_BUTTON_PRIMARY)
 		{
 		pan_info_update(pw, nullptr);
 		return;
@@ -1567,7 +1567,7 @@ static void button_cb(PixbufRenderer *pr, GdkEventButton *event, gpointer data)
 
 	switch (event->button)
 		{
-		case MOUSE_BUTTON_LEFT:
+		case GDK_BUTTON_PRIMARY:
 			pan_info_update(pw, pi);
 
 			if (!pi && pw->layout == PAN_LAYOUT_CALENDAR)
@@ -1576,9 +1576,9 @@ static void button_cb(PixbufRenderer *pr, GdkEventButton *event, gpointer data)
 				pan_calendar_update(pw, pi);
 				}
 			break;
-		case MOUSE_BUTTON_MIDDLE:
+		case GDK_BUTTON_MIDDLE:
 			break;
-		case MOUSE_BUTTON_RIGHT:
+		case GDK_BUTTON_SECONDARY:
 			pan_info_update(pw, pi);
 			menu = pan_popup_menu(pw);
 			gtk_menu_popup_at_pointer(GTK_MENU(menu), nullptr);

--- a/src/pixbuf-renderer.cc
+++ b/src/pixbuf-renderer.cc
@@ -2050,7 +2050,7 @@ static gboolean pr_mouse_press_cb(GtkWidget *widget, GdkEventButton *bevent, gpo
 
 	switch (bevent->button)
 		{
-		case MOUSE_BUTTON_LEFT:
+		case GDK_BUTTON_PRIMARY:
 			pr->in_drag = TRUE;
 			pr->drag_last_x = bevent->x;
 			pr->drag_last_y = bevent->y;
@@ -2060,10 +2060,10 @@ static gboolean pr_mouse_press_cb(GtkWidget *widget, GdkEventButton *bevent, gpo
 			                    nullptr, nullptr, bevent->time);
 			gtk_grab_add(widget);
 			break;
-		case MOUSE_BUTTON_MIDDLE:
+		case GDK_BUTTON_MIDDLE:
 			pr->drag_moved = 0;
 			break;
-		case MOUSE_BUTTON_RIGHT:
+		case GDK_BUTTON_SECONDARY:
 			pr_clicked_signal(pr, bevent);
 			break;
 		default:
@@ -2100,11 +2100,11 @@ static gboolean pr_mouse_release_cb(GtkWidget *widget, GdkEventButton *bevent, g
 
 	if (pr->drag_moved < PR_DRAG_SCROLL_THRESHHOLD)
 		{
-		if (bevent->button == MOUSE_BUTTON_LEFT && (bevent->state & GDK_CONTROL_MASK))
+		if (bevent->button == GDK_BUTTON_PRIMARY && (bevent->state & GDK_CONTROL_MASK))
 			{
 			pr_scroller_start(pr, bevent->x, bevent->y);
 			}
-		else if (bevent->button == MOUSE_BUTTON_LEFT || bevent->button == MOUSE_BUTTON_MIDDLE)
+		else if (bevent->button == GDK_BUTTON_PRIMARY || bevent->button == GDK_BUTTON_MIDDLE)
 			{
 			pr_clicked_signal(pr, bevent);
 			}

--- a/src/search.cc
+++ b/src/search.cc
@@ -1239,7 +1239,7 @@ static gboolean search_result_press_cb(GtkWidget *widget, GdkEventButton *bevent
 
 	sd->click_fd = mfd ? mfd->fd : nullptr;
 
-	if (bevent->button == MOUSE_BUTTON_RIGHT)
+	if (bevent->button == GDK_BUTTON_SECONDARY)
 		{
 		GtkWidget *menu = search_result_menu(sd, mfd != nullptr, search_result_count(sd) == 0);
 		gtk_menu_popup_at_pointer(GTK_MENU(menu), nullptr);
@@ -1247,14 +1247,14 @@ static gboolean search_result_press_cb(GtkWidget *widget, GdkEventButton *bevent
 
 	if (!mfd) return FALSE;
 
-	if (bevent->button == MOUSE_BUTTON_LEFT && bevent->type == GDK_2BUTTON_PRESS)
+	if (bevent->button == GDK_BUTTON_PRIMARY && bevent->type == GDK_2BUTTON_PRESS)
 		{
 		layout_set_fd(nullptr, mfd->fd);
 		}
 
-	if (bevent->button == MOUSE_BUTTON_MIDDLE) return TRUE;
+	if (bevent->button == GDK_BUTTON_MIDDLE) return TRUE;
 
-	if (bevent->button == MOUSE_BUTTON_RIGHT)
+	if (bevent->button == GDK_BUTTON_SECONDARY)
 		{
 		if (!search_result_row_selected(sd, mfd->fd))
 			{
@@ -1271,7 +1271,7 @@ static gboolean search_result_press_cb(GtkWidget *widget, GdkEventButton *bevent
 		return TRUE;
 		}
 
-	if (bevent->button == MOUSE_BUTTON_LEFT && bevent->type == GDK_BUTTON_PRESS &&
+	if (bevent->button == GDK_BUTTON_PRIMARY && bevent->type == GDK_BUTTON_PRESS &&
 	    !(bevent->state & GDK_SHIFT_MASK ) &&
 	    !(bevent->state & GDK_CONTROL_MASK ) &&
 	    search_result_row_selected(sd, mfd->fd))
@@ -1293,7 +1293,7 @@ static gboolean search_result_release_cb(GtkWidget *widget, GdkEventButton *beve
 
 	MatchFileData *mfd = nullptr;
 
-	if (bevent->button != MOUSE_BUTTON_LEFT && bevent->button != MOUSE_BUTTON_MIDDLE) return TRUE;
+	if (bevent->button != GDK_BUTTON_PRIMARY && bevent->button != GDK_BUTTON_MIDDLE) return TRUE;
 
 	store = gtk_tree_view_get_model(GTK_TREE_VIEW(widget));
 
@@ -1306,7 +1306,7 @@ static gboolean search_result_release_cb(GtkWidget *widget, GdkEventButton *beve
 		gtk_tree_path_free(tpath);
 		}
 
-	if (bevent->button == MOUSE_BUTTON_MIDDLE)
+	if (bevent->button == GDK_BUTTON_MIDDLE)
 		{
 		if (mfd && sd->click_fd == mfd->fd)
 			{

--- a/src/toolbar.cc
+++ b/src/toolbar.cc
@@ -110,7 +110,7 @@ static void toolbarlist_add_button(const gchar *name, const gchar *label,
 #else
 	gesture = gtk_gesture_multi_press_new(button);
 #endif
-	gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(gesture), MOUSE_BUTTON_RIGHT);
+	gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(gesture), GDK_BUTTON_SECONDARY);
 	g_signal_connect(gesture, "released", G_CALLBACK(toolbar_press_cb), button);
 
 	GtkWidget *image;

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -26,16 +26,6 @@
 
 #include <glib.h>
 
-enum MouseButton {
-	MOUSE_BUTTON_LEFT	= 1,
-	MOUSE_BUTTON_MIDDLE	= 2,
-	MOUSE_BUTTON_RIGHT	= 3,
-	MOUSE_BUTTON_WHEEL_UP	= 4,
-	MOUSE_BUTTON_WHEEL_DOWN	= 5,
-	MOUSE_BUTTON_8	= 8,
-	MOUSE_BUTTON_9	= 9
-};
-
 enum SortType {
 	SORT_NONE,
 	SORT_NAME,

--- a/src/ui-bookmark.cc
+++ b/src/ui-bookmark.cc
@@ -37,7 +37,6 @@
 #include "main-defines.h"
 #include "misc.h"
 #include "pixbuf-util.h"
-#include "typedefs.h"
 #include "ui-file-chooser.h"
 #include "ui-fileops.h"
 #include "ui-menu.h"
@@ -404,7 +403,7 @@ static gboolean bookmark_press_cb(GtkWidget *button, GdkEventButton *event, gpoi
 {
 	auto bm = static_cast<BookMarkData *>(data);
 
-	if (event->button != MOUSE_BUTTON_RIGHT) return FALSE;
+	if (event->button != GDK_BUTTON_SECONDARY) return FALSE;
 
 	bookmark_menu_popup(bm, button, event->button, event->time, FALSE);
 

--- a/src/ui-misc.cc
+++ b/src/ui-misc.cc
@@ -1379,13 +1379,14 @@ std::vector<ActionItem> get_action_items()
 
 bool defined_mouse_buttons(GdkEventButton *event, gpointer data)
 {
-	bool ret = false;
+	enum MouseButton {
+		MOUSE_BUTTON_8 = 8,
+		MOUSE_BUTTON_9 = 9
+	};
 
-	const auto handle_button = [data](const gchar *action_name)
+	const auto handle_button = [lw = static_cast<LayoutWindow *>(data)](const gchar *action_name)
 	{
 		if (!action_name) return false;
-
-		auto *lw = static_cast<LayoutWindow *>(data);
 
 		if (g_strstr_len(action_name, -1, ".desktop") != nullptr)
 			{
@@ -1406,16 +1407,12 @@ bool defined_mouse_buttons(GdkEventButton *event, gpointer data)
 	switch (event->button)
 		{
 		case MOUSE_BUTTON_8:
-			ret = handle_button(options->mouse_button_8);
-			break;
+			return handle_button(options->mouse_button_8);
 		case MOUSE_BUTTON_9:
-			ret = handle_button(options->mouse_button_9);
-			break;
+			return handle_button(options->mouse_button_9);
 		default:
-			break;
+			return false;
 		}
-
-	return ret;
 }
 
 GdkPixbuf *gq_gtk_icon_theme_load_icon_copy(GtkIconTheme *icon_theme, const gchar *icon_name, gint size, GtkIconLookupFlags flags)

--- a/src/view-dir-list.cc
+++ b/src/view-dir-list.cc
@@ -402,7 +402,7 @@ gboolean vdlist_press_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer dat
 	if (options->view_dir_list_single_click_enter)
 		vd_color_set(vd, vd->click_fd, TRUE);
 
-	if (bevent->button == MOUSE_BUTTON_RIGHT)
+	if (bevent->button == GDK_BUTTON_SECONDARY)
 		{
 		vd->popup = vd_pop_menu(vd, vd->click_fd);
 		gtk_menu_popup_at_pointer(GTK_MENU(vd->popup), nullptr);

--- a/src/view-dir-tree.cc
+++ b/src/view-dir-tree.cc
@@ -834,7 +834,7 @@ gboolean vdtree_press_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer dat
 			/* clicking this region should automatically reveal an expander, if necessary
 			 * treeview bug: the expander will not expand until a button_motion_event highlights it.
 			 */
-			if (bevent->button == MOUSE_BUTTON_LEFT &&
+			if (bevent->button == GDK_BUTTON_PRIMARY &&
 			    !left_of_expander &&
 			    !gtk_tree_view_row_expanded(GTK_TREE_VIEW(vd->view), tpath))
 				{
@@ -861,13 +861,13 @@ gboolean vdtree_press_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer dat
 	vd->click_fd = (nd) ? nd->fd : nullptr;
 	vd_color_set(vd, vd->click_fd, TRUE);
 
-	if (bevent->button == MOUSE_BUTTON_RIGHT)
+	if (bevent->button == GDK_BUTTON_SECONDARY)
 		{
 		vd->popup = vd_pop_menu(vd, vd->click_fd);
 		gtk_menu_popup_at_pointer(GTK_MENU(vd->popup), nullptr);
 		}
 
-	return (bevent->button != MOUSE_BUTTON_LEFT);
+	return (bevent->button != GDK_BUTTON_PRIMARY);
 }
 
 static void vdtree_row_expanded(GtkTreeView *treeview, GtkTreeIter *iter, GtkTreePath *tpath, gpointer data)

--- a/src/view-dir.cc
+++ b/src/view-dir.cc
@@ -1117,7 +1117,7 @@ gboolean vd_release_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer data)
 	if (!vd->click_fd) return FALSE;
 	vd_color_set(vd, vd->click_fd, FALSE);
 
-	if (bevent->button != MOUSE_BUTTON_LEFT) return TRUE;
+	if (bevent->button != GDK_BUTTON_PRIMARY) return TRUE;
 
 	if ((bevent->x != 0 || bevent->y != 0) &&
 	    gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(widget), bevent->x, bevent->y,
@@ -1159,7 +1159,7 @@ gboolean vd_press_cb(GtkWidget *widget, GdkEventButton *bevent, gpointer data)
 	NodeData *nd = nullptr;
 	GtkTreeModel *store;
 
-	if (bevent->button == MOUSE_BUTTON_RIGHT)
+	if (bevent->button == GDK_BUTTON_SECONDARY)
 		{
 		if (gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(widget), bevent->x, bevent->y, &tpath, nullptr, nullptr, nullptr))
 			{

--- a/src/view-file/view-file-icon.cc
+++ b/src/view-file/view-file-icon.cc
@@ -1191,7 +1191,7 @@ gboolean vficon_press_cb(ViewFile *vf, GtkWidget *, GdkEventButton *bevent)
 
 		switch (bevent->button)
 			{
-			case MOUSE_BUTTON_LEFT:
+			case GDK_BUTTON_PRIMARY:
 				if (!gtk_widget_has_focus(vf->listview))
 					{
 					gtk_widget_grab_focus(vf->listview);
@@ -1210,7 +1210,7 @@ gboolean vficon_press_cb(ViewFile *vf, GtkWidget *, GdkEventButton *bevent)
 						}
 					}
 				break;
-			case MOUSE_BUTTON_RIGHT:
+			case GDK_BUTTON_SECONDARY:
 				vf->popup = vf_pop_menu(vf);
 				gtk_menu_popup_at_pointer(GTK_MENU(vf->popup), nullptr);
 				break;
@@ -1251,7 +1251,7 @@ gboolean vficon_release_cb(ViewFile *vf, GtkWidget *, GdkEventButton *bevent)
 
 	switch (bevent->button)
 		{
-		case MOUSE_BUTTON_LEFT:
+		case GDK_BUTTON_PRIMARY:
 			{
 			vficon_set_focus(vf, fd);
 
@@ -1285,7 +1285,7 @@ gboolean vficon_release_cb(ViewFile *vf, GtkWidget *, GdkEventButton *bevent)
 				}
 			}
 			break;
-		case MOUSE_BUTTON_MIDDLE:
+		case GDK_BUTTON_MIDDLE:
 			{
 			vficon_select_util(vf, fd, !(fd->selected & SELECTION_SELECTED));
 			}

--- a/src/view-file/view-file-list.cc
+++ b/src/view-file/view-file-list.cc
@@ -463,7 +463,7 @@ gboolean vflist_press_cb(ViewFile *vf, GtkWidget *widget, GdkEventButton *bevent
 		GtkTreeModel *store;
 		gint col_idx = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(column), "column_store_idx"));
 
-		if (bevent->button == MOUSE_BUTTON_LEFT &&
+		if (bevent->button == GDK_BUTTON_PRIMARY &&
 		    col_idx >= FILE_COLUMN_MARKS && col_idx <= FILE_COLUMN_MARKS_LAST)
 			return FALSE;
 
@@ -479,7 +479,7 @@ gboolean vflist_press_cb(ViewFile *vf, GtkWidget *widget, GdkEventButton *bevent
 
 	vf->click_fd = fd;
 
-	if (bevent->button == MOUSE_BUTTON_RIGHT)
+	if (bevent->button == GDK_BUTTON_SECONDARY)
 		{
 		vf->popup = vf_pop_menu(vf);
 		gtk_menu_popup_at_pointer(GTK_MENU(vf->popup), nullptr);
@@ -488,7 +488,7 @@ gboolean vflist_press_cb(ViewFile *vf, GtkWidget *widget, GdkEventButton *bevent
 
 	if (!fd) return FALSE;
 
-	if (bevent->button == MOUSE_BUTTON_MIDDLE)
+	if (bevent->button == GDK_BUTTON_MIDDLE)
 		{
 		if (!vflist_row_is_selected(vf, fd))
 			{
@@ -498,7 +498,7 @@ gboolean vflist_press_cb(ViewFile *vf, GtkWidget *widget, GdkEventButton *bevent
 		}
 
 
-	if (bevent->button == MOUSE_BUTTON_LEFT && bevent->type == GDK_BUTTON_PRESS &&
+	if (bevent->button == GDK_BUTTON_PRIMARY && bevent->type == GDK_BUTTON_PRESS &&
 	    !(bevent->state & GDK_SHIFT_MASK ) &&
 	    !(bevent->state & GDK_CONTROL_MASK ) &&
 	    vflist_row_is_selected(vf, fd))
@@ -516,7 +516,7 @@ gboolean vflist_press_cb(ViewFile *vf, GtkWidget *widget, GdkEventButton *bevent
 		return (gtk_tree_selection_count_selected_rows(selection) > 1);
 		}
 
-	if (bevent->button == MOUSE_BUTTON_LEFT && bevent->type == GDK_2BUTTON_PRESS)
+	if (bevent->button == GDK_BUTTON_PRIMARY && bevent->type == GDK_2BUTTON_PRESS)
 		{
 		if (vf->click_fd->format_class == FORMAT_CLASS_COLLECTION)
 			{
@@ -542,12 +542,12 @@ gboolean vflist_release_cb(ViewFile *vf, GtkWidget *widget, GdkEventButton *beve
 		return TRUE;
 		}
 
-	if (bevent->button == MOUSE_BUTTON_MIDDLE)
+	if (bevent->button == GDK_BUTTON_MIDDLE)
 		{
 		vflist_color_set(vf, vf->click_fd, FALSE);
 		}
 
-	if (bevent->button != MOUSE_BUTTON_LEFT && bevent->button != MOUSE_BUTTON_MIDDLE)
+	if (bevent->button != GDK_BUTTON_PRIMARY && bevent->button != GDK_BUTTON_MIDDLE)
 		{
 		return TRUE;
 		}
@@ -564,7 +564,7 @@ gboolean vflist_release_cb(ViewFile *vf, GtkWidget *widget, GdkEventButton *beve
 		gtk_tree_path_free(tpath);
 		}
 
-	if (bevent->button == MOUSE_BUTTON_MIDDLE)
+	if (bevent->button == GDK_BUTTON_MIDDLE)
 		{
 		if (fd && vf->click_fd == fd)
 			{

--- a/src/view-file/view-file.cc
+++ b/src/view-file/view-file.cc
@@ -949,7 +949,7 @@ static gboolean vf_marks_tooltip_cb(GtkWidget *widget,
 	GtkWidget *table;
 	gint i = GPOINTER_TO_INT(user_data);
 
-	if (event->button != MOUSE_BUTTON_RIGHT)
+	if (event->button != GDK_BUTTON_SECONDARY)
 		return FALSE;
 
 	auto mte = g_new0(MarksTextEntry, 1);


### PR DESCRIPTION
Replace `MOUSE_BUTTON_LEFT`, `MOUSE_BUTTON_MIDDLE`, `MOUSE_BUTTON_RIGHT` with `GDK_BUTTON_PRIMARY`, `GDK_BUTTON_MIDDLE`, `GDK_BUTTON_SECONDARY`.

Remove unused `MOUSE_BUTTON_WHEEL_UP`, `MOUSE_BUTTON_WHEEL_DOWN`.