### PR TITLE
Hide deprecation warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -808,7 +808,7 @@ if gtk4_migration_check_sh.found()
     compat_h = join_paths(meson.project_source_root(), 'src', 'compat.h')
     foreach source_file : code_sources
         source_file_name = fs.name(source_file)
-        if (source_file_name != 'debug.h')
+        if (source_file_name != 'compat-deprecated.h' and source_file_name != 'debug.h')
             test('GTK4 migration_ ' + source_file_name, gtk4_migration_check_sh, args : [source_file, compat_cc, compat_h], timeout : 100, suite : 'analysis')
         endif
     endforeach

--- a/src/collect-table.cc
+++ b/src/collect-table.cc
@@ -2329,7 +2329,7 @@ static void collection_table_cell_data_cb(GtkTreeViewColumn *, GtkCellRenderer *
 
 	info = static_cast<CollectInfo *>(g_list_nth_data(list, cd->number));
 
-	style = gq_gtk_widget_get_style(ct->listview);
+	style = deprecated_gtk_widget_get_style(ct->listview);
 	if (info && (info->flag_mask & SELECTION_SELECTED))
 		{
 		color_fg = convert_gdkcolor_to_gdkrgba(&style->text[GTK_STATE_SELECTED]);

--- a/src/command-line-handling.cc
+++ b/src/command-line-handling.cc
@@ -186,10 +186,10 @@ void gq_action(GtkApplication *, GApplicationCommandLine *app_command_line, GVar
 		{
 		GtkAction *action;
 
-		action = gq_gtk_action_group_get_action(lw_id->action_group, text);
+		action = deprecated_gtk_action_group_get_action(lw_id->action_group, text);
 		if (action)
 			{
-			gq_gtk_action_activate(action);
+			deprecated_gtk_action_activate(action);
 			}
 		else
 			{

--- a/src/compat-deprecated.h
+++ b/src/compat-deprecated.h
@@ -28,73 +28,76 @@
 G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 // Hide GtkAction deprecation warnings
 // @todo Remove after porting to GAction/GMenu
-inline GtkAction *GQ_GTK_ACTION(gconstpointer obj) { return GTK_ACTION(obj); }
-inline GtkActionGroup *GQ_GTK_ACTION_GROUP(gconstpointer obj) { return GTK_ACTION_GROUP(obj); }
-inline GtkImageMenuItem *GQ_GTK_IMAGE_MENU_ITEM(GtkWidget *widget) { return GTK_IMAGE_MENU_ITEM(widget); }
-inline gboolean GQ_GTK_IS_RADIO_ACTION(GtkAction *action) { return GTK_IS_RADIO_ACTION(action); }
-inline gboolean GQ_GTK_IS_TOGGLE_ACTION(GtkAction *action) { return GTK_IS_TOGGLE_ACTION(action); }
-inline GtkRadioAction *GQ_GTK_RADIO_ACTION(GtkAction *action) { return GTK_RADIO_ACTION(action); }
-inline GtkToggleAction *GQ_GTK_TOGGLE_ACTION(GtkAction *action) { return GTK_TOGGLE_ACTION(action); }
-const auto gq_gtk_action_activate = gtk_action_activate;
-const auto gq_gtk_action_create_icon = gtk_action_create_icon;
-const auto gq_gtk_action_get_accel_path = gtk_action_get_accel_path;
-const auto gq_gtk_action_get_icon_name = gtk_action_get_icon_name;
-const auto gq_gtk_action_get_label = gtk_action_get_label;
-const auto gq_gtk_action_get_name = gtk_action_get_name;
-const auto gq_gtk_action_get_tooltip = gtk_action_get_tooltip;
-const auto gq_gtk_action_set_label = gtk_action_set_label;
-const auto gq_gtk_action_set_sensitive = gtk_action_set_sensitive;
-const auto gq_gtk_action_set_tooltip = gtk_action_set_tooltip;
-const auto gq_gtk_action_set_visible = gtk_action_set_visible;
-const auto gq_gtk_action_group_add_actions = gtk_action_group_add_actions;
-const auto gq_gtk_action_group_add_radio_actions = gtk_action_group_add_radio_actions;
-const auto gq_gtk_action_group_add_toggle_actions = gtk_action_group_add_toggle_actions;
-const auto gq_gtk_action_group_get_action = gtk_action_group_get_action;
-const auto gq_gtk_action_group_list_actions = gtk_action_group_list_actions;
-const auto gq_gtk_action_group_new = gtk_action_group_new;
-const auto gq_gtk_action_group_set_translate_func = gtk_action_group_set_translate_func;
-const auto gq_gtk_radio_action_get_current_value = gtk_radio_action_get_current_value;
-const auto gq_gtk_radio_action_set_current_value = gtk_radio_action_set_current_value;
-const auto gq_gtk_toggle_action_get_active = gtk_toggle_action_get_active;
-const auto gq_gtk_toggle_action_set_active = gtk_toggle_action_set_active;
-const auto gq_gtk_ui_manager_add_ui = gtk_ui_manager_add_ui;
-const auto gq_gtk_ui_manager_add_ui_from_resource = gtk_ui_manager_add_ui_from_resource;
-const auto gq_gtk_ui_manager_add_ui_from_string = gtk_ui_manager_add_ui_from_string;
-const auto gq_gtk_ui_manager_ensure_update = gtk_ui_manager_ensure_update;
-const auto gq_gtk_ui_manager_get_accel_group = gtk_ui_manager_get_accel_group;
-const auto gq_gtk_ui_manager_get_action_groups = gtk_ui_manager_get_action_groups;
-const auto gq_gtk_ui_manager_get_widget = gtk_ui_manager_get_widget;
-const auto gq_gtk_ui_manager_insert_action_group = gtk_ui_manager_insert_action_group;
-const auto gq_gtk_ui_manager_new = gtk_ui_manager_new;
-const auto gq_gtk_ui_manager_new_merge_id = gtk_ui_manager_new_merge_id;
-const auto gq_gtk_ui_manager_remove_action_group = gtk_ui_manager_remove_action_group;
-const auto gq_gtk_ui_manager_remove_ui = gtk_ui_manager_remove_ui;
-const auto gq_gtk_ui_manager_set_add_tearoffs = gtk_ui_manager_set_add_tearoffs;
+inline GtkAction *deprecated_GTK_ACTION(gconstpointer obj) { return GTK_ACTION(obj); }
+inline GtkActionGroup *deprecated_GTK_ACTION_GROUP(gconstpointer obj) { return GTK_ACTION_GROUP(obj); }
+inline GtkImageMenuItem *deprecated_GTK_IMAGE_MENU_ITEM(GtkWidget *widget) { return GTK_IMAGE_MENU_ITEM(widget); }
+inline gboolean deprecated_GTK_IS_RADIO_ACTION(GtkAction *action) { return GTK_IS_RADIO_ACTION(action); }
+inline gboolean deprecated_GTK_IS_TOGGLE_ACTION(GtkAction *action) { return GTK_IS_TOGGLE_ACTION(action); }
+inline GtkRadioAction *deprecated_GTK_RADIO_ACTION(GtkAction *action) { return GTK_RADIO_ACTION(action); }
+inline GtkToggleAction *deprecated_GTK_TOGGLE_ACTION(GtkAction *action) { return GTK_TOGGLE_ACTION(action); }
+const auto deprecated_gtk_action_activate = gtk_action_activate;
+const auto deprecated_gtk_action_create_icon = gtk_action_create_icon;
+const auto deprecated_gtk_action_get_accel_path = gtk_action_get_accel_path;
+const auto deprecated_gtk_action_get_icon_name = gtk_action_get_icon_name;
+const auto deprecated_gtk_action_get_label = gtk_action_get_label;
+const auto deprecated_gtk_action_get_name = gtk_action_get_name;
+const auto deprecated_gtk_action_get_stock_id = gtk_action_get_stock_id;
+const auto deprecated_gtk_action_get_tooltip = gtk_action_get_tooltip;
+const auto deprecated_gtk_action_set_label = gtk_action_set_label;
+const auto deprecated_gtk_action_set_sensitive = gtk_action_set_sensitive;
+const auto deprecated_gtk_action_set_tooltip = gtk_action_set_tooltip;
+const auto deprecated_gtk_action_set_visible = gtk_action_set_visible;
+const auto deprecated_gtk_action_group_add_actions = gtk_action_group_add_actions;
+const auto deprecated_gtk_action_group_add_radio_actions = gtk_action_group_add_radio_actions;
+const auto deprecated_gtk_action_group_add_toggle_actions = gtk_action_group_add_toggle_actions;
+const auto deprecated_gtk_action_group_get_action = gtk_action_group_get_action;
+const auto deprecated_gtk_action_group_list_actions = gtk_action_group_list_actions;
+const auto deprecated_gtk_action_group_new = gtk_action_group_new;
+const auto deprecated_gtk_action_group_set_translate_func = gtk_action_group_set_translate_func;
+const auto deprecated_gtk_radio_action_get_current_value = gtk_radio_action_get_current_value;
+const auto deprecated_gtk_radio_action_set_current_value = gtk_radio_action_set_current_value;
+const auto deprecated_gtk_toggle_action_get_active = gtk_toggle_action_get_active;
+const auto deprecated_gtk_toggle_action_set_active = gtk_toggle_action_set_active;
+const auto deprecated_gtk_ui_manager_add_ui = gtk_ui_manager_add_ui;
+const auto deprecated_gtk_ui_manager_add_ui_from_resource = gtk_ui_manager_add_ui_from_resource;
+const auto deprecated_gtk_ui_manager_add_ui_from_string = gtk_ui_manager_add_ui_from_string;
+const auto deprecated_gtk_ui_manager_ensure_update = gtk_ui_manager_ensure_update;
+const auto deprecated_gtk_ui_manager_get_accel_group = gtk_ui_manager_get_accel_group;
+const auto deprecated_gtk_ui_manager_get_action_groups = gtk_ui_manager_get_action_groups;
+const auto deprecated_gtk_ui_manager_get_widget = gtk_ui_manager_get_widget;
+const auto deprecated_gtk_ui_manager_insert_action_group = gtk_ui_manager_insert_action_group;
+const auto deprecated_gtk_ui_manager_new = gtk_ui_manager_new;
+const auto deprecated_gtk_ui_manager_new_merge_id = gtk_ui_manager_new_merge_id;
+const auto deprecated_gtk_ui_manager_remove_action_group = gtk_ui_manager_remove_action_group;
+const auto deprecated_gtk_ui_manager_remove_ui = gtk_ui_manager_remove_ui;
+const auto deprecated_gtk_ui_manager_set_add_tearoffs = gtk_ui_manager_set_add_tearoffs;
 
 // Hide other Gdk/Gtk deprecation warnings
-const auto gq_gdk_cairo_create = gdk_cairo_create;
-const auto gq_gdk_flush = gdk_flush;
-const auto gq_gdk_pixbuf_animation_get_iter = gdk_pixbuf_animation_get_iter;
-const auto gq_gdk_pixbuf_animation_iter_advance = gdk_pixbuf_animation_iter_advance;
-const auto gq_gdk_pixbuf_animation_iter_get_delay_time = gdk_pixbuf_animation_iter_get_delay_time;
-const auto gq_gdk_pixbuf_animation_iter_get_pixbuf = gdk_pixbuf_animation_iter_get_pixbuf;
-const auto gq_gdk_pixbuf_animation_is_static_image = gdk_pixbuf_animation_is_static_image;
-const auto gq_gdk_pixbuf_animation_new_from_stream_async = gdk_pixbuf_animation_new_from_stream_async;
-const auto gq_gdk_pixbuf_animation_new_from_stream_finish = gdk_pixbuf_animation_new_from_stream_finish;
-const auto gq_gdk_screen_get_height = gdk_screen_get_height;
-const auto gq_gdk_screen_get_monitor_at_window = gdk_screen_get_monitor_at_window;
-const auto gq_gdk_screen_get_width = gdk_screen_get_width;
-const auto gq_gdk_screen_height = gdk_screen_height;
-const auto gq_gdk_screen_width = gdk_screen_width;
-const auto gq_gtk_icon_factory_add = gtk_icon_factory_add;
-const auto gq_gtk_icon_factory_add_default = gtk_icon_factory_add_default;
-const auto gq_gtk_icon_factory_new = gtk_icon_factory_new;
-const auto gq_gtk_image_menu_item_new_with_mnemonic = gtk_image_menu_item_new_with_mnemonic;
-const auto gq_gtk_image_menu_item_set_image = gtk_image_menu_item_set_image;
-const auto gq_gtk_style_context_get_background_color = gtk_style_context_get_background_color;
-const auto gq_gtk_widget_get_requisition = gtk_widget_get_requisition;
-const auto gq_gtk_widget_get_style = gtk_widget_get_style;
-const auto gq_gtk_widget_set_double_buffered = gtk_widget_set_double_buffered;
+const auto deprecated_gdk_cairo_create = gdk_cairo_create;
+const auto deprecated_gdk_flush = gdk_flush;
+const auto deprecated_gdk_pixbuf_animation_get_iter = gdk_pixbuf_animation_get_iter;
+const auto deprecated_gdk_pixbuf_animation_iter_advance = gdk_pixbuf_animation_iter_advance;
+const auto deprecated_gdk_pixbuf_animation_iter_get_delay_time = gdk_pixbuf_animation_iter_get_delay_time;
+const auto deprecated_gdk_pixbuf_animation_iter_get_pixbuf = gdk_pixbuf_animation_iter_get_pixbuf;
+const auto deprecated_gdk_pixbuf_animation_is_static_image = gdk_pixbuf_animation_is_static_image;
+const auto deprecated_gdk_pixbuf_animation_new_from_stream_async = gdk_pixbuf_animation_new_from_stream_async;
+const auto deprecated_gdk_pixbuf_animation_new_from_stream_finish = gdk_pixbuf_animation_new_from_stream_finish;
+const auto deprecated_gdk_screen_get_height = gdk_screen_get_height;
+const auto deprecated_gdk_screen_get_monitor_at_window = gdk_screen_get_monitor_at_window;
+const auto deprecated_gdk_screen_get_width = gdk_screen_get_width;
+const auto deprecated_gdk_screen_height = gdk_screen_height;
+const auto deprecated_gdk_screen_width = gdk_screen_width;
+const auto deprecated_gtk_icon_factory_add = gtk_icon_factory_add;
+const auto deprecated_gtk_icon_factory_add_default = gtk_icon_factory_add_default;
+const auto deprecated_gtk_icon_factory_new = gtk_icon_factory_new;
+const auto deprecated_gtk_icon_set_new_from_pixbuf = gtk_icon_set_new_from_pixbuf;
+const auto deprecated_gtk_image_menu_item_new_with_mnemonic = gtk_image_menu_item_new_with_mnemonic;
+const auto deprecated_gtk_image_menu_item_set_image = gtk_image_menu_item_set_image;
+const auto deprecated_gtk_image_new_from_stock = gtk_image_new_from_stock;
+const auto deprecated_gtk_style_context_get_background_color = gtk_style_context_get_background_color;
+const auto deprecated_gtk_widget_get_requisition = gtk_widget_get_requisition;
+const auto deprecated_gtk_widget_get_style = gtk_widget_get_style;
+const auto deprecated_gtk_widget_set_double_buffered = gtk_widget_set_double_buffered;
 G_GNUC_END_IGNORE_DEPRECATIONS
 
 #endif /* COMPAT_DEPRECATED_H */

--- a/src/compat.cc
+++ b/src/compat.cc
@@ -22,6 +22,8 @@
 
 #include <config.h>
 
+#include "compat-deprecated.h"
+
 #if HAVE_GTK4
 void gq_gtk_container_add(GtkWidget *container, GtkWidget *widget)
 {
@@ -107,7 +109,7 @@ void gq_gtk_container_add(GtkWidget *container, GtkWidget *widget)
 
 GtkWidget *gq_gtk_image_new_from_stock(const gchar *stock_id, GtkIconSize size)
 {
-	return gtk_image_new_from_stock(stock_id, size);
+	return deprecated_gtk_image_new_from_stock(stock_id, size);
 }
 
 GtkWidget *gq_gtk_bin_get_child(GtkWidget *widget)

--- a/src/dupe.cc
+++ b/src/dupe.cc
@@ -3714,7 +3714,7 @@ static GdkRGBA *dupe_listview_color_shifted(GtkWidget *widget)
 		{
 		GtkStyle *style;
 
-		style = gq_gtk_widget_get_style(widget);
+		style = deprecated_gtk_widget_get_style(widget);
 		color = convert_gdkcolor_to_gdkrgba(&style->base[GTK_STATE_NORMAL]);
 
 		shift_color(color);

--- a/src/fullscreen.cc
+++ b/src/fullscreen.cc
@@ -222,8 +222,8 @@ GdkRectangle get_screen_default_geometry(GdkScreen *screen)
 
 	geometry.x = 0;
 	geometry.y = 0;
-	geometry.width = gq_gdk_screen_get_width(screen);
-	geometry.height = gq_gdk_screen_get_height(screen);
+	geometry.width = deprecated_gdk_screen_get_width(screen);
+	geometry.height = deprecated_gdk_screen_get_height(screen);
 
 	return geometry;
 }
@@ -393,7 +393,7 @@ GdkRectangle fullscreen_prefs_get_geometry(gint screen_num, GtkWidget *widget, G
 			same_region = (!widget || !gtk_widget_get_window(widget) ||
 			               (dest_screen == gtk_widget_get_screen(widget) &&
 			                (it->number%100 == 0 ||
-			                 it->number%100 == gq_gdk_screen_get_monitor_at_window(dest_screen, gtk_widget_get_window(widget)) + 1)));
+			                 it->number%100 == deprecated_gdk_screen_get_monitor_at_window(dest_screen, gtk_widget_get_window(widget)) + 1)));
 			return it->geometry;
 			}
 		}

--- a/src/image.cc
+++ b/src/image.cc
@@ -1801,7 +1801,7 @@ void image_background_set_color_from_options(ImageWindow *imd, gboolean fullscre
 		if (!lw) return;
 
 		style_context = gtk_widget_get_style_context(lw->window);
-		gq_gtk_style_context_get_background_color(style_context, GTK_STATE_FLAG_NORMAL, &bg_color);
+		deprecated_gtk_style_context_get_background_color(style_context, GTK_STATE_FLAG_NORMAL, &bg_color);
 
 		theme_color.red = bg_color.red * 1;
 		theme_color.green = bg_color.green * 1;

--- a/src/img-view.cc
+++ b/src/img-view.cc
@@ -954,8 +954,8 @@ static ViewWindow *real_view_window_new(FileData *fd, GList *list, CollectionDat
 
 	if (options->image.limit_window_size)
 		{
-		gint mw = gq_gdk_screen_width() * options->image.max_window_size / 100;
-		gint mh = gq_gdk_screen_height() * options->image.max_window_size / 100;
+		gint mw = deprecated_gdk_screen_width() * options->image.max_window_size / 100;
+		gint mh = deprecated_gdk_screen_height() * options->image.max_window_size / 100;
 
 		w = std::min(w, mw);
 		h = std::min(h, mh);

--- a/src/layout-image.cc
+++ b/src/layout-image.cc
@@ -331,19 +331,19 @@ static gboolean show_next_frame(gpointer data)
 
 	PixbufRenderer *pr = PIXBUF_RENDERER(fd->iw->pr);
 
-	if (!gq_gdk_pixbuf_animation_iter_advance(fd->iter, nullptr))
+	if (!deprecated_gdk_pixbuf_animation_iter_advance(fd->iter, nullptr))
 		{
 		/* This indicates the animation is complete.
 		   Return FALSE here to disable looping. */
 		}
 
-	fd->gpb = gq_gdk_pixbuf_animation_iter_get_pixbuf(fd->iter);
+	fd->gpb = deprecated_gdk_pixbuf_animation_iter_get_pixbuf(fd->iter);
 	image_change_pixbuf(fd->iw,fd->gpb,pr->zoom,FALSE);
 
 	if (fd->iw->func_update)
 		fd->iw->func_update(fd->iw, fd->iw->data_update);
 
-	delay = gq_gdk_pixbuf_animation_iter_get_delay_time(fd->iter);
+	delay = deprecated_gdk_pixbuf_animation_iter_get_delay_time(fd->iter);
 	if (delay!=fd->delay)
 		{
 		if (delay>0) /* Current frame not static. */
@@ -404,7 +404,7 @@ static void animation_async_ready_cb(GObject *, GAsyncResult *res, gpointer data
 
 	if (g_cancellable_is_cancelled(animation->cancellable))
 		{
-		gq_gdk_pixbuf_animation_new_from_stream_finish(res, nullptr);
+		deprecated_gdk_pixbuf_animation_new_from_stream_finish(res, nullptr);
 		g_object_unref(animation->in_file);
 		g_object_unref(animation->gfstream);
 		image_animation_data_free(animation);
@@ -412,16 +412,16 @@ static void animation_async_ready_cb(GObject *, GAsyncResult *res, gpointer data
 		}
 
 	g_autoptr(GError) error = nullptr;
-	animation->gpa = gq_gdk_pixbuf_animation_new_from_stream_finish(res, &error);
+	animation->gpa = deprecated_gdk_pixbuf_animation_new_from_stream_finish(res, &error);
 	if (animation->gpa)
 		{
-		if (!gq_gdk_pixbuf_animation_is_static_image(animation->gpa))
+		if (!deprecated_gdk_pixbuf_animation_is_static_image(animation->gpa))
 			{
-			animation->iter = gq_gdk_pixbuf_animation_get_iter(animation->gpa, nullptr);
+			animation->iter = deprecated_gdk_pixbuf_animation_get_iter(animation->gpa, nullptr);
 			if (animation->iter)
 				{
 				animation->data_adr = animation->lw->image->image_fd;
-				animation->delay = gq_gdk_pixbuf_animation_iter_get_delay_time(animation->iter);
+				animation->delay = deprecated_gdk_pixbuf_animation_iter_get_delay_time(animation->iter);
 				animation->valid = TRUE;
 
 				layout_image_animate_update_image(animation->lw);
@@ -466,7 +466,7 @@ static gboolean layout_image_animate_new_file(LayoutWindow *lw)
 	if (gfstream)
 		{
 		animation->gfstream = gfstream;
-		gq_gdk_pixbuf_animation_new_from_stream_async(G_INPUT_STREAM(gfstream), animation->cancellable, animation_async_ready_cb, animation);
+		deprecated_gdk_pixbuf_animation_new_from_stream_async(G_INPUT_STREAM(gfstream), animation->cancellable, animation_async_ready_cb, animation);
 		}
 	else
 		{
@@ -484,8 +484,8 @@ void layout_image_animate_toggle(LayoutWindow *lw)
 
 	lw->options.animate = !lw->options.animate;
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "Animate");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), lw->options.animate);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "Animate");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), lw->options.animate);
 
 	layout_image_animate_new_file(lw);
 }

--- a/src/layout-util.cc
+++ b/src/layout-util.cc
@@ -329,10 +329,10 @@ bool layout_handle_user_defined_mouse_buttons(LayoutWindow *lw, GdkEventButton *
 			}
 		else
 			{
-			GtkAction *action = gq_gtk_action_group_get_action(lw->action_group, action_name);
+			GtkAction *action = deprecated_gtk_action_group_get_action(lw->action_group, action_name);
 			if (action)
 				{
-				gq_gtk_action_activate(action);
+				deprecated_gtk_action_activate(action);
 				}
 			}
 
@@ -569,43 +569,43 @@ static void layout_menu_alter_desaturate_cb(GtkToggleAction *action, gpointer da
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	layout_image_set_desaturate(lw, gq_gtk_toggle_action_get_active(action));
+	layout_image_set_desaturate(lw, deprecated_gtk_toggle_action_get_active(action));
 }
 
 static void layout_menu_alter_ignore_alpha_cb(GtkToggleAction *action, gpointer data)
 {
-   auto lw = static_cast<LayoutWindow *>(data);
+	auto lw = static_cast<LayoutWindow *>(data);
 
-	if (lw->options.ignore_alpha == gq_gtk_toggle_action_get_active(action)) return;
+	if (lw->options.ignore_alpha == deprecated_gtk_toggle_action_get_active(action)) return;
 
-   layout_image_set_ignore_alpha(lw, gq_gtk_toggle_action_get_active(action));
+	layout_image_set_ignore_alpha(lw, deprecated_gtk_toggle_action_get_active(action));
 }
 
 static void layout_menu_exif_rotate_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	options->image.exif_rotate_enable = gq_gtk_toggle_action_get_active(action);
+	options->image.exif_rotate_enable = deprecated_gtk_toggle_action_get_active(action);
 	layout_image_reset_orientation(lw);
 }
 
 static void layout_menu_select_rectangle_cb(GtkToggleAction *action, gpointer)
 {
-	options->draw_rectangle = gq_gtk_toggle_action_get_active(action);
+	options->draw_rectangle = deprecated_gtk_toggle_action_get_active(action);
 }
 
 static void layout_menu_split_pane_sync_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	lw->options.split_pane_sync = gq_gtk_toggle_action_get_active(action);
+	lw->options.split_pane_sync = deprecated_gtk_toggle_action_get_active(action);
 }
 
 static void layout_menu_select_overunderexposed_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	layout_image_set_overunderexposed(lw, gq_gtk_toggle_action_get_active(action));
+	layout_image_set_overunderexposed(lw, deprecated_gtk_toggle_action_get_active(action));
 }
 
 template<gboolean keep_date>
@@ -758,7 +758,7 @@ static void layout_menu_split_cb(GtkRadioAction *action, GtkRadioAction *, gpoin
 	ImageSplitMode mode;
 
 	layout_exit_fullscreen(lw);
-	mode = static_cast<ImageSplitMode>(gq_gtk_radio_action_get_current_value(action));
+	mode = static_cast<ImageSplitMode>(deprecated_gtk_radio_action_get_current_value(action));
 	layout_split_change(lw, mode);
 }
 
@@ -767,7 +767,7 @@ static void layout_menu_thumb_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	layout_thumb_set(lw, gq_gtk_toggle_action_get_active(action));
+	layout_thumb_set(lw, deprecated_gtk_toggle_action_get_active(action));
 }
 
 
@@ -776,7 +776,7 @@ static void layout_menu_list_cb(GtkRadioAction *action, GtkRadioAction *, gpoint
 	auto lw = static_cast<LayoutWindow *>(data);
 
 	layout_exit_fullscreen(lw);
-	layout_views_set(lw, lw->options.dir_view_type, static_cast<FileViewType>(gq_gtk_radio_action_get_current_value(action)));
+	layout_views_set(lw, lw->options.dir_view_type, static_cast<FileViewType>(deprecated_gtk_radio_action_get_current_value(action)));
 }
 
 static void layout_menu_view_dir_as_cb(GtkToggleAction *action,  gpointer data)
@@ -785,7 +785,7 @@ static void layout_menu_view_dir_as_cb(GtkToggleAction *action,  gpointer data)
 
 	layout_exit_fullscreen(lw);
 
-	if (gq_gtk_toggle_action_get_active(action))
+	if (deprecated_gtk_toggle_action_get_active(action))
 		{
 		layout_views_set(lw, DIRVIEW_TREE, lw->options.file_view_type);
 		}
@@ -1132,7 +1132,7 @@ static void layout_menu_overlay_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	if (gq_gtk_toggle_action_get_active(action))
+	if (deprecated_gtk_toggle_action_get_active(action))
 		{
 		OsdShowFlags flags = image_osd_get(lw->image);
 
@@ -1141,10 +1141,10 @@ static void layout_menu_overlay_cb(GtkToggleAction *action, gpointer data)
 		}
 	else
 		{
-		GtkToggleAction *histogram_action = GQ_GTK_TOGGLE_ACTION(gq_gtk_action_group_get_action(lw->action_group, "ImageHistogram"));
+		GtkToggleAction *histogram_action = deprecated_GTK_TOGGLE_ACTION(deprecated_gtk_action_group_get_action(lw->action_group, "ImageHistogram"));
 
 		image_osd_set(lw->image, OSD_SHOW_NOTHING);
-		gq_gtk_toggle_action_set_active(histogram_action, FALSE); /* this calls layout_menu_histogram_cb */
+		deprecated_gtk_toggle_action_set_active(histogram_action, FALSE); /* this calls layout_menu_histogram_cb */
 		}
 }
 
