### PR TITLE
Fix clang-tidy readability-math-missing-parentheses warning

### DIFF
--- a/src/exif-common.cc
+++ b/src/exif-common.cc
@@ -590,14 +590,9 @@ bool exif_build_tz_data(ExifData *exif, gchar **timezone, gchar **countryname, g
 		const gchar *min_val = strtok(nullptr, "deg'");
 		if (!deg_val || !min_val) return {};
 
-		gfloat value = atof(deg_val) + atof(min_val) / 60;
+		const gfloat value = atof(deg_val) + (atof(min_val) / 60);
 
-		if (!g_strcmp0(text_ref, ref_inverse))
-			{
-			value = -value;
-			}
-
-		return value;
+		return (g_strcmp0(text_ref, ref_inverse) != 0) ? value : -value;
 	};
 
 	auto latitude = get_latlon("Exif.GPSInfo.GPSLatitude", "Exif.GPSInfo.GPSLatitudeRef", "South");


### PR DESCRIPTION
#2107 follow-up