### PR TITLE
Drop redundant GTK_TREE_SELECTION macros

### DIFF
--- a/src/collect-table.cc
+++ b/src/collect-table.cc
@@ -2486,7 +2486,6 @@ CollectTable *collection_table_new(CollectionData *cd)
 {
 	CollectTable *ct;
 	GtkListStore *store;
-	GtkTreeSelection *selection;
 	gint i;
 
 	ct = g_new0(CollectTable, 1);
@@ -2505,8 +2504,8 @@ CollectTable *collection_table_new(CollectionData *cd)
 	ct->listview = gtk_tree_view_new_with_model(GTK_TREE_MODEL(store));
 	g_object_unref(store);
 
-	selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(ct->listview));
-	gtk_tree_selection_set_mode(GTK_TREE_SELECTION(selection), GTK_SELECTION_NONE);
+	GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(ct->listview));
+	gtk_tree_selection_set_mode(selection, GTK_SELECTION_NONE);
 
 	gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(ct->listview), FALSE);
 	gtk_tree_view_set_enable_search(GTK_TREE_VIEW(ct->listview), FALSE);

--- a/src/desktop-file.cc
+++ b/src/desktop-file.cc
@@ -379,17 +379,15 @@ void editor_list_window_help_cb(GtkWidget *, gpointer)
 	help_window_show("GuidePluginsConfig.html");
 }
 
-void editor_list_window_selection_changed_cb(GtkWidget *, gpointer data)
+void editor_list_window_selection_changed_cb(GtkTreeSelection *sel, gpointer user_data)
 {
-	auto ewl = static_cast<EditorListWindow *>(data);
-	GtkTreeSelection *sel = gtk_tree_view_get_selection(GTK_TREE_VIEW(ewl->view));
 	GtkTreeIter iter;
-
 	if (!gtk_tree_selection_get_selected(sel, nullptr, &iter)) return;
 
+	auto *ewl = static_cast<EditorListWindow *>(user_data);
 	GtkTreeModel *store = gtk_tree_view_get_model(GTK_TREE_VIEW(ewl->view));
-	g_autofree gchar *path = nullptr;
 
+	g_autofree gchar *path = nullptr;
 	gtk_tree_model_get(store, &iter,
 	                   DESKTOP_FILE_COLUMN_PATH, &path,
 	                   -1);
@@ -499,7 +497,6 @@ void editor_list_window_create()
 	GtkWidget *button;
 	GtkWidget *scrolled;
 	GtkCellRenderer *renderer;
-	GtkTreeSelection *selection;
 	GtkTreeViewColumn *column;
 	GtkTreeModel *store;
 	GtkTreeSortable *sortable;
@@ -568,8 +565,8 @@ void editor_list_window_create()
 	gtk_widget_show(scrolled);
 
 	ewl->view = gtk_tree_view_new_with_model(GTK_TREE_MODEL(desktop_file_list));
-	selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(ewl->view));
-	gtk_tree_selection_set_mode(GTK_TREE_SELECTION(selection), GTK_SELECTION_SINGLE);
+	GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(ewl->view));
+	gtk_tree_selection_set_mode(selection, GTK_SELECTION_SINGLE);
  	g_signal_connect(selection, "changed", G_CALLBACK(editor_list_window_selection_changed_cb), ewl);
 
 	gtk_tree_view_set_enable_search(GTK_TREE_VIEW(ewl->view), FALSE);

--- a/src/dupe.cc
+++ b/src/dupe.cc
@@ -4275,7 +4275,6 @@ DupeWindow *dupe_window_new()
 	GtkWidget *label;
 	GtkWidget *button;
 	GtkListStore *store;
-	GtkTreeSelection *selection;
 	GdkGeometry geometry;
 
 	dw = g_new0(DupeWindow, 1);