@@ -1152,7 +1152,7 @@ static void layout_menu_histogram_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	if (gq_gtk_toggle_action_get_active(action))
+	if (deprecated_gtk_toggle_action_get_active(action))
 		{
 		image_osd_set(lw->image, static_cast<OsdShowFlags>(OSD_SHOW_INFO | OSD_SHOW_STATUS | OSD_SHOW_HISTOGRAM));
 		layout_util_sync_views(lw); /* show the overlay state, default channel and mode in the menu */
@@ -1169,13 +1169,13 @@ static void layout_menu_animate_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	if (lw->options.animate == gq_gtk_toggle_action_get_active(action)) return;
+	if (lw->options.animate == deprecated_gtk_toggle_action_get_active(action)) return;
 	layout_image_animate_toggle(lw);
 }
 
 static void layout_menu_rectangular_selection_cb(GtkToggleAction *action, gpointer)
 {
-	options->collections.rectangular_selection = gq_gtk_toggle_action_get_active(action);
+	options->collections.rectangular_selection = deprecated_gtk_toggle_action_get_active(action);
 }
 
 static void layout_menu_histogram_toggle_channel_cb(GtkAction *, gpointer data)
@@ -1196,24 +1196,24 @@ static void layout_menu_histogram_toggle_mode_cb(GtkAction *, gpointer data)
 
 static void layout_menu_histogram_channel_cb(GtkRadioAction *action, GtkRadioAction *, gpointer data)
 {
-	gint channel = gq_gtk_radio_action_get_current_value(action);
+	gint channel = deprecated_gtk_radio_action_get_current_value(action);
 	if (channel < 0 || channel >= HCHAN_COUNT) return;
 
 	auto *lw = static_cast<LayoutWindow *>(data);
-	GtkToggleAction *histogram_action = GQ_GTK_TOGGLE_ACTION(gq_gtk_action_group_get_action(lw->action_group, "ImageHistogram"));
-	gq_gtk_toggle_action_set_active(histogram_action, TRUE); /* this calls layout_menu_histogram_cb */
+	GtkToggleAction *histogram_action = deprecated_GTK_TOGGLE_ACTION(deprecated_gtk_action_group_get_action(lw->action_group, "ImageHistogram"));
+	deprecated_gtk_toggle_action_set_active(histogram_action, TRUE); /* this calls layout_menu_histogram_cb */
 
 	image_osd_histogram_set_channel(lw->image, channel);
 }
 
 static void layout_menu_histogram_mode_cb(GtkRadioAction *action, GtkRadioAction *, gpointer data)
 {
-	gint mode = gq_gtk_radio_action_get_current_value(action);
+	gint mode = deprecated_gtk_radio_action_get_current_value(action);
 	if (mode < 0 || mode >= HMODE_COUNT) return;
 
 	auto *lw = static_cast<LayoutWindow *>(data);
-	GtkToggleAction *histogram_action = GQ_GTK_TOGGLE_ACTION(gq_gtk_action_group_get_action(lw->action_group, "ImageHistogram"));
-	gq_gtk_toggle_action_set_active(histogram_action, TRUE); /* this calls layout_menu_histogram_cb */
+	GtkToggleAction *histogram_action = deprecated_GTK_TOGGLE_ACTION(deprecated_gtk_action_group_get_action(lw->action_group, "ImageHistogram"));
+	deprecated_gtk_toggle_action_set_active(histogram_action, TRUE); /* this calls layout_menu_histogram_cb */
 
 	image_osd_histogram_set_mode(lw->image, mode);
 }
