### PR TITLE
Fix warnings found by clang-tidy's bugprone-reserved-identifier

### DIFF
--- a/CODING.md
+++ b/CODING.md
@@ -183,7 +183,7 @@ Pragma: (Indentation 2 spaces)
 Headers:
 
 ```c
-#ifndef _FILENAME_H
+#ifndef FILENAME_H
 ```
 
 Use [Names and Order of Includes](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes) for headers include order.

--- a/src/archives.h
+++ b/src/archives.h
@@ -18,8 +18,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef _ARCHIVES_H
-#define _ARCHIVES_H
+#ifndef ARCHIVES_H
+#define ARCHIVES_H
 
 #include <glib.h>
 
@@ -27,5 +27,5 @@ class FileData;
 
 gchar *open_archive(const FileData *fd);
 
-#endif /* _ARCHIVES_H */
+#endif /* ARCHIVES_H */
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/cellrenderericon.h
+++ b/src/cellrenderericon.h
@@ -17,8 +17,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef __GQV_CELL_RENDERER_ICON_H__
-#define __GQV_CELL_RENDERER_ICON_H__
+#ifndef GQV_CELL_RENDERER_ICON_H
+#define GQV_CELL_RENDERER_ICON_H
 
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <glib-object.h>
@@ -82,5 +82,5 @@ struct GQvCellRendererIconClass
 GType            gqv_cell_renderer_icon_get_type();
 GtkCellRenderer *gqv_cell_renderer_icon_new();
 
-#endif /* __GQV_CELL_RENDERER_ICON_H__ */
+#endif /* GQV_CELL_RENDERER_ICON_H */
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/exif-int.h
+++ b/src/exif-int.h
@@ -19,8 +19,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef __EXIF_INT_H
-#define __EXIF_INT_H
+#ifndef EXIF_INT_H
+#define EXIF_INT_H
 
 #include <cstdio>
 

--- a/src/exif.h
+++ b/src/exif.h
@@ -19,8 +19,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef __EXIF_H
-#define __EXIF_H
+#ifndef EXIF_H
+#define EXIF_H
 
 #include <optional>
 

--- a/src/format-canon.h
+++ b/src/format-canon.h
@@ -19,8 +19,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef __FORMAT_CANON_H
-#define __FORMAT_CANON_H
+#ifndef FORMAT_CANON_H
+#define FORMAT_CANON_H
 
 #include <glib.h>
 

--- a/src/format-fuji.h
+++ b/src/format-fuji.h
@@ -20,8 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef __FORMAT_FUJI_H
-#define __FORMAT_FUJI_H
+#ifndef FORMAT_FUJI_H
+#define FORMAT_FUJI_H
 
 #include <glib.h>
 

--- a/src/format-nikon.h
+++ b/src/format-nikon.h
@@ -17,8 +17,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef __FORMAT_NIKON_H
-#define __FORMAT_NIKON_H
+#ifndef FORMAT_NIKON_H
+#define FORMAT_NIKON_H
 
 #include <glib.h>
 

--- a/src/format-olympus.h
+++ b/src/format-olympus.h
@@ -17,8 +17,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef __FORMAT_OLYMPUS_H
-#define __FORMAT_OLYMPUS_H
+#ifndef FORMAT_OLYMPUS_H
+#define FORMAT_OLYMPUS_H
 
 #include <glib.h>
 

--- a/src/format-raw.h
+++ b/src/format-raw.h
@@ -19,8 +19,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef __FORMAT_RAW_H
-#define __FORMAT_RAW_H
+#ifndef FORMAT_RAW_H
+#define FORMAT_RAW_H
 
 #include <glib.h>
 

--- a/src/glua.h
+++ b/src/glua.h
@@ -18,8 +18,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef __GLUA_H
-#define __GLUA_H
+#ifndef GLUA_H
+#define GLUA_H
 
 #include <glib.h>
 
@@ -29,5 +29,5 @@ void lua_init();
 
 gchar *lua_callvalue(FileData *fd, const gchar *file, const gchar *function);
 
-#endif /* __GLUA_H */
+#endif /* GLUA_H */
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/intl.h
+++ b/src/intl.h
@@ -19,8 +19,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef __INTL_H__
-#define __INTL_H__
+#ifndef INTL_H
+#define INTL_H
 
 #include <config.h>
 

--- a/src/main-defines.h
+++ b/src/main-defines.h
@@ -19,8 +19,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef _MAIN_DEFINES_H
-#define _MAIN_DEFINES_H
+#ifndef MAIN_DEFINES_H
+#define MAIN_DEFINES_H
 
 #define USE_XDG 1
 
@@ -169,5 +169,5 @@
 // PIXBUF_INLINE_ICON_ZOOMFILLHOR
 // PIXBUF_INLINE_ICON_ZOOMFILLVERT
 
-#endif /* _MAIN_DEFINES_H */
+#endif /* MAIN_DEFINES_H */
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */


### PR DESCRIPTION
Can't enable `bugprone-reserved-identifier` in `.clang-tidy` since it alerts on GLib macros.

Fix #2138.