### PR TITLE
Fix ImageLoader::size-prepared signal

### DIFF
--- a/src/image-load.h
+++ b/src/image-load.h
@@ -113,6 +113,7 @@ struct ImageLoaderClass {
 	void (*error)(ImageLoader *, gpointer);
 	void (*done)(ImageLoader *, gpointer);
 	void (*percent)(ImageLoader *, gdouble, gpointer);
+	void (*size_prepared)(ImageLoader *, gint width, gint height, gpointer);
 };
 
 GType image_loader_get_type();

--- a/src/image.cc
+++ b/src/image.cc
@@ -897,7 +897,7 @@ static void image_load_done_cb(ImageLoader *, gpointer data)
 	image_read_ahead_start(imd);
 }
 
-static void image_load_size_cb(ImageLoader *, guint width, guint height, gpointer data)
+static void image_load_size_prepared_cb(ImageLoader *, gint width, gint height, gpointer data)
 {
 	auto imd = static_cast<ImageWindow *>(data);
 
@@ -927,7 +927,7 @@ static void image_load_set_signals(ImageWindow *imd, gboolean override_old_signa
 	g_signal_connect(G_OBJECT(imd->il), "area_ready", (GCallback)image_load_area_cb, imd);
 	g_signal_connect(G_OBJECT(imd->il), "error", (GCallback)image_load_error_cb, imd);
 	g_signal_connect(G_OBJECT(imd->il), "done", (GCallback)image_load_done_cb, imd);
-	g_signal_connect(G_OBJECT(imd->il), "size_prepared", (GCallback)image_load_size_cb, imd);
+	g_signal_connect(G_OBJECT(imd->il), "size-prepared", G_CALLBACK(image_load_size_prepared_cb), imd);
 }
 
 /* this read ahead is located here merely for the callbacks, above */

--- a/src/pixbuf-renderer.cc
+++ b/src/pixbuf-renderer.cc
@@ -2949,7 +2949,7 @@ gboolean pixbuf_renderer_get_visible_rect(PixbufRenderer *pr, GdkRectangle *rect
 	return TRUE;
 }
 
-void pixbuf_renderer_set_size_early(PixbufRenderer *, guint, guint)
+void pixbuf_renderer_set_size_early(PixbufRenderer *, gint, gint)
 {
 #if 0
 	/** @FIXME this function does not consider the image orientation,

--- a/src/pixbuf-renderer.h
+++ b/src/pixbuf-renderer.h
@@ -357,7 +357,7 @@ gboolean pixbuf_renderer_get_mouse_position(PixbufRenderer *pr, gint *x_pixel, g
 gboolean pixbuf_renderer_get_pixel_colors(PixbufRenderer *pr, gint x_pixel, gint y_pixel,
 	 				gint *r_mouse, gint *g_mouse, gint *b_mouse, gint *a_mouse);
 
-void pixbuf_renderer_set_size_early(PixbufRenderer *pr, guint width, guint height);
+void pixbuf_renderer_set_size_early(PixbufRenderer *pr, gint width, gint height);
 
 /* stereo */
 void pixbuf_renderer_stereo_set(PixbufRenderer *pr, gint stereo_mode);


### PR DESCRIPTION
Rename related functions to *_size_prepared*.