@@ -1246,7 +1246,7 @@ static void layout_menu_float_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	if (lw->options.tools_float == gq_gtk_toggle_action_get_active(action)) return;
+	if (lw->options.tools_float == deprecated_gtk_toggle_action_get_active(action)) return;
 
 	layout_exit_fullscreen(lw);
 	layout_tools_float_toggle(lw);
@@ -1264,7 +1264,7 @@ static void layout_menu_selectable_toolbars_cb(GtkToggleAction *action, gpointer
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	if (lw->options.selectable_toolbars_hidden == gq_gtk_toggle_action_get_active(action)) return;
+	if (lw->options.selectable_toolbars_hidden == deprecated_gtk_toggle_action_get_active(action)) return;
 
 	layout_exit_fullscreen(lw);
 	current_layout_selectable_toolbars_toggle();
@@ -1274,7 +1274,7 @@ static void layout_menu_info_pixel_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	if (lw->options.show_info_pixel == gq_gtk_toggle_action_get_active(action)) return;
+	if (lw->options.show_info_pixel == deprecated_gtk_toggle_action_get_active(action)) return;
 
 	layout_exit_fullscreen(lw);
 	layout_info_pixel_set(lw, !lw->options.show_info_pixel);
@@ -1285,7 +1285,7 @@ static void layout_menu_bar_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	if (layout_bar_enabled(lw) == gq_gtk_toggle_action_get_active(action)) return;
+	if (layout_bar_enabled(lw) == deprecated_gtk_toggle_action_get_active(action)) return;
 
 	layout_exit_fullscreen(lw);
 	layout_bar_toggle(lw);
@@ -1295,7 +1295,7 @@ static void layout_menu_bar_sort_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	if (layout_bar_sort_enabled(lw) == gq_gtk_toggle_action_get_active(action)) return;
+	if (layout_bar_sort_enabled(lw) == deprecated_gtk_toggle_action_get_active(action)) return;
 
 	layout_exit_fullscreen(lw);
 	layout_bar_sort_toggle(lw);
@@ -1305,7 +1305,7 @@ static void layout_menu_hide_bars_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	if (lw->options.bars_state.hidden == gq_gtk_toggle_action_get_active(action))
+	if (lw->options.bars_state.hidden == deprecated_gtk_toggle_action_get_active(action))
 		{
 		return;
 		}
@@ -1316,7 +1316,7 @@ static void layout_menu_slideshow_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	if (layout_image_slideshow_active(lw) == gq_gtk_toggle_action_get_active(action)) return;
+	if (layout_image_slideshow_active(lw) == deprecated_gtk_toggle_action_get_active(action)) return;
 	layout_image_slideshow_toggle(lw);
 }
 
