### PR TITLE
Fixes infinite loop + memory exhaustion when reentrant calls to file_cache_get occur

### DIFF
--- a/src/filecache.cc
+++ b/src/filecache.cc
@@ -39,6 +39,7 @@ namespace
 struct FileCacheEntry {
 	FileData *fd;
 	gulong size;
+	gboolean checking_if_changed;
 };
 
 #ifdef DEBUG
@@ -126,6 +127,24 @@ FileCacheData *file_cache_new(FileCacheReleaseFunc release, gulong max_size)
 
 gboolean file_cache_get(FileCacheData *fc, FileData *fd)
 {
+	/* Operating theory of this function:
+	 * This function must be re-entrant, which means it must specifically be implemented in a
+	 * way that remains correct even when a re-entrant call happens.
+	 *
+	 * In particular, the file_data_check_changed_files function call may trigger another call
+	 * into this function.  In order to handle that case correctly, we establish that if the
+	 * FileData has changed (in which case we plan to evict it and return FALSE), any
+	 * re-entrant calls into the function will return TRUE _without_ checking for changes.
+	 * Then we will evict the FileData from the cache (if that hasn't happened already), and
+	 * then we will return FALSE.
+	 *
+	 * That said, because it's also possible for a re-entrant call to target a _different_
+	 * FileData than the one that we plan to evict, we stash a checking_if_changed bool in
+	 * every FileCacheEntry.  That is, we need to handle the case where
+	 * file_cache_get(fc, fd_A) triggers file_cache_get(fc, fd_B), which in turn triggers
+	 * file_cache_get(fc, fd_A) again.
+	 */
+
 	g_assert(fc && fd);
 
 	GList *work = g_list_find_custom(fc->list, fd, reinterpret_cast<GCompareFunc>(file_cache_entry_compare_fd));
@@ -135,10 +154,10 @@ gboolean file_cache_get(FileCacheData *fc, FileData *fd)
 		return FALSE;
 		}
 
-	/* entry exists */
+	// Entry exists.
 	DEBUG_2("cache hit: fc=%p %s", (void *)fc, fd->path);
 
-	/* move it to the beginning, if needed */
+	// Move it to the beginning, if needed.
 	if (work != fc->list)
 		{
 		DEBUG_2("cache move to front: fc=%p %s", (void *)fc, fd->path);
@@ -146,14 +165,34 @@ gboolean file_cache_get(FileCacheData *fc, FileData *fd)
 		fc->list = g_list_concat(work, fc->list);
 		}
 
-	if (file_data_check_changed_files(fd))
-		{
-		/* file has been changed, cache entry is no longer valid */
-		/* note that it may have already been evicted from the cache! */
-		file_cache_dump(fc);
-		work = g_list_find_custom(fc->list, fd, reinterpret_cast<GCompareFunc>(file_cache_entry_compare_fd));
-		if (work) file_cache_remove_entry(fc, work);
+	// Most of the following code is defending against the case where
+	// file_data_check_changed_files triggers a re-entrant call back into this file_cache_get.
+	{
+		auto *entry = static_cast<FileCacheEntry *>(work->data);
+		if (entry->checking_if_changed) return TRUE;  // Avoid infinite recursion.
 
+		entry->checking_if_changed = TRUE;
+	}
+
+	// We assume that file_data_check_changed_files may invalidate work.
+	work = nullptr;
+	const gboolean fd_changed = file_data_check_changed_files(fd);
+
+	// Now we re-acquire work to take the appropriate action, if it still exists.
+	work = g_list_find_custom(fc->list, fd, reinterpret_cast<GCompareFunc>(file_cache_entry_compare_fd));
+	if (!work) return FALSE;
+
+	// Doing this here for correctness, even though we might immediately evict the entry.
+	{
+		auto *entry = static_cast<FileCacheEntry *>(work->data);
+		entry->checking_if_changed = FALSE;
+	}
+
+	if (fd_changed)
+		{
+		// Underlying file has been changed.  Evict the cache entry.
+		file_cache_dump(fc);
+		file_cache_remove_entry(fc, work);
 		return FALSE;
 		}
 
@@ -168,9 +207,11 @@ void file_cache_put(FileCacheData *fc, FileData *fd, gulong size)
 	if (file_cache_get(fc, fd)) return;
 
 	DEBUG_2("cache add: fc=%p %s", (void *)fc, fd->path);
+	// TODO[xsdg]: Switch to an stl container and do this initialization in a constructor.
 	fe = g_new(FileCacheEntry, 1);
 	fe->fd = file_data_ref(fd);
 	fe->size = size;
+	fe->checking_if_changed = FALSE;
 	fc->list = g_list_prepend(fc->list, fe);
 	fc->size += size;
 

--- a/src/filecache.cc
+++ b/src/filecache.cc
@@ -67,9 +67,16 @@ gint file_cache_entry_compare_fd(const FileCacheEntry *fe, const FileData *fd)
 	return (fe->fd == fd) ? 0 : 1;
 }
 
