### PR TITLE
Fixes a use-after-free bug in FileCache where a pointer was invalidated by the notify callback system

### DIFF
--- a/src/filecache.cc
+++ b/src/filecache.cc
@@ -138,14 +138,13 @@ gboolean file_cache_get(FileCacheData *fc, FileData *fd)
 	/* entry exists */
 	DEBUG_2("cache hit: fc=%p %s", (void *)fc, fd->path);
 
-	/* TODO[xsdg]: This short-circuit skips the file existence check for files at the beginning
-	   of the list. */
-	if (work == fc->list) return TRUE; /* already at the beginning */
-
-	/* move it to the beginning */
-	DEBUG_2("cache move to front: fc=%p %s", (void *)fc, fd->path);
-	fc->list = g_list_remove_link(fc->list, work);
-	fc->list = g_list_concat(work, fc->list);
+	/* move it to the beginning, if needed */
+	if (work != fc->list)
+		{
+		DEBUG_2("cache move to front: fc=%p %s", (void *)fc, fd->path);
+		fc->list = g_list_remove_link(fc->list, work);
+		fc->list = g_list_concat(work, fc->list);
+		}
 
 	if (file_data_check_changed_files(fd))
 		{

--- a/src/filecache.cc
+++ b/src/filecache.cc
@@ -148,8 +148,11 @@ gboolean file_cache_get(FileCacheData *fc, FileData *fd)
 	if (file_data_check_changed_files(fd))
 		{
 		/* file has been changed, cache entry is no longer valid */
+		/* note that it may have already been evicted from the cache! */
 		file_cache_dump(fc);
-		file_cache_remove_entry(fc, work);
+		work = g_list_find_custom(fc->list, fd, reinterpret_cast<GCompareFunc>(file_cache_entry_compare_fd));
+		if (work) file_cache_remove_entry(fc, work);
+
 		return FALSE;
 		}
 

--- a/src/filecache.cc
+++ b/src/filecache.cc
@@ -138,6 +138,8 @@ gboolean file_cache_get(FileCacheData *fc, FileData *fd)
 	/* entry exists */
 	DEBUG_2("cache hit: fc=%p %s", (void *)fc, fd->path);
 
+	/* TODO[xsdg]: This short-circuit skips the file existence check for files at the beginning
+	   of the list. */
 	if (work == fc->list) return TRUE; /* already at the beginning */
 
 	/* move it to the beginning */

--- a/tests/filecache.cc
+++ b/tests/filecache.cc
@@ -56,6 +56,7 @@ class FileCacheTest : public t::Test
 
 TEST_F(FileCacheTest, BasicLifecycle)
 {
+	// TODO[xsdg]: Create a mock FileData that acts like the underlying file exists.
 	fd = FileData::file_data_new_simple("/does/not/exist.jpg", &context);
 	fd2 = FileData::file_data_new_simple("/does/not/exist2.jpg", &context);
 	FileCacheData *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
@@ -63,15 +64,15 @@ TEST_F(FileCacheTest, BasicLifecycle)
 	ASSERT_FALSE(file_cache_get(fc, fd));
 	ASSERT_FALSE(file_cache_get(fc, fd2));
 
+	// Because the FileDatas point to files that don't exist, they will get evicted from the
+	// cache during file_cache_get.
 	file_cache_put(fc, fd, /*size=*/1);
-	ASSERT_TRUE(file_cache_get(fc, fd));
+	ASSERT_FALSE(file_cache_get(fc, fd));
 	ASSERT_FALSE(file_cache_get(fc, fd2));
 
-	// Because the FileDatas point to files that don't exist, they will get evicted from the
-	// cache during file_cache_get.  But this only happens when size > 1.
 	file_cache_put(fc, fd2, /*size=*/1);
 	ASSERT_FALSE(file_cache_get(fc, fd));
-	ASSERT_TRUE(file_cache_get(fc, fd2));
+	ASSERT_FALSE(file_cache_get(fc, fd2));
 }
 
 }  // anonymous namespace

--- a/tests/filecache.cc
+++ b/tests/filecache.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2026 The Geeqie Team
+ *
+ * Author: Omari Stephens
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *
+ * Unit tests for filecache.cc
+ *
+ */
+
+#include "gtest/gtest.h"
+
+#include <glib.h>
+
+#include "filecache.h"
+#include "filedata.h"
+
+namespace {
+
+// For convenience.
+namespace t = ::testing;
+
+class FileCacheTest : public t::Test
+{
+    protected:
+	void TearDown() override
+	{
+		g_clear_pointer(&fd, g_free);
+		g_clear_pointer(&fd2, g_free);
+	}
+
+	static void cache_release(FileData *fd)
+	{
+		std::cerr << "released " << static_cast<void *>(fd) << " (" << fd->path << ")\n";
+	}
+
+	FileData *fd = nullptr;
+	FileData *fd2 = nullptr;
+	FileDataContext context;
+};
+
+
+TEST_F(FileCacheTest, BasicLifecycle)
+{
+	fd = FileData::file_data_new_simple("/does/not/exist.jpg", &context);
+	fd2 = FileData::file_data_new_simple("/does/not/exist2.jpg", &context);
+	FileCacheData *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
+
+	ASSERT_FALSE(file_cache_get(fc, fd));
+	ASSERT_FALSE(file_cache_get(fc, fd2));
+
+	file_cache_put(fc, fd, /*size=*/1);
+	ASSERT_TRUE(file_cache_get(fc, fd));
+	ASSERT_FALSE(file_cache_get(fc, fd2));
+
+	// Because the FileDatas point to files that don't exist, they will get evicted from the
+	// cache during file_cache_get.  But this only happens when size > 1.
+	file_cache_put(fc, fd2, /*size=*/1);
+	ASSERT_FALSE(file_cache_get(fc, fd));
+	ASSERT_TRUE(file_cache_get(fc, fd2));
+}
+
+}  // anonymous namespace
+
+/* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-unit_test_sources = files('filedata/filedata.cc',
+unit_test_sources = files(
+'filecache.cc',
+'filedata/filedata.cc',
 'filedata/filelist.cc',
 'pixbuf-util.cc')
 


### PR DESCRIPTION
See the analysis in #2335 .  This fixes the use-after-free bug (which caused the crashes), and adds a basic unit test that reliably triggered the bug.  Also fixes an unrelated bug in the same function.

It looks like this bug was introduced in 2012, but went unnoticed for so long because it's predominantly triggered when (1) thumbnail modes are turned on -- which is not the default configuration, and (2) images are rendered (triggering `file_cache_get`) when those FileData point to files that no longer exist on disk.

Fixes #2335
Fixes #1221 