@@ -1345,8 +1345,8 @@ static void layout_menu_stereo_mode_next_cb(GtkAction *, gpointer data)
 	/* 0->1, 1->2, 2->3, 3->1 - disable auto, then cycle */
 	const gint mode = (layout_image_stereo_pixbuf_get(lw) % 3) + 1;
 
-	GtkAction *radio = gq_gtk_action_group_get_action(lw->action_group, "StereoAuto");
-	gq_gtk_radio_action_set_current_value(GQ_GTK_RADIO_ACTION(radio), mode);
+	GtkAction *radio = deprecated_gtk_action_group_get_action(lw->action_group, "StereoAuto");
+	deprecated_gtk_radio_action_set_current_value(deprecated_GTK_RADIO_ACTION(radio), mode);
 
 	/*
 	this is called via fallback in layout_menu_stereo_mode_cb
@@ -1357,12 +1357,12 @@ static void layout_menu_stereo_mode_next_cb(GtkAction *, gpointer data)
 static void layout_menu_stereo_mode_cb(GtkRadioAction *action, GtkRadioAction *, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
-	layout_image_stereo_pixbuf_set(lw, static_cast<StereoPixbufData>(gq_gtk_radio_action_get_current_value(action)));
+	layout_image_stereo_pixbuf_set(lw, static_cast<StereoPixbufData>(deprecated_gtk_radio_action_get_current_value(action)));
 }
 
 static void layout_menu_draw_rectangle_aspect_ratio_cb(GtkRadioAction *action, GtkRadioAction *, gpointer)
 {
-	options->rectangle_draw_aspect_ratio = static_cast<RectangleDrawAspectRatio>(gq_gtk_radio_action_get_current_value(action));
+	options->rectangle_draw_aspect_ratio = static_cast<RectangleDrawAspectRatio>(deprecated_gtk_radio_action_get_current_value(action));
 }
 
 static void overlay_screen_display_profile_set(gint i)
@@ -1385,7 +1385,7 @@ static void layout_menu_osd_cb(GtkRadioAction *action, GtkRadioAction *, gpointe
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	options->overlay_screen_display_selected_profile = static_cast<OverlayScreenDisplaySelectedTab>(gq_gtk_radio_action_get_current_value(action));
+	options->overlay_screen_display_selected_profile = static_cast<OverlayScreenDisplaySelectedTab>(deprecated_gtk_radio_action_get_current_value(action));
 	overlay_screen_display_profile_set(options->overlay_screen_display_selected_profile);
 
 	layout_image_refresh(lw);
@@ -1630,14 +1630,14 @@ static void layout_menu_file_filter_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	layout_file_filter_set(lw, gq_gtk_toggle_action_get_active(action));
+	layout_file_filter_set(lw, deprecated_gtk_toggle_action_get_active(action));
 }
 
 static void layout_menu_marks_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	layout_marks_set(lw, gq_gtk_toggle_action_get_active(action));
+	layout_marks_set(lw, deprecated_gtk_toggle_action_get_active(action));
 }
 
 template<SelectionToMarkMode mode>
@@ -1916,7 +1916,7 @@ static void layout_menu_up_cb(GtkAction *, gpointer data)
 static void layout_menu_edit_cb(GtkAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
-	const gchar *key = gq_gtk_action_get_name(action);
+	const gchar *key = deprecated_gtk_action_get_name(action);
 
 	if (!editor_window_flag_set(key))
 		layout_exit_fullscreen(lw);
@@ -1960,9 +1960,9 @@ static void layout_color_menu_enable_cb(GtkToggleAction *action, gpointer data)
 {
 	auto lw = static_cast<LayoutWindow *>(data);
 
-	if (layout_image_color_profile_get_use(lw) == gq_gtk_toggle_action_get_active(action)) return;
+	if (layout_image_color_profile_get_use(lw) == deprecated_gtk_toggle_action_get_active(action)) return;
 
-	layout_image_color_profile_set_use(lw, gq_gtk_toggle_action_get_active(action));
+	layout_image_color_profile_set_use(lw, deprecated_gtk_toggle_action_get_active(action));
 	layout_util_sync_color(lw);
 	layout_image_refresh(lw);
 }
@@ -1974,8 +1974,8 @@ static void layout_color_menu_use_image_cb(GtkToggleAction *action, gpointer dat
 	gboolean use_image;
 
 	if (!layout_image_color_profile_get(lw, input, use_image)) return;
-	if (use_image == gq_gtk_toggle_action_get_active(action)) return;
-	layout_image_color_profile_set(lw, input, gq_gtk_toggle_action_get_active(action));
+	if (use_image == deprecated_gtk_toggle_action_get_active(action)) return;
+	layout_image_color_profile_set(lw, input, deprecated_gtk_toggle_action_get_active(action));
 	layout_util_sync_color(lw);
 	layout_image_refresh(lw);
 }
@@ -1987,7 +1987,7 @@ static void layout_color_menu_input_cb(GtkRadioAction *action, GtkRadioAction *,
 	gint input;
 	gboolean use_image;
 
-	type = gq_gtk_radio_action_get_current_value(action);
+	type = deprecated_gtk_radio_action_get_current_value(action);
 	if (type < 0 || type >= COLOR_PROFILE_FILE + COLOR_PROFILE_INPUTS) return;
 
 	if (!layout_image_color_profile_get(lw, input, use_image)) return;
@@ -2104,7 +2104,7 @@ static void layout_menu_new_window_update(LayoutWindow *lw)
 
 	g_autolist(WindowNames) list = layout_window_menu_list();
 
-	GtkWidget *menu = gq_gtk_ui_manager_get_widget(lw->ui_manager,
+	GtkWidget *menu = deprecated_gtk_ui_manager_get_widget(lw->ui_manager,
 	                                               options->hamburger_menu ? "/MainMenu/OpenMenu/WindowsMenu/NewWindow" : "/MainMenu/WindowsMenu/NewWindow");
 	GtkWidget *sub_menu = gtk_menu_item_get_submenu(GTK_MENU_ITEM(menu));
 
@@ -2214,7 +2214,7 @@ static void layout_menu_windows_menu_cb(GtkWidget *, gpointer data)
 	GtkWidget *menu;
 	GtkWidget *sub_menu;
 
-	menu = gq_gtk_ui_manager_get_widget(lw->ui_manager, options->hamburger_menu ? "/MainMenu/OpenMenu/WindowsMenu/" : "/MainMenu/WindowsMenu/");
+	menu = deprecated_gtk_ui_manager_get_widget(lw->ui_manager, options->hamburger_menu ? "/MainMenu/OpenMenu/WindowsMenu/" : "/MainMenu/WindowsMenu/");
 
 	sub_menu = gtk_menu_item_get_submenu(GTK_MENU_ITEM(menu));
 
@@ -2239,7 +2239,7 @@ static void layout_menu_view_menu_cb(GtkWidget *, gpointer data)
 	GtkWidget *sub_menu;
 	FileData *fd;
 
-	menu = gq_gtk_ui_manager_get_widget(lw->ui_manager, options->hamburger_menu ? "/MainMenu/OpenMenu/ViewMenu/" : "/MainMenu/ViewMenu/");
+	menu = deprecated_gtk_ui_manager_get_widget(lw->ui_manager, options->hamburger_menu ? "/MainMenu/OpenMenu/ViewMenu/" : "/MainMenu/ViewMenu/");
 	sub_menu = gtk_menu_item_get_submenu(GTK_MENU_ITEM(menu));
 
 	fd = layout_image_get_fd(lw);
@@ -2683,8 +2683,8 @@ static void layout_actions_setup_mark(LayoutWindow *lw, gint mark, const gchar *
 	else
 		entry.tooltip = nullptr;
 
-	gq_gtk_action_group_add_actions(lw->action_group, &entry, 1, lw);
-	action = gq_gtk_action_group_get_action(lw->action_group, name);
+	deprecated_gtk_action_group_add_actions(lw->action_group, &entry, 1, lw);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, name);
 	g_object_set_data(G_OBJECT(action), "mark_num", GINT_TO_POINTER(mark > 0 ? mark : 10));
 }
 
@@ -2753,7 +2753,7 @@ static void layout_actions_setup_marks(LayoutWindow *lw)
 	g_string_append(desc,   "</ui>" );
 
 	g_autoptr(GError) error = nullptr;
-	if (!gq_gtk_ui_manager_add_ui_from_string(lw->ui_manager, desc->str, -1, &error))
+	if (!deprecated_gtk_ui_manager_add_ui_from_string(lw->ui_manager, desc->str, -1, &error))
 		{
 		g_message("building menus failed: %s", error->message);
 		exit(EXIT_FAILURE);
@@ -2841,16 +2841,16 @@ static void layout_actions_setup_editors(LayoutWindow *lw)
 {
 	if (lw->ui_editors_id)
 		{
-		gq_gtk_ui_manager_remove_ui(lw->ui_manager, lw->ui_editors_id);
+		deprecated_gtk_ui_manager_remove_ui(lw->ui_manager, lw->ui_editors_id);
 		}
 
 	if (lw->action_group_editors)
 		{
-		gq_gtk_ui_manager_remove_action_group(lw->ui_manager, lw->action_group_editors);
+		deprecated_gtk_ui_manager_remove_action_group(lw->ui_manager, lw->action_group_editors);
 		g_object_unref(lw->action_group_editors);
 		}
-	lw->action_group_editors = gq_gtk_action_group_new("MenuActionsExternal");
-	gq_gtk_ui_manager_insert_action_group(lw->ui_manager, lw->action_group_editors, 1);
+	lw->action_group_editors = deprecated_gtk_action_group_new("MenuActionsExternal");
+	deprecated_gtk_ui_manager_insert_action_group(lw->ui_manager, lw->action_group_editors, 1);
 
 	/* lw->action_group_editors contains translated entries, no translate func is required */
 	g_autoptr(GString) desc = g_string_new(
@@ -2900,7 +2900,7 @@ static void layout_actions_setup_editors(LayoutWindow *lw)
 			                         editor->comment ? editor->comment : editor->name,
 			                         G_CALLBACK(layout_menu_edit_cb) };
 