-void file_cache_remove_entry(FileCacheData *fc, GList *link)
+gboolean file_cache_remove_entry(FileCacheData *fc, GList *link)
 {
 	auto *fe = static_cast<FileCacheEntry *>(link->data);
+
+	// Avoid evicting a FileCacheEntry that implicitly triggered this removal attempt.
+	if (fe->checking_if_changed)
+		{
+		DEBUG_1("deferring cache remove: fc=%p %s", (void *)fc, fe->fd->path);
+		return FALSE;
+		}
 
 	DEBUG_1("cache remove: fc=%p %s", (void *)fc, fe->fd->path);
 
@@ -78,6 +85,8 @@ void file_cache_remove_entry(FileCacheData *fc, GList *link)
 	fc->release(fe->fd);
 	file_data_unref(fe->fd);
 	g_free(fe);
+
+	return TRUE;
 }
 
 void file_cache_notify_cb(FileData *fd, NotifyType type, gpointer data)
@@ -104,6 +113,9 @@ void file_cache_shrink_to_max_size(FileCacheData *fc)
 	while (fc->size > fc->max_size && work)
 		{
 		GList *prev = work->prev;
+		// This may fail to remove the specified entry if this resize was implicitly
+		// triggered during a file_cache_get call.  Any file_cache_put after the
+		// file_cache_get will re-trigger the shrink and correct the cache size, if needed.
 		file_cache_remove_entry(fc, work);
 		work = prev;
 		}

--- a/tests/filecache.cc
+++ b/tests/filecache.cc
@@ -41,6 +41,18 @@ class FileCacheTest : public t::Test
 	{
 		g_clear_pointer(&fd, g_free);
 		g_clear_pointer(&fd2, g_free);
+
+		// We have to clean this up by hand since the notify funcs are stored in a global.
+		for (const auto notify_func_pair : unregister_fd_funcs_at_teardown)
+			{
+			file_data_unregister_notify_func(notify_func_pair.first, notify_func_pair.second);
+			}
+	}
+
+	void register_notify_func_with_cleanup(FileData::NotifyFunc func, gpointer data, NotifyPriority priority)
+	{
+		unregister_fd_funcs_at_teardown.emplace_back(func, data);
+		file_data_register_notify_func(func, data, priority);
 	}
 
 	static void cache_release(FileData *fd)
@@ -51,6 +63,7 @@ class FileCacheTest : public t::Test
 	FileData *fd = nullptr;
 	FileData *fd2 = nullptr;
 	FileDataContext context;
+	std::vector<std::pair<FileData::NotifyFunc, gpointer>> unregister_fd_funcs_at_teardown;
 };
 
 
@@ -114,8 +127,45 @@ TEST_F(FileCacheTest, ReentrantCacheGet)
 	FileCacheData *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
 
 	CacheAndFds cache_and_fds = {fc, fd, fd2};