@@ -4358,8 +4357,8 @@ DupeWindow *dupe_window_new()
 	gtk_tree_sortable_set_sort_func(dw->sortable, DUPE_COLUMN_DIMENSIONS, column_sort_cb, dw->sortable, nullptr);
 	gtk_tree_sortable_set_sort_func(dw->sortable, DUPE_COLUMN_PATH, column_sort_cb, dw->sortable, nullptr);
 
-	selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(dw->listview));
-	gtk_tree_selection_set_mode(GTK_TREE_SELECTION(selection), GTK_SELECTION_MULTIPLE);
+	GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(dw->listview));
+	gtk_tree_selection_set_mode(selection, GTK_SELECTION_MULTIPLE);
 	gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(dw->listview), TRUE);
 	gtk_tree_view_set_enable_search(GTK_TREE_VIEW(dw->listview), FALSE);
 
@@ -4404,7 +4403,7 @@ DupeWindow *dupe_window_new()
 	dw->second_listview = gtk_tree_view_new_with_model(GTK_TREE_MODEL(store));
 
 	selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(dw->second_listview));
-	gtk_tree_selection_set_mode(GTK_TREE_SELECTION(selection), GTK_SELECTION_MULTIPLE);
+	gtk_tree_selection_set_mode(selection, GTK_SELECTION_MULTIPLE);
 
 	gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(dw->second_listview), TRUE);
 	gtk_tree_view_set_enable_search(GTK_TREE_VIEW(dw->second_listview), FALSE);

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -2595,7 +2595,6 @@ static void config_tab_files(GtkWidget *notebook)
 	GtkWidget *scrolled;
 	GtkWidget *filter_view;
 	GtkCellRenderer *renderer;
-	GtkTreeSelection *selection;
 	GtkTreeViewColumn *column;
 
 	vbox = scrolled_notebook_page(notebook, _("File Filters"));
@@ -2637,8 +2636,9 @@ static void config_tab_files(GtkWidget *notebook)
 	filter_store = gtk_list_store_new(1, G_TYPE_POINTER);
 	filter_view = gtk_tree_view_new_with_model(GTK_TREE_MODEL(filter_store));
 	g_object_unref(filter_store);
-	selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(filter_view));
-	gtk_tree_selection_set_mode(GTK_TREE_SELECTION(selection), GTK_SELECTION_SINGLE);
+
+	GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(filter_view));
+	gtk_tree_selection_set_mode(selection, GTK_SELECTION_SINGLE);
 
 	gtk_tree_view_set_enable_search(GTK_TREE_VIEW(filter_view), FALSE);
 
@@ -3566,7 +3566,6 @@ static void config_tab_accelerators(GtkWidget *notebook)
 	GtkWidget *scrolled;
 	GtkWidget *accel_view;
 	GtkCellRenderer *renderer;
-	GtkTreeSelection *selection;
 	GtkTreeViewColumn *column;
 
 	vbox = scrolled_notebook_page(notebook, _("Keyboard"));
@@ -3583,8 +3582,9 @@ static void config_tab_accelerators(GtkWidget *notebook)
 
 	accel_view = gtk_tree_view_new_with_model(GTK_TREE_MODEL(accel_store));
 	g_object_unref(accel_store);
-	selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(accel_view));
-	gtk_tree_selection_set_mode(GTK_TREE_SELECTION(selection), GTK_SELECTION_MULTIPLE);
+
+	GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(accel_view));
+	gtk_tree_selection_set_mode(selection, GTK_SELECTION_MULTIPLE);
 
 	gtk_tree_view_set_enable_search(GTK_TREE_VIEW(accel_view), FALSE);
 

--- a/src/search.cc
+++ b/src/search.cc
@@ -3505,7 +3505,7 @@ void search_new(FileData *dir_fd, FileData *example_file)
 	gtk_widget_show(sd->ui.result_view);
 
 	GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(sd->ui.result_view));