-			gq_gtk_action_group_add_actions(lw->action_group_editors, &entry, 1, lw);
+			deprecated_gtk_action_group_add_actions(lw->action_group_editors, &entry, 1, lw);
 
 			// @todo Use g_list_find_custom() if tooltip is unique
 			gtk_container_foreach(GTK_CONTAINER(main_toolbar), set_image_and_tooltip_from_editor, editor);
@@ -2927,7 +2927,7 @@ static void layout_actions_setup_editors(LayoutWindow *lw)
 
 	g_autoptr(GError) error = nullptr;
 
-	lw->ui_editors_id = gq_gtk_ui_manager_add_ui_from_string(lw->ui_manager, desc->str, -1, &error);
+	lw->ui_editors_id = deprecated_gtk_ui_manager_add_ui_from_string(lw->ui_manager, desc->str, -1, &error);
 	if (!lw->ui_editors_id)
 		{
 		g_message("building menus failed: %s", error->message);
@@ -2951,51 +2951,51 @@ void layout_actions_setup(LayoutWindow *lw)
 	DEBUG_1("%s layout_actions_setup: start", get_exec_time());
 	if (lw->ui_manager) return;
 
-	lw->action_group = gq_gtk_action_group_new("MenuActions");
-	gq_gtk_action_group_set_translate_func(lw->action_group, menu_translate, nullptr, nullptr);
+	lw->action_group = deprecated_gtk_action_group_new("MenuActions");
+	deprecated_gtk_action_group_set_translate_func(lw->action_group, menu_translate, nullptr, nullptr);
 
-	gq_gtk_action_group_add_actions(lw->action_group,
+	deprecated_gtk_action_group_add_actions(lw->action_group,
 	                                menu_entries, std::size(menu_entries), lw);
-	gq_gtk_action_group_add_toggle_actions(lw->action_group,
+	deprecated_gtk_action_group_add_toggle_actions(lw->action_group,
 	                                       menu_toggle_entries, std::size(menu_toggle_entries),
 	                                       lw);
-	gq_gtk_action_group_add_radio_actions(lw->action_group,
+	deprecated_gtk_action_group_add_radio_actions(lw->action_group,
 	                                      menu_radio_entries, std::size(menu_radio_entries),
 	                                      0, G_CALLBACK(layout_menu_list_cb), lw);
-	gq_gtk_action_group_add_radio_actions(lw->action_group,
+	deprecated_gtk_action_group_add_radio_actions(lw->action_group,
 	                                      menu_split_radio_entries, std::size(menu_split_radio_entries),
 	                                      0, G_CALLBACK(layout_menu_split_cb), lw);
-	gq_gtk_action_group_add_toggle_actions(lw->action_group,
+	deprecated_gtk_action_group_add_toggle_actions(lw->action_group,
 	                                       menu_view_dir_toggle_entries, std::size(menu_view_dir_toggle_entries),
 	                                       lw);
-	gq_gtk_action_group_add_radio_actions(lw->action_group,
+	deprecated_gtk_action_group_add_radio_actions(lw->action_group,
 	                                      menu_color_radio_entries, std::size(menu_color_radio_entries),
 	                                      0, G_CALLBACK(layout_color_menu_input_cb), lw);
-	gq_gtk_action_group_add_radio_actions(lw->action_group,
+	deprecated_gtk_action_group_add_radio_actions(lw->action_group,
 	                                      menu_histogram_channel, std::size(menu_histogram_channel),
 	                                      0, G_CALLBACK(layout_menu_histogram_channel_cb), lw);
-	gq_gtk_action_group_add_radio_actions(lw->action_group,
+	deprecated_gtk_action_group_add_radio_actions(lw->action_group,
 	                                      menu_histogram_mode, std::size(menu_histogram_mode),
 	                                      0, G_CALLBACK(layout_menu_histogram_mode_cb), lw);
-	gq_gtk_action_group_add_radio_actions(lw->action_group,
+	deprecated_gtk_action_group_add_radio_actions(lw->action_group,
 	                                      menu_stereo_mode_entries, std::size(menu_stereo_mode_entries),
 	                                      0, G_CALLBACK(layout_menu_stereo_mode_cb), lw);
-	gq_gtk_action_group_add_radio_actions(lw->action_group,
+	deprecated_gtk_action_group_add_radio_actions(lw->action_group,
 	                                      menu_draw_rectangle_aspect_ratios, std::size(menu_draw_rectangle_aspect_ratios),
 	                                      0, G_CALLBACK(layout_menu_draw_rectangle_aspect_ratio_cb), lw);
-	gq_gtk_action_group_add_radio_actions(lw->action_group,
+	deprecated_gtk_action_group_add_radio_actions(lw->action_group,
 	                                      menu_osd, std::size(menu_osd),
 	                                      0, G_CALLBACK(layout_menu_osd_cb), lw);
 
 
-	lw->ui_manager = gq_gtk_ui_manager_new();
-	gq_gtk_ui_manager_set_add_tearoffs(lw->ui_manager, TRUE);
-	gq_gtk_ui_manager_insert_action_group(lw->ui_manager, lw->action_group, 0);
+	lw->ui_manager = deprecated_gtk_ui_manager_new();
+	deprecated_gtk_ui_manager_set_add_tearoffs(lw->ui_manager, TRUE);
+	deprecated_gtk_ui_manager_insert_action_group(lw->ui_manager, lw->action_group, 0);
 
 	DEBUG_1("%s layout_actions_setup: add menu", get_exec_time());
 	g_autoptr(GError) error = nullptr;
 
-	if (!gq_gtk_ui_manager_add_ui_from_resource(lw->ui_manager, options->hamburger_menu ? GQ_RESOURCE_PATH_UI "/menu-hamburger.ui" : GQ_RESOURCE_PATH_UI "/menu-classic.ui" , &error))
+	if (!deprecated_gtk_ui_manager_add_ui_from_resource(lw->ui_manager, options->hamburger_menu ? GQ_RESOURCE_PATH_UI "/menu-hamburger.ui" : GQ_RESOURCE_PATH_UI "/menu-classic.ui" , &error))
 		{
 		g_message("building menus failed: %s", error->message);
 		exit(EXIT_FAILURE);
@@ -3092,14 +3092,14 @@ void layout_actions_add_window(LayoutWindow *lw, GtkWidget *window)
 
 	if (!lw->ui_manager) return;
 
-	group = gq_gtk_ui_manager_get_accel_group(lw->ui_manager);
+	group = deprecated_gtk_ui_manager_get_accel_group(lw->ui_manager);
 	gtk_window_add_accel_group(GTK_WINDOW(window), group);
 }
 
 GtkWidget *layout_actions_menu_bar(LayoutWindow *lw)
 {
 	if (lw->menu_bar) return lw->menu_bar;
-	lw->menu_bar = gq_gtk_ui_manager_get_widget(lw->ui_manager, "/MainMenu");
+	lw->menu_bar = deprecated_gtk_ui_manager_get_widget(lw->ui_manager, "/MainMenu");
 	return g_object_ref(lw->menu_bar);
 }
 
@@ -3155,13 +3155,13 @@ void layout_toolbar_clear(LayoutWindow *lw, ToolbarType type)
 {
 	if (lw->toolbar_merge_id[type])
 		{
-		gq_gtk_ui_manager_remove_ui(lw->ui_manager, lw->toolbar_merge_id[type]);
-		gq_gtk_ui_manager_ensure_update(lw->ui_manager);
+		deprecated_gtk_ui_manager_remove_ui(lw->ui_manager, lw->toolbar_merge_id[type]);
+		deprecated_gtk_ui_manager_ensure_update(lw->ui_manager);
 		}
 	g_list_free_full(lw->toolbar_actions[type], g_free);
 	lw->toolbar_actions[type] = nullptr;
 
-	lw->toolbar_merge_id[type] = gq_gtk_ui_manager_new_merge_id(lw->ui_manager);
+	lw->toolbar_merge_id[type] = deprecated_gtk_ui_manager_new_merge_id(lw->ui_manager);
 
 	if (lw->toolbar[type])
 		{
@@ -3177,7 +3177,7 @@ static void action_radio_changed_cb(GtkAction *action, GtkAction *current, gpoin
 static void action_toggle_activate_cb(GtkAction* self, gpointer data)
 {
 	auto button = static_cast<GtkToggleButton *>(data);
-	const gboolean action_active = gq_gtk_toggle_action_get_active(GQ_GTK_TOGGLE_ACTION(self));
+	const gboolean action_active = deprecated_gtk_toggle_action_get_active(deprecated_GTK_TOGGLE_ACTION(self));
 
 	if (gtk_toggle_button_get_active(button) != action_active)
 		{
@@ -3187,7 +3187,7 @@ static void action_toggle_activate_cb(GtkAction* self, gpointer data)
 
 static gboolean toolbar_button_press_event_cb(GtkWidget *, GdkEvent *, gpointer data)
 {
-	gq_gtk_action_activate(GQ_GTK_ACTION(data));
+	deprecated_gtk_action_activate(deprecated_GTK_ACTION(data));
 
 	return TRUE;
 }
@@ -3226,10 +3226,10 @@ void layout_toolbar_add(LayoutWindow *lw, ToolbarType type, const gchar *action_
 		   create a dummy action for now */
 		if (!lw->action_group_editors)
 			{
-			lw->action_group_editors = gq_gtk_action_group_new("MenuActionsExternal");
-			gq_gtk_ui_manager_insert_action_group(lw->ui_manager, lw->action_group_editors, 1);
+			lw->action_group_editors = deprecated_gtk_action_group_new("MenuActionsExternal");
+			deprecated_gtk_ui_manager_insert_action_group(lw->ui_manager, lw->action_group_editors, 1);
 			}
-		if (!gq_gtk_action_group_get_action(lw->action_group_editors, action_name))
+		if (!deprecated_gtk_action_group_get_action(lw->action_group_editors, action_name))
 			{
 			GtkActionEntry entry = { action_name,
 			                         GQ_ICON_MISSING_IMAGE,
@@ -3239,7 +3239,7 @@ void layout_toolbar_add(LayoutWindow *lw, ToolbarType type, const gchar *action_
 			                         nullptr
 			                       };
 			DEBUG_1("Creating temporary action %s", action_name);
-			gq_gtk_action_group_add_actions(lw->action_group_editors, &entry, 1, lw);
+			deprecated_gtk_action_group_add_actions(lw->action_group_editors, &entry, 1, lw);
 			}
 		}
 
@@ -3251,32 +3251,32 @@ void layout_toolbar_add(LayoutWindow *lw, ToolbarType type, const gchar *action_
 		{
 		if (g_str_has_suffix(action_name, ".desktop"))
 			{
-			action = gq_gtk_action_group_get_action(lw->action_group_editors, action_name);
+			action = deprecated_gtk_action_group_get_action(lw->action_group_editors, action_name);
 
 			/** @FIXME Using tootip as a flag to layout_actions_setup_editors()
 			 * is not a good way.
 			 */
-			tooltip_text = gq_gtk_action_get_label(action);
+			tooltip_text = deprecated_gtk_action_get_label(action);
 			}
 		else
 			{
-			action = gq_gtk_action_group_get_action(lw->action_group, action_name);
+			action = deprecated_gtk_action_group_get_action(lw->action_group, action_name);
 
-			tooltip_text = gq_gtk_action_get_tooltip(action);
+			tooltip_text = deprecated_gtk_action_get_tooltip(action);
 			}
 
-		action_icon = gq_gtk_action_create_icon(action, GTK_ICON_SIZE_SMALL_TOOLBAR);
+		action_icon = deprecated_gtk_action_create_icon(action, GTK_ICON_SIZE_SMALL_TOOLBAR);
 
 		/** @FIXME This is a hack to remove run-time errors */
 		if (lw->toolbar_merge_id[type] > 0)
 			{
-			gq_gtk_ui_manager_add_ui(lw->ui_manager, lw->toolbar_merge_id[type], path, action_name, action_name, GTK_UI_MANAGER_TOOLITEM, FALSE);
+			deprecated_gtk_ui_manager_add_ui(lw->ui_manager, lw->toolbar_merge_id[type], path, action_name, action_name, GTK_UI_MANAGER_TOOLITEM, FALSE);
 			}
 
-		if (GQ_GTK_IS_RADIO_ACTION(action) || GQ_GTK_IS_TOGGLE_ACTION(action))
+		if (deprecated_GTK_IS_RADIO_ACTION(action) || deprecated_GTK_IS_TOGGLE_ACTION(action))
 			{
 			button = gtk_toggle_button_new();
-			gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), gq_gtk_toggle_action_get_active(GQ_GTK_TOGGLE_ACTION(action)));
+			gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), deprecated_gtk_toggle_action_get_active(deprecated_GTK_TOGGLE_ACTION(action)));
 			}
 		else
 			{
@@ -3295,12 +3295,12 @@ void layout_toolbar_add(LayoutWindow *lw, ToolbarType type, const gchar *action_
 		gtk_button_set_relief(GTK_BUTTON(button), GTK_RELIEF_NONE);
 		gtk_widget_set_tooltip_text(button, tooltip_text);
 
-		if (GQ_GTK_IS_RADIO_ACTION(action))
+		if (deprecated_GTK_IS_RADIO_ACTION(action))
 			{
 			id = g_signal_connect(G_OBJECT(action), "changed", G_CALLBACK(action_radio_changed_cb), button);
 			g_object_set_data(G_OBJECT(button), "id", GUINT_TO_POINTER(id));
 			}
-		else if (GQ_GTK_IS_TOGGLE_ACTION(action))
+		else if (deprecated_GTK_IS_TOGGLE_ACTION(action))
 			{
 			id = g_signal_connect(G_OBJECT(action), "activate", G_CALLBACK(action_toggle_activate_cb), button);
 			g_object_set_data(G_OBJECT(button), "id", GUINT_TO_POINTER(id));
@@ -3398,8 +3398,8 @@ void layout_util_status_update_write(LayoutWindow *lw)
 {
 	GtkAction *action;
 	gint n = metadata_queue_length();
-	action = gq_gtk_action_group_get_action(lw->action_group, "SaveMetadata");
-	gq_gtk_action_set_sensitive(action, n > 0);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "SaveMetadata");
+	deprecated_gtk_action_set_sensitive(action, n > 0);
 
 	const gchar *icon_name = n > 0 ? GQ_ICON_SAVE_AS : GQ_ICON_SAVE;
 	g_autofree const gchar *icon_tooltip= n > 0 ? g_strdup_printf("Number of files with unsaved metadata: %d",n) : g_strdup("No unsaved metadata");
@@ -3468,34 +3468,34 @@ void layout_util_sync_color(LayoutWindow *lw)
 
 	use_color = layout_image_color_profile_get_use(lw);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "UseColorProfiles");
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "UseColorProfiles");
 #if HAVE_LCMS
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), use_color);
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), use_color);
 
 	if (const auto status = layout_image_color_profile_get_status(lw); status.has_value())
 		{
 		g_autofree gchar *buf = g_strdup_printf(_("Image profile: %s\nScreen profile: %s"),
 		                                        status->image_profile.c_str(), status->screen_profile.c_str());
-		gq_gtk_action_set_tooltip(action, buf);
+		deprecated_gtk_action_set_tooltip(action, buf);
 		}
 	else
 		{
-		gq_gtk_action_set_tooltip(action, _("Click to enable color management"));
+		deprecated_gtk_action_set_tooltip(action, _("Click to enable color management"));
 		}
 #else
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), FALSE);
-	gq_gtk_action_set_sensitive(action, FALSE);
-	gq_gtk_action_set_tooltip(action, _("Color profiles not supported"));
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), FALSE);
+	deprecated_gtk_action_set_sensitive(action, FALSE);
+	deprecated_gtk_action_set_tooltip(action, _("Color profiles not supported"));
 #endif
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "UseImageProfile");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), use_image);
-	gq_gtk_action_set_sensitive(action, use_color);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "UseImageProfile");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), use_image);
+	deprecated_gtk_action_set_sensitive(action, use_color);
 
 	for (i = 0; i < COLOR_PROFILE_FILE + COLOR_PROFILE_INPUTS; i++)
 		{
 		sprintf(action_name, "ColorProfile%d", i);
-		action = gq_gtk_action_group_get_action(lw->action_group, action_name);
+		action = deprecated_gtk_action_group_get_action(lw->action_group, action_name);
 
 		if (i >= COLOR_PROFILE_FILE)
 			{
@@ -3507,16 +3507,16 @@ void layout_util_sync_color(LayoutWindow *lw)
 			g_autofree gchar *end = layout_color_name_parse(name);
 			g_autofree gchar *buf = g_strdup_printf(_("Input _%d: %s"), i, end);
 
-			gq_gtk_action_set_label(action, buf);
-			gq_gtk_action_set_visible(action, file && file[0]);
+			deprecated_gtk_action_set_label(action, buf);
+			deprecated_gtk_action_set_visible(action, file && file[0]);
 			}
 
-		gq_gtk_action_set_sensitive(action, !use_image);
-		gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), (i == input));
+		deprecated_gtk_action_set_sensitive(action, !use_image);
+		deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), (i == input));
 		}
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "Grayscale");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), layout_image_get_desaturate(lw));
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "Grayscale");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), layout_image_get_desaturate(lw));
 }
 
 void layout_util_sync_file_filter(LayoutWindow *lw)