-	file_data_register_notify_func(
+	register_notify_func_with_cleanup(
 		reentrant_cache_notify_cb, &cache_and_fds, NOTIFY_PRIORITY_HIGH);
+
+	ASSERT_FALSE(file_cache_get(fc, fd));
+	file_cache_put(fc, fd, /*size=*/1);
+	ASSERT_FALSE(file_cache_get(fc, fd));
+	ASSERT_EQ(1, cache_and_fds.trigger_count);
+}
+
+void notify_put_get_cache_notify_cb(FileData *fd, NotifyType, gpointer data)
+{
+	auto *cache_and_fds = static_cast<CacheAndFds *>(data);
+	std::cerr << "triggering eviction with set_max_size\n";
+	file_cache_set_max_size(cache_and_fds->fc, 0);
+	file_cache_set_max_size(cache_and_fds->fc, 5);
+
+	std::cerr << "triggering file_cache_put(fc, " << static_cast<void *>(fd) << ")\n";
+	file_cache_put(cache_and_fds->fc, fd, /*size=*/1);
+
+	std::cerr << "re-calling file_cache_get(fc, " << static_cast<void *>(fd) << ")\n";
+	file_cache_get(cache_and_fds->fc, fd);
+
+	++cache_and_fds->trigger_count;
+}
+
+/**
+ * Ensures that file_cache_get behaves correctly (and avoids infinite recursion) with reentrant
+ * calls to cache_notify_cb, put, and get through the notification system.
+ **/
+TEST_F(FileCacheTest, ReentrantNotifyPutGet)
+{
+	// TODO[xsdg]: Create a mock FileData that acts like the underlying file exists.
+	fd = FileData::file_data_new_simple("/does/not/exist.jpg", &context);
+	fd2 = FileData::file_data_new_simple("/does/not/exist2.jpg", &context);
+	FileCacheData *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
+
+	CacheAndFds cache_and_fds = {fc, fd, fd2};
+	register_notify_func_with_cleanup(
+		notify_put_get_cache_notify_cb, &cache_and_fds, NOTIFY_PRIORITY_HIGH);
 
 	ASSERT_FALSE(file_cache_get(fc, fd));
 	file_cache_put(fc, fd, /*size=*/1);

--- a/tests/filecache.cc
+++ b/tests/filecache.cc
@@ -75,6 +75,54 @@ TEST_F(FileCacheTest, BasicLifecycle)
 	ASSERT_FALSE(file_cache_get(fc, fd2));
 }
 
+struct CacheAndFds
+{
+	FileCacheData *fc;
+	FileData *fd;
+	FileData *fd2;
+	int trigger_count = 0;
+};
+void reentrant_cache_notify_cb(FileData *fd, NotifyType, gpointer data)
+{
+	auto *cache_and_fds = static_cast<CacheAndFds *>(data);
+	std::cerr << "re-calling file_cache_get(fc, " << static_cast<void *>(fd) << ")\n";
+	++cache_and_fds->trigger_count;
+	file_cache_get(cache_and_fds->fc, fd);
+
+	/* TODO[xsdg] switch to this version of the test once FileData can persist in the cache.
+
+	if (fd == cache_and_fds->fd2)
+	{
+		// Recurse from fd2 to fd.
+		file_cache_get(cache_and_fds->fc, cache_and_fds->fd);
+	} else {
+		// Recurse from fd to fd2.
+		file_cache_get(cache_and_fds->fc, cache_and_fds->fd2);
+	}
+	*/
+}
+
+/**
+ * Ensures that file_cache_get behaves correctly (and avoids infinite recursion) with reentrant
+ * calls through the notification system.
+ **/
+TEST_F(FileCacheTest, ReentrantCacheGet)
+{
+	// TODO[xsdg]: Create a mock FileData that acts like the underlying file exists.
+	fd = FileData::file_data_new_simple("/does/not/exist.jpg", &context);
+	fd2 = FileData::file_data_new_simple("/does/not/exist2.jpg", &context);
+	FileCacheData *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
+
+	CacheAndFds cache_and_fds = {fc, fd, fd2};
+	file_data_register_notify_func(
+		reentrant_cache_notify_cb, &cache_and_fds, NOTIFY_PRIORITY_HIGH);
+
+	ASSERT_FALSE(file_cache_get(fc, fd));
+	file_cache_put(fc, fd, /*size=*/1);
+	ASSERT_FALSE(file_cache_get(fc, fd));
+	ASSERT_EQ(1, cache_and_fds.trigger_count);
+}
+
 }  // anonymous namespace
 
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */


### PR DESCRIPTION
Depends on prior PR #2340 

Also adds significant documentation around the constraints for `file_cache_get` to operate correctly, as well as a unit test that reproduces and confirms the fix for #2342 

Fixes #2342 