### PR TITLE
Updates image-test.py to always fail when Geeqie crashes, even if we're running an image that's expected to fail.

### DIFF
--- a/build-aux/image-test.py
+++ b/build-aux/image-test.py
@@ -157,8 +157,22 @@ def main(argv) -> int:
 
 if __name__ == "__main__":
     try:
-        exit(main(sys.argv))
+        exit_code = main(sys.argv)
+        if exit_code not in [0, 1]:
+            # This is so that Geeqie crashes in expected-failure cases will
+            # still trigger a non-passing result.  This is following the
+            # protocol that Meson describes here:
+            # https://mesonbuild.com/Unit-tests.html#skipped-tests-and-hard-errors
+            #
+            # We can replace this with expected_exitcode once we bump our meson
+            # dependency to 1.11.0 .
+            exit_code = 99
+
+        exit(exit_code)
 
     except GeeqieTestError as e:
         traceback.print_exception(e)
+        if e.exit_code not in [0, 1]:
+            # See comment above.
+            exit(99)
         exit(e.exit_code)


### PR DESCRIPTION
So, for example, a Geeqie segfault might have return code 134.  Without this change, that would be considered an "expected failure", by virtue of being a non-zero return code.  But with this change, it would still be considered an error, given that it's not 0 (no error) or 1 (Geeqie failed to load the image, but did not crash).

See https://mesonbuild.com/Unit-tests.html#skipped-tests-and-hard-errors .  This is a workaround for a feature introduced in meson 1.11.0

This is intended to allow us to distinguish a Geeqie crash (pre-fix) from an expected-failure (post-fix) for the #2281 test image