@@ -3525,8 +3525,8 @@ void layout_util_sync_file_filter(LayoutWindow *lw)
 
 	if (!lw->action_group) return;
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "ShowFileFilter");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), lw->options.show_file_filter);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "ShowFileFilter");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), lw->options.show_file_filter);
 }
 
 void layout_util_sync_marks(LayoutWindow *lw)
@@ -3535,8 +3535,8 @@ void layout_util_sync_marks(LayoutWindow *lw)
 
 	if (!lw->action_group) return;
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "ShowMarks");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), lw->options.show_marks);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "ShowMarks");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), lw->options.show_marks);
 }
 
 static void layout_util_sync_views(LayoutWindow *lw)
@@ -3546,104 +3546,104 @@ static void layout_util_sync_views(LayoutWindow *lw)
 
 	if (!lw->action_group) return;
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "FolderTree");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), lw->options.dir_view_type);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "FolderTree");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), lw->options.dir_view_type);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "SplitSingle");
-	gq_gtk_radio_action_set_current_value(GQ_GTK_RADIO_ACTION(action), lw->split_mode);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "SplitSingle");
+	deprecated_gtk_radio_action_set_current_value(deprecated_GTK_RADIO_ACTION(action), lw->split_mode);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "SplitNextPane");
-	gq_gtk_action_set_sensitive(action, !(lw->split_mode == SPLIT_NONE));
-	action = gq_gtk_action_group_get_action(lw->action_group, "SplitPreviousPane");
-	gq_gtk_action_set_sensitive(action, !(lw->split_mode == SPLIT_NONE));
-	action = gq_gtk_action_group_get_action(lw->action_group, "SplitUpPane");
-	gq_gtk_action_set_sensitive(action, !(lw->split_mode == SPLIT_NONE));
-	action = gq_gtk_action_group_get_action(lw->action_group, "SplitDownPane");
-	gq_gtk_action_set_sensitive(action, !(lw->split_mode == SPLIT_NONE));
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "SplitNextPane");
+	deprecated_gtk_action_set_sensitive(action, !(lw->split_mode == SPLIT_NONE));
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "SplitPreviousPane");
+	deprecated_gtk_action_set_sensitive(action, !(lw->split_mode == SPLIT_NONE));
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "SplitUpPane");
+	deprecated_gtk_action_set_sensitive(action, !(lw->split_mode == SPLIT_NONE));
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "SplitDownPane");
+	deprecated_gtk_action_set_sensitive(action, !(lw->split_mode == SPLIT_NONE));
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "SplitPaneSync");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), lw->options.split_pane_sync);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "SplitPaneSync");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), lw->options.split_pane_sync);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "ViewIcons");
-	gq_gtk_radio_action_set_current_value(GQ_GTK_RADIO_ACTION(action), lw->options.file_view_type);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "ViewIcons");
+	deprecated_gtk_radio_action_set_current_value(deprecated_GTK_RADIO_ACTION(action), lw->options.file_view_type);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "CropNone");
-	gq_gtk_radio_action_set_current_value(GQ_GTK_RADIO_ACTION(action), options->rectangle_draw_aspect_ratio);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "CropNone");
+	deprecated_gtk_radio_action_set_current_value(deprecated_GTK_RADIO_ACTION(action), options->rectangle_draw_aspect_ratio);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "OSD1");
-	gq_gtk_radio_action_set_current_value(GQ_GTK_RADIO_ACTION(action), options->overlay_screen_display_selected_profile);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "OSD1");
+	deprecated_gtk_radio_action_set_current_value(deprecated_GTK_RADIO_ACTION(action), options->overlay_screen_display_selected_profile);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "FloatTools");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), lw->options.tools_float);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "FloatTools");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), lw->options.tools_float);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "SBar");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), layout_bar_enabled(lw));
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "SBar");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), layout_bar_enabled(lw));
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "SBarSort");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), layout_bar_sort_enabled(lw));
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "SBarSort");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), layout_bar_sort_enabled(lw));
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "HideSelectableToolbars");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), lw->options.selectable_toolbars_hidden);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "HideSelectableToolbars");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), lw->options.selectable_toolbars_hidden);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "ShowInfoPixel");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), lw->options.show_info_pixel);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "ShowInfoPixel");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), lw->options.show_info_pixel);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "SlideShow");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), layout_image_slideshow_active(lw));
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "SlideShow");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), layout_image_slideshow_active(lw));
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "IgnoreAlpha");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), lw->options.ignore_alpha);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "IgnoreAlpha");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), lw->options.ignore_alpha);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "Animate");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), lw->options.animate);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "Animate");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), lw->options.animate);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "ImageOverlay");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), osd_flags != OSD_SHOW_NOTHING);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "ImageOverlay");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), osd_flags != OSD_SHOW_NOTHING);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "ImageHistogram");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), osd_flags & OSD_SHOW_HISTOGRAM);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "ImageHistogram");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), osd_flags & OSD_SHOW_HISTOGRAM);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "ExifRotate");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), options->image.exif_rotate_enable);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "ExifRotate");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), options->image.exif_rotate_enable);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "OverUnderExposed");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), options->overunderexposed);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "OverUnderExposed");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), options->overunderexposed);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "DrawRectangle");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), options->draw_rectangle);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "DrawRectangle");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), options->draw_rectangle);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "RectangularSelection");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), options->collections.rectangular_selection);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "RectangularSelection");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), options->collections.rectangular_selection);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "ShowFileFilter");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), lw->options.show_file_filter);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "ShowFileFilter");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), lw->options.show_file_filter);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "HideBars");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), (lw->options.bars_state.hidden));
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "HideBars");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), (lw->options.bars_state.hidden));
 
 	if (osd_flags & OSD_SHOW_HISTOGRAM)
 		{
-		action = gq_gtk_action_group_get_action(lw->action_group, "HistogramChanR");
-		gq_gtk_radio_action_set_current_value(GQ_GTK_RADIO_ACTION(action), image_osd_histogram_get_channel(lw->image));
+		action = deprecated_gtk_action_group_get_action(lw->action_group, "HistogramChanR");
+		deprecated_gtk_radio_action_set_current_value(deprecated_GTK_RADIO_ACTION(action), image_osd_histogram_get_channel(lw->image));
 
-		action = gq_gtk_action_group_get_action(lw->action_group, "HistogramModeLin");
-		gq_gtk_radio_action_set_current_value(GQ_GTK_RADIO_ACTION(action), image_osd_histogram_get_mode(lw->image));
+		action = deprecated_gtk_action_group_get_action(lw->action_group, "HistogramModeLin");
+		deprecated_gtk_radio_action_set_current_value(deprecated_GTK_RADIO_ACTION(action), image_osd_histogram_get_mode(lw->image));
 		}
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "ConnectZoomMenu");
-	gq_gtk_action_set_sensitive(action, lw->split_mode != SPLIT_NONE);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "ConnectZoomMenu");
+	deprecated_gtk_action_set_sensitive(action, lw->split_mode != SPLIT_NONE);
 
 	// @todo `which` is deprecated, use command -v
 	gboolean is_write_rotation = !runcmd("which exiftran >/dev/null 2>&1")
 	                          && !runcmd("which mogrify >/dev/null 2>&1")
 	                          && !options->metadata.write_orientation;