-	gtk_tree_selection_set_mode(GTK_TREE_SELECTION(selection), GTK_SELECTION_MULTIPLE);
+	gtk_tree_selection_set_mode(selection, GTK_SELECTION_MULTIPLE);
 	gtk_tree_selection_set_select_function(selection, search_result_select_cb, sd, nullptr);
 
 	gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(sd->ui.result_view), TRUE);

--- a/src/utilops.cc
+++ b/src/utilops.cc
@@ -1808,7 +1808,6 @@ static GtkWidget *furm_simple_vlabel(GtkWidget *box, const gchar *text, gboolean
 static void file_util_dialog_init_source_dest(UtilityData *ud, gboolean second_image)
 {
 	GtkTreeModel *store;
-	GtkTreeSelection *selection;
 	GtkWidget *box;
 	GtkWidget *hbox;
 	GtkWidget *box2;
@@ -1843,8 +1842,8 @@ static void file_util_dialog_init_source_dest(UtilityData *ud, gboolean second_i
 
 	file_util_dialog_add_list_column(ud->listview, _("New name"), FALSE, UTILITY_COLUMN_DEST_NAME);
 
-	selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(ud->listview));
-	gtk_tree_selection_set_mode(GTK_TREE_SELECTION(selection), GTK_SELECTION_SINGLE);
+	GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(ud->listview));
+	gtk_tree_selection_set_mode(selection, GTK_SELECTION_SINGLE);
 	gtk_tree_selection_set_select_function(selection, file_util_preview_cb, ud, nullptr);
 
 	gtk_tree_view_set_reorderable(GTK_TREE_VIEW(ud->listview), TRUE);

--- a/src/view-file/view-file-icon.cc
+++ b/src/view-file/view-file-icon.cc
@@ -2048,7 +2048,6 @@ void vficon_destroy_cb(ViewFile *vf)
 ViewFile *vficon_new(ViewFile *vf)
 {
 	GtkListStore *store;
-	GtkTreeSelection *selection;
 	gint i;
 
 	vf->info = g_new0(ViewFileInfoIcon, 1);
@@ -2059,8 +2058,8 @@ ViewFile *vficon_new(ViewFile *vf)
 	vf->listview = gtk_tree_view_new_with_model(GTK_TREE_MODEL(store));
 	g_object_unref(store);
 
-	selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(vf->listview));
-	gtk_tree_selection_set_mode(GTK_TREE_SELECTION(selection), GTK_SELECTION_NONE);
+	GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(vf->listview));
+	gtk_tree_selection_set_mode(selection, GTK_SELECTION_NONE);
 
 	gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(vf->listview), FALSE);
 	gtk_tree_view_set_enable_search(GTK_TREE_VIEW(vf->listview), FALSE);

--- a/src/view-file/view-file-list.cc
+++ b/src/view-file/view-file-list.cc
@@ -1862,7 +1862,6 @@ void vflist_destroy_cb(ViewFile *vf)
 ViewFile *vflist_new(ViewFile *vf)
 {
 	GtkTreeStore *store;
-	GtkTreeSelection *selection;
 	GType flist_types[FILE_COLUMN_COUNT];
 	gint i;
 	gint column;
@@ -1895,8 +1894,8 @@ ViewFile *vflist_new(ViewFile *vf)
 	g_signal_connect(G_OBJECT(vf->listview), "row-collapsed",
 	                 G_CALLBACK(vflist_expand_cb<FALSE>), vf);
 
-	selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(vf->listview));
-	gtk_tree_selection_set_mode(GTK_TREE_SELECTION(selection), GTK_SELECTION_MULTIPLE);
+	GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(vf->listview));
+	gtk_tree_selection_set_mode(selection, GTK_SELECTION_MULTIPLE);
 	gtk_tree_selection_set_select_function(selection, vflist_select_cb, vf, nullptr);
 
 	gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(vf->listview), FALSE);


### PR DESCRIPTION
Simplify `GtkTreeSelection::changed` signal handler a bit.