### PR TITLE
Stop overwriting prepared image data

### DIFF
--- a/src/image-load.cc
+++ b/src/image-load.cc
@@ -528,32 +528,8 @@ static void image_loader_area_updated_cb(gpointer,
 	g_mutex_unlock(il->data_mutex);
 }
 
-static void image_loader_area_prepared_cb(gpointer, gpointer data)
+static void image_loader_area_prepared_cb(gpointer, gpointer)
 {
-	auto il = static_cast<ImageLoader *>(data);
-	GdkPixbuf *pb;
-	guchar *pix;
-	size_t h;
-	size_t rs;
-
-	/* a workaround for
-	   https://bugzilla.gnome.org/show_bug.cgi?id=547669
-	   https://bugzilla.gnome.org/show_bug.cgi?id=589334
-	*/
-	g_autofree gchar *format = il->backend->get_format_name();
-	if (strcmp(format, "svg") == 0 ||
-	    strcmp(format, "xpm") == 0)
-		{
-		return;
-		}
-
-	pb = il->backend->get_pixbuf();
-
-	h = gdk_pixbuf_get_height(pb);
-	rs = gdk_pixbuf_get_rowstride(pb);
-	pix = gdk_pixbuf_get_pixels(pb);
-
-	memset(pix, 0, rs * h); /*this should be faster than pixbuf_fill */
 }
 
 static void image_loader_size_cb(gpointer,


### PR DESCRIPTION
As mentioned in the bugs referenced, clearing the pixbuf in the prepared signal is not a valid thing to do.

See: https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/commit/75ac8deaf04f362efa5fc0ace51031350e70e8be
Closes: https://github.com/BestImageViewer/geeqie/issues/1921

[Added comment by @xsdg]
This is a version of #1928 with the "Don't remove PATH from tests" commit dropped.  Consequently, this should be considered a **partial fix** that will make the same code change as the original, but where the geeqie functional tests will still be broken with glycin (which is already the case, given the original bug)