-	action = gq_gtk_action_group_get_action(lw->action_group, "WriteRotation");
-	gq_gtk_action_set_sensitive(action, is_write_rotation);
-	action = gq_gtk_action_group_get_action(lw->action_group, "WriteRotationKeepDate");
-	gq_gtk_action_set_sensitive(action, is_write_rotation);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "WriteRotation");
+	deprecated_gtk_action_set_sensitive(action, is_write_rotation);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "WriteRotationKeepDate");
+	deprecated_gtk_action_set_sensitive(action, is_write_rotation);
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "StereoAuto");
-	gq_gtk_radio_action_set_current_value(GQ_GTK_RADIO_ACTION(action), layout_image_stereo_pixbuf_get(lw));
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "StereoAuto");
+	deprecated_gtk_radio_action_set_current_value(deprecated_GTK_RADIO_ACTION(action), layout_image_stereo_pixbuf_get(lw));
 
 	layout_util_sync_marks(lw);
 	layout_util_sync_color(lw);
@@ -3658,9 +3658,9 @@ void layout_util_sync_thumb(LayoutWindow *lw)
 
 	if (!lw->action_group) return;
 
-	action = gq_gtk_action_group_get_action(lw->action_group, "Thumbnails");
-	gq_gtk_toggle_action_set_active(GQ_GTK_TOGGLE_ACTION(action), lw->options.show_thumbnails);
-	gq_gtk_action_set_sensitive(action, lw->options.file_view_type == FILEVIEW_LIST);
+	action = deprecated_gtk_action_group_get_action(lw->action_group, "Thumbnails");
+	deprecated_gtk_toggle_action_set_active(deprecated_GTK_TOGGLE_ACTION(action), lw->options.show_thumbnails);
+	deprecated_gtk_action_set_sensitive(action, lw->options.file_view_type == FILEVIEW_LIST);
 }
 
 void layout_util_sync(LayoutWindow *lw)

--- a/src/main.cc
+++ b/src/main.cc
@@ -648,7 +648,7 @@ void set_theme_bg_color()
 		LayoutWindow *lw = layout_window_first();
 
 		style_context = gtk_widget_get_style_context(lw->window);
-		gq_gtk_style_context_get_background_color(style_context, GTK_STATE_FLAG_NORMAL, &bg_color);
+		deprecated_gtk_style_context_get_background_color(style_context, GTK_STATE_FLAG_NORMAL, &bg_color);
 
 		theme_color.red = bg_color.red  ;
 		theme_color.green = bg_color.green  ;

--- a/src/pixbuf-renderer.cc
+++ b/src/pixbuf-renderer.cc
@@ -448,7 +448,7 @@ static void pixbuf_renderer_init(PixbufRenderer *pr)
 
 	pr->renderer2 = nullptr;
 
-	gq_gtk_widget_set_double_buffered(box, FALSE);
+	deprecated_gtk_widget_set_double_buffered(box, FALSE);
 	gtk_widget_set_app_paintable(box, TRUE);
 	g_signal_connect_after(G_OBJECT(box), "size_allocate",
 			       G_CALLBACK(pr_size_cb), pr);
@@ -639,8 +639,8 @@ static gboolean pr_parent_window_resize(PixbufRenderer *pr, gint w, gint h)
 
 	if (pr->window_limit)
 		{
-		gint sw = gq_gdk_screen_width() * pr->window_limit_size / 100;
-		gint sh = gq_gdk_screen_height() * pr->window_limit_size / 100;
+		gint sw = deprecated_gdk_screen_width() * pr->window_limit_size / 100;
+		gint sh = deprecated_gdk_screen_height() * pr->window_limit_size / 100;
 
 		w = std::min(w, sw);
 		h = std::min(h, sh);
@@ -1606,8 +1606,8 @@ static gboolean pr_zoom_clamp(PixbufRenderer *pr, gdouble zoom,
 
 		if (sizeable)
 			{
-			max_w = gq_gdk_screen_width();
-			max_h = gq_gdk_screen_height();
+			max_w = deprecated_gdk_screen_width();
+			max_h = deprecated_gdk_screen_height();
 
 			if (pr->window_limit)
 				{

--- a/src/pixbuf-util.cc
+++ b/src/pixbuf-util.cc
@@ -243,13 +243,13 @@ static void register_stock_icon(const gchar *key, GdkPixbuf *pixbuf)
 {
 	static GtkIconFactory *icon_factory = []()
 	{
-		GtkIconFactory *icon_factory = gq_gtk_icon_factory_new();
-		gq_gtk_icon_factory_add_default(icon_factory);
+		GtkIconFactory *icon_factory = deprecated_gtk_icon_factory_new();
+		deprecated_gtk_icon_factory_add_default(icon_factory);
 		return icon_factory;
 	}();
 
-	GtkIconSet *icon_set = gtk_icon_set_new_from_pixbuf(pixbuf);
-	gq_gtk_icon_factory_add(icon_factory, key, icon_set);
+	GtkIconSet *icon_set = deprecated_gtk_icon_set_new_from_pixbuf(pixbuf);
+	deprecated_gtk_icon_factory_add(icon_factory, key, icon_set);
 }
 #endif
 

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -1587,14 +1587,14 @@ static void accel_store_populate()
 	LayoutWindow *lw = layout_window_first(); /* get the actions from the first window, it should not matter, they should be the same in all windows */
 
 	g_assert(lw && lw->ui_manager);
-	groups = gq_gtk_ui_manager_get_action_groups(lw->ui_manager);
+	groups = deprecated_gtk_ui_manager_get_action_groups(lw->ui_manager);
 	while (groups)
 		{
-		g_autoptr(GList) actions = gq_gtk_action_group_list_actions(GQ_GTK_ACTION_GROUP(groups->data));
+		g_autoptr(GList) actions = deprecated_gtk_action_group_list_actions(deprecated_GTK_ACTION_GROUP(groups->data));
 		for (GList *work = actions; work; work = work->next)
 			{
-			GtkAction *action = GQ_GTK_ACTION(work->data);
-			accel_path = gq_gtk_action_get_accel_path(action);
+			GtkAction *action = deprecated_GTK_ACTION(work->data);
+			accel_path = deprecated_gtk_action_get_accel_path(action);
 			if (accel_path && gtk_accel_map_lookup_entry(accel_path, &key))
 				{
 				g_autofree gchar *label = nullptr;
@@ -1613,7 +1613,7 @@ static void accel_store_populate()
 						}
 
 					g_autofree gchar *accel = gtk_accelerator_name(key.accel_key, key.accel_mods);
-					const gchar *icon_name = gq_gtk_action_get_icon_name(action);
+					const gchar *icon_name = deprecated_gtk_action_get_icon_name(action);
 
 					gtk_tree_store_append(accel_store, &iter, nullptr);
 					gtk_tree_store_set(accel_store, &iter,

--- a/src/renderer-tiles.cc
+++ b/src/renderer-tiles.cc
@@ -576,7 +576,7 @@ void rt_overlay_draw(RendererTiles *rt, GdkRectangle request_rect, ImageTile *it
 				cairo_fill(cr);
 				cairo_destroy (cr);
 
-				cr = gq_gdk_cairo_create(od->window);
+				cr = deprecated_gdk_cairo_create(od->window);
 				cairo_set_source_surface(cr, rt->overlay_buffer, r.x - od_rect.x, r.y - od_rect.y);
 				cairo_rectangle (cr, r.x - od_rect.x, r.y - od_rect.y, r.width, r.height);
 				cairo_fill (cr);

--- a/src/search-and-run.cc
+++ b/src/search-and-run.cc
@@ -71,14 +71,14 @@ static void command_store_populate(SarData* sar)
 
 	gtk_tree_sortable_set_sort_column_id(sortable, SAR_LABEL, GTK_SORT_ASCENDING);
 
-	groups = gq_gtk_ui_manager_get_action_groups(sar->lw->ui_manager);
+	groups = deprecated_gtk_ui_manager_get_action_groups(sar->lw->ui_manager);
 	while (groups)
 		{
-		g_autoptr(GList) actions = gq_gtk_action_group_list_actions(GQ_GTK_ACTION_GROUP(groups->data));
+		g_autoptr(GList) actions = deprecated_gtk_action_group_list_actions(deprecated_GTK_ACTION_GROUP(groups->data));
 		for (GList *work = actions; work; work = work->next)
 			{
-			GtkAction *action = GQ_GTK_ACTION(work->data);
-			accel_path = gq_gtk_action_get_accel_path(action);
+			GtkAction *action = deprecated_GTK_ACTION(work->data);
+			accel_path = deprecated_gtk_action_get_accel_path(action);
 			if (accel_path && gtk_accel_map_lookup_entry(accel_path, &key))
 				{
 				g_autofree gchar *label = nullptr;
@@ -164,7 +164,7 @@ static gboolean entry_box_activate_cb(GtkWidget *, gpointer data)
 
 	if (sar->action)
 		{
-		gq_gtk_action_activate(sar->action);
+		deprecated_gtk_action_activate(sar->action);
 		}
 
 	search_and_run_destroy(sar);
@@ -202,7 +202,7 @@ static gboolean match_selected_cb(GtkEntryCompletion *, GtkTreeModel *model, Gtk
 
 	if (sar->action)
 		{
-		gq_gtk_action_activate(sar->action);
+		deprecated_gtk_action_activate(sar->action);
 		}
 
 	g_idle_add(search_and_run_destroy, sar);

--- a/src/ui-menu.cc
+++ b/src/ui-menu.cc
@@ -83,8 +83,8 @@ static gint actions_sort_cb(gconstpointer a, gconstpointer b)
 	const gchar *accel_path_b;
 	GtkAccelKey key_b;
 
-	accel_path_a = gq_gtk_action_get_accel_path(GQ_GTK_ACTION(a));
-	accel_path_b = gq_gtk_action_get_accel_path(GQ_GTK_ACTION(b));
+	accel_path_a = deprecated_gtk_action_get_accel_path(deprecated_GTK_ACTION(a));
+	accel_path_b = deprecated_gtk_action_get_accel_path(deprecated_GTK_ACTION(b));
 
 	if (accel_path_a && gtk_accel_map_lookup_entry(accel_path_a, &key_a) && accel_path_b && gtk_accel_map_lookup_entry(accel_path_b, &key_b))
 		{
@@ -117,17 +117,17 @@ static void menu_item_add_main_window_accelerator(GtkWidget *menu, GtkAccelGroup
 	LayoutWindow *lw = layout_window_first(); /* get the actions from the first window, it should not matter, they should be the same in all windows */
 
 	g_assert(lw && lw->ui_manager);
-	groups = gq_gtk_ui_manager_get_action_groups(lw->ui_manager);
+	groups = deprecated_gtk_ui_manager_get_action_groups(lw->ui_manager);
 
 	while (groups)
 		{
-		g_autoptr(GList) actions = gq_gtk_action_group_list_actions(GQ_GTK_ACTION_GROUP(groups->data));
+		g_autoptr(GList) actions = deprecated_gtk_action_group_list_actions(deprecated_GTK_ACTION_GROUP(groups->data));
 		actions = g_list_sort(actions, actions_sort_cb);
 
 		for (GList *work = actions; work; work = work->next)
 			{
-			GtkAction *action = GQ_GTK_ACTION(work->data);
-			accel_path = gq_gtk_action_get_accel_path(action);
+			GtkAction *action = deprecated_GTK_ACTION(work->data);
+			accel_path = deprecated_gtk_action_get_accel_path(action);
 			GtkAccelKey key;
 			if (accel_path && gtk_accel_map_lookup_entry(accel_path, &key) && key.accel_key != 0)
 				{
@@ -192,10 +192,10 @@ GtkWidget *menu_item_add_stock(GtkWidget *menu, const gchar *label, const gchar 
 	GtkWidget *item;
 	GtkWidget *image;
 
-	item = gq_gtk_image_menu_item_new_with_mnemonic(label);
+	item = deprecated_gtk_image_menu_item_new_with_mnemonic(label);
 
 	image = gq_gtk_image_new_from_stock(stock_id, GTK_ICON_SIZE_MENU);
-	gq_gtk_image_menu_item_set_image(GQ_GTK_IMAGE_MENU_ITEM(item), image);
+	deprecated_gtk_image_menu_item_set_image(deprecated_GTK_IMAGE_MENU_ITEM(item), image);
 	gtk_widget_show(image);
 
 	menu_item_add_accelerator(menu, item);
@@ -211,10 +211,10 @@ GtkWidget *menu_item_add_icon(GtkWidget *menu, const gchar *label, const gchar *
 	GtkWidget *item;
 	GtkWidget *image;
 
-	item = gq_gtk_image_menu_item_new_with_mnemonic(label);
+	item = deprecated_gtk_image_menu_item_new_with_mnemonic(label);
 
 	image = gtk_image_new_from_icon_name(icon_name, GTK_ICON_SIZE_MENU);
-	gq_gtk_image_menu_item_set_image(GQ_GTK_IMAGE_MENU_ITEM(item), image);
+	deprecated_gtk_image_menu_item_set_image(deprecated_GTK_IMAGE_MENU_ITEM(item), image);
 	gtk_widget_show(image);
 
 	menu_item_add_accelerator(menu, item);

--- a/src/ui-misc.cc
+++ b/src/ui-misc.cc
@@ -825,7 +825,7 @@ static void date_selection_popup(DateSelection *ds)
 	x = wx + button_allocation.x + button_allocation.width - window_allocation.width;
 	y = wy + button_allocation.y + button_allocation.height;
 
-	if (y + window_allocation.height > gq_gdk_screen_height())
+	if (y + window_allocation.height > deprecated_gdk_screen_height())
 		{
 		y = wy + button_allocation.y - window_allocation.height;
 		}
@@ -856,7 +856,7 @@ static void button_size_allocate_cb(GtkWidget *button, GtkAllocation *allocation
 {
 	auto spin = static_cast<GtkWidget *>(data);
 	GtkRequisition spin_requisition;
-	gq_gtk_widget_get_requisition(spin, &spin_requisition);
+	deprecated_gtk_widget_get_requisition(spin, &spin_requisition);
 
 	if (allocation->height > spin_requisition.height)
 		{
@@ -1290,14 +1290,14 @@ std::vector<ActionItem> get_action_items()
 
 	std::vector<ActionItem> list_duplicates;
 
-	for (GList *groups = gq_gtk_ui_manager_get_action_groups(lw->ui_manager); groups; groups = groups->next)
+	for (GList *groups = deprecated_gtk_ui_manager_get_action_groups(lw->ui_manager); groups; groups = groups->next)
 		{
-		g_autoptr(GList) actions = gq_gtk_action_group_list_actions(GQ_GTK_ACTION_GROUP(groups->data));
+		g_autoptr(GList) actions = deprecated_gtk_action_group_list_actions(deprecated_GTK_ACTION_GROUP(groups->data));
 		for (GList *work = actions; work; work = work->next)
 			{
-			GtkAction *action = GQ_GTK_ACTION(work->data);
+			GtkAction *action = deprecated_GTK_ACTION(work->data);
 
-			const gchar *accel_path = gq_gtk_action_get_accel_path(action);
+			const gchar *accel_path = deprecated_gtk_action_get_accel_path(action);
 			if (accel_path && gtk_accel_map_lookup_entry(accel_path, nullptr))
 				{
 				g_autofree gchar *action_name = g_path_get_basename(accel_path);
@@ -1310,7 +1310,7 @@ std::vector<ActionItem> get_action_items()
 #if HAVE_GTK4
 /* @FIXME GTK4 stub */
 #else
-					list_duplicates.emplace_back(action_name, action_label, gtk_action_get_stock_id(action));
+					list_duplicates.emplace_back(action_name, action_label, deprecated_gtk_action_get_stock_id(action));
 #endif
 					}
 				}

--- a/src/view-dir-tree.cc
+++ b/src/view-dir-tree.cc
@@ -82,7 +82,7 @@ static void set_cursor(GtkWidget *widget, gint cursor_type)
 	if (!widget) return;
 
 	widget_set_cursor(widget, cursor_type);
-	gq_gdk_flush();
+	deprecated_gdk_flush();
 }
 
 static void vdtree_busy_push(ViewDir *vd)

--- a/src/view-dir.cc
+++ b/src/view-dir.cc
@@ -1079,7 +1079,7 @@ static GdkRGBA *vd_color_shifted(GtkWidget *widget)
 		GtkStyleContext *style_context;
 
 		style_context = gtk_widget_get_style_context(widget);
-		gq_gtk_style_context_get_background_color(style_context, GTK_STATE_FLAG_NORMAL, &color);
+		deprecated_gtk_style_context_get_background_color(style_context, GTK_STATE_FLAG_NORMAL, &color);
 
 		shift_color(color);
 		done = widget;

--- a/src/view-file/view-file-icon.cc
+++ b/src/view-file/view-file-icon.cc
@@ -1948,7 +1948,7 @@ static void vficon_cell_data_cb(GtkTreeViewColumn *, GtkCellRenderer *cell,
 			name_sidecars = g_string_append(name_sidecars, star_rating);
 			}
 
-		GtkStyle *style = gq_gtk_widget_get_style(vf->listview);
+		GtkStyle *style = deprecated_gtk_widget_get_style(vf->listview);
 		GtkStateType state = (fd->selected & SELECTION_SELECTED) ? GTK_STATE_SELECTED : GTK_STATE_NORMAL;
 
 		GdkRGBA color_fg = convert_gdkcolor_to_gdkrgba(&style->text[state]);

--- a/src/view-file/view-file-list.cc
+++ b/src/view-file/view-file-list.cc
@@ -1704,7 +1704,7 @@ static GdkRGBA *vflist_listview_color_shifted(GtkWidget *widget)
 		{
 		GtkStyle *style;
 
-		style = gq_gtk_widget_get_style(widget);
+		style = deprecated_gtk_widget_get_style(widget);
 		color = convert_gdkcolor_to_gdkrgba(&style->base[GTK_STATE_NORMAL]);
 
 		shift_color(color);


### PR DESCRIPTION
Replace `gq` prefix with `deprecated` prefix in `compat-deprecated.h` to avoid confusing with `compat.h` functions.
Disable GTK4 migration regression check for `compat-deprecated.h`.