### PR TITLE
Switches FileCache implementation from C/glib style to C++ style

### DIFF
--- a/src/exif-common.cc
+++ b/src/exif-common.cc
@@ -853,7 +853,7 @@ ExifData *exif_read_fd(FileData *fd)
 {
 	if (!fd) return nullptr;
 
-	static FileCacheData *exif_cache = file_cache_new(exif_release_cb, 4);
+	static FileCache *exif_cache = file_cache_new(exif_release_cb, 4);
 
 	if (file_cache_get(exif_cache, fd)) return fd->exif;
 	g_assert(fd->exif == nullptr);

--- a/src/filecache.cc
+++ b/src/filecache.cc
@@ -232,22 +232,22 @@ void FileCache::set_max_size(size_t size)
 }
 
 // Trampoline implementation of C-style API.
-FileCacheData *file_cache_new(FileCacheReleaseFunc release, size_t max_size)
+FileCache *file_cache_new(FileCacheReleaseFunc release, size_t max_size)
 {
 	return new FileCache(release, max_size);
 }
 
-bool file_cache_get(FileCacheData *fc, FileData *fd)
+bool file_cache_get(FileCache *fc, FileData *fd)
 {
 	return fc->get(fd);
 }
 
-void file_cache_put(FileCacheData *fc, FileData *fd, size_t size)
+void file_cache_put(FileCache *fc, FileData *fd, size_t size)
 {
 	fc->put(fd, size);
 }
 
-void file_cache_set_max_size(FileCacheData *fc, size_t size)
+void file_cache_set_max_size(FileCache *fc, size_t size)
 {
 	fc->set_max_size(size);
 }

--- a/src/filecache.cc
+++ b/src/filecache.cc
@@ -20,8 +20,8 @@
 
 #include "filecache.h"
 
-#include <config.h>
 #include <algorithm>
+#include <config.h>
 #include <list>
 #include <optional>
 
@@ -29,106 +29,85 @@
 
 /* this implements a simple LRU algorithm */
 
-namespace
-{
-
-struct FileCacheEntry {
-	FileData *fd;
-	size_t size;
-	gboolean checking_if_changed;
-};
-
-}  // namespace
-
-struct FileCacheData {
-	using ListIterT = std::list<FileCacheEntry>::iterator;
-
-	// TODO[xsdg]: turn file_cache_new into a c++ constructor.
-	FileCacheReleaseFunc release;
-	std::list<FileCacheEntry> *list;
-	size_t max_size;
-	size_t size;
-};
-
-namespace
-{
-
 #ifdef DEBUG
 constexpr bool debug_file_cache = false; /* Set to true to add file cache dumps to the debug output */
 
-void file_cache_dump(FileCacheData *fc)
+void FileCache::dump()
 {
 	if (!debug_file_cache) return;
 
-	DEBUG_1("cache dump: fc=%p max size:%lu size:%lu", (void *)fc, fc->max_size, fc->size);
+	DEBUG_1("cache dump: fc=%p max size:%lu size:%lu", (void *)this, max_size_, size_);
 
 	size_t n = 0;
-	for (const auto &entry : *fc->list)
+	for (const auto &entry : contents_)
 		{
-		DEBUG_1("cache entry: fc=%p [%lu] %s %lu", (void *)fc, ++n, entry.fd->path, entry.size);
+		DEBUG_1("cache entry: fc=%p [%lu] %s %lu", (void *)this, ++n, entry.fd->path, entry.size);
 		}
 }
 #else
-#  define file_cache_dump(fc)
+// TODO[xsdg]: Make this a no-op again.
+void FileCache::dump() {}
+// #  define file_cache_dump(fc)
 #endif
 
-gboolean file_cache_remove_entry(FileCacheData *fc, FileCacheData::ListIterT entry_iter)
+bool FileCache::remove_entry(FileCache::ListIterT entry_iter)
 {
 	auto &entry = *entry_iter;
 
 	// Avoid evicting a FileCacheEntry that implicitly triggered this removal attempt.
 	if (entry.checking_if_changed)
 		{
-		DEBUG_1("deferring cache remove: fc=%p %s", (void *)fc, entry.fd->path);
-		return FALSE;
+		DEBUG_1("deferring cache remove: fc=%p %s", (void *)this, entry.fd->path);
+		return false;
 		}
 
-	DEBUG_1("cache remove: fc=%p %s", (void *)fc, entry.fd->path);
+	DEBUG_1("cache remove: fc=%p %s", (void *)this, entry.fd->path);
 
-	fc->size -= entry.size;
-	fc->release(entry.fd);
+	size_ -= entry.size;
+	release_(entry.fd);
 	file_data_unref(entry.fd);
-	fc->list->erase(entry_iter);
+	contents_.erase(entry_iter);
 
-	return TRUE;
+	return true;
 }
 
-std::optional<FileCacheData::ListIterT> file_cache_find_by_fd(FileCacheData *fc, FileData *fd)
+std::optional<FileCache::ListIterT> FileCache::find_by_fd(FileData *fd)
 {
 	const auto entry_iter = std::find_if(
-		fc->list->begin(),
-		fc->list->end(),
-		[fd](const FileCacheEntry &entry) { return entry.fd == fd; });
+		contents_.begin(),
+		contents_.end(),
+		[fd](const Entry &entry) { return entry.fd == fd; });
 
-	if (entry_iter != fc->list->end()) return entry_iter;
+	if (entry_iter != contents_.end()) return entry_iter;
 	return std::nullopt;
 }
 
-void file_cache_notify_cb(FileData *fd, NotifyType type, gpointer data)
+// static
+void FileCache::notify_cb(FileData *fd, NotifyType type, gpointer data)
 {
 	/* invalidate the entry on each file change */
 	if (!(type & (NOTIFY_REREAD | NOTIFY_CHANGE))) return;
 
 	DEBUG_1("Notify cache: %s %04x", fd->path, type);
 
-	auto *fc = static_cast<FileCacheData *>(data);
-	file_cache_dump(fc);
+	auto *fc = static_cast<FileCache *>(data);
+	fc->dump();
 
-	const auto maybe_iter = file_cache_find_by_fd(fc, fd);
+	const auto maybe_iter = fc->find_by_fd(fd);
 	if (!maybe_iter) return;
 
-	file_cache_remove_entry(fc, *maybe_iter);
+	fc->remove_entry(*maybe_iter);
 }
 
-void file_cache_shrink_to_max_size(FileCacheData *fc)
+void FileCache::shrink_to_max_size()
 {
-	file_cache_dump(fc);
+	dump();
 
-	g_assert((fc->size == 0) == fc->list->empty());  // Assert that size is consistent with emptiness.
+	g_assert((size_ == 0) == contents_.empty());  // Assert that size is consistent with emptiness.
 
-	if (fc->list->empty()) return;
-	auto entry_iter = std::prev(fc->list->end());
-	while(fc->size > fc->max_size && entry_iter != fc->list->begin())
+	if (contents_.empty()) return;
+	auto entry_iter = std::prev(contents_.end());
+	while(size_ > max_size_ && entry_iter != contents_.begin())
 		{
 		// This is valid since the list is guaranteed non-empty.
 		auto evict_iter = entry_iter;
@@ -137,47 +116,31 @@ void file_cache_shrink_to_max_size(FileCacheData *fc)
 		// This may fail to remove the specified entry if this resize was implicitly
 		// triggered during a file_cache_get call.  Any file_cache_put after the
 		// file_cache_get will re-trigger the shrink and correct the cache size, if needed.
-		file_cache_remove_entry(fc, evict_iter);
+		remove_entry(evict_iter);
 		}
 
-	g_assert((fc->size == 0) == fc->list->empty());  // Assert that size is consistent with emptiness.
+	g_assert((size_ == 0) == contents_.empty());  // Assert that size is consistent with emptiness.
 
 	// At this point, the loop won't have been able to evict the begin() entry.  Maybe do so now.
-	if (fc->size > fc->max_size && !fc->list->empty())
+	if (size_ > max_size_ && !contents_.empty())
 		{
-		file_cache_remove_entry(fc, fc->list->begin());
+		remove_entry(contents_.begin());
 		}
 
-	g_assert((fc->size == 0) == fc->list->empty());  // Assert that size is consistent with emptiness.
+	g_assert((size_ == 0) == contents_.empty());  // Assert that size is consistent with emptiness.
 }
-
-} // namespace
 
 FileCache::FileCache(ReleaseFunc release, size_t max_size) : release_(release), max_size_(max_size)
 {
-	file_data_register_notify_func(file_cache_notify_cb, this, NOTIFY_PRIORITY_HIGH);
+	file_data_register_notify_func(FileCache::notify_cb, this, NOTIFY_PRIORITY_HIGH);
 }
 
 FileCache::~FileCache()
 {
-	file_data_unregister_notify_func(file_cache_notify_cb, this);
+	file_data_unregister_notify_func(FileCache::notify_cb, this);
 }
 
-FileCacheData *file_cache_new(FileCacheReleaseFunc release, size_t max_size)
-{
-	auto fc = g_new(FileCacheData, 1);
-
-	fc->release = release;
-	fc->list = new std::list<FileCacheEntry>();  // TODO[xsdg]: This is never freed.
-	fc->max_size = max_size;
-	fc->size = 0;
-
-	file_data_register_notify_func(file_cache_notify_cb, fc, NOTIFY_PRIORITY_HIGH);
-
-	return fc;
-}
-
-gboolean file_cache_get(FileCacheData *fc, FileData *fd)
+bool FileCache::get(FileData *fd)
 {
 	/* Operating theory of this function:
 	 * This function must be re-entrant, which means it must specifically be implemented in a
@@ -197,79 +160,96 @@ gboolean file_cache_get(FileCacheData *fc, FileData *fd)
 	 * file_cache_get(fc, fd_A) again.
 	 */
 
-	g_assert(fc && fd);
+	g_assert(fd);
 
 	// We assume that file_data_check_changed_files may invalidate fc iterators.  So we create
 	// a "before" scope, so that the iters will be undefined by the time we make the
 	// invalidating call
 	{
-		const auto maybe_entry_iter = file_cache_find_by_fd(fc, fd);
+		const auto maybe_entry_iter = find_by_fd(fd);
 		if (!maybe_entry_iter)
 			{
-			DEBUG_2("cache miss: fc=%p %s", (void *)fc, fd->path);
+			DEBUG_2("cache miss: fc=%p %s", (void *)this, fd->path);
 			return FALSE;
 			}
 		auto entry_iter = *maybe_entry_iter;
 
 		// Entry exists.
-		DEBUG_2("cache hit: fc=%p %s", (void *)fc, fd->path);
+		DEBUG_2("cache hit: fc=%p %s", (void *)this, fd->path);
 
 		// Move it to the beginning, if needed.
-		if (entry_iter != fc->list->begin())
+		if (entry_iter != contents_.begin())
 			{
-			DEBUG_2("cache move to front: fc=%p %s", (void *)fc, fd->path);
-			// Moves entry_iter from fc->list to before fc->list->begin();
-			fc->list->splice(fc->list->begin(), *fc->list, entry_iter);
+			DEBUG_2("cache move to front: fc=%p %s", (void *)this, fd->path);
+			// Moves entry_iter from somewhere in contents_ to before contents_.begin();
+			contents_.splice(contents_.begin(), contents_, entry_iter);
 			}
 
 		// Most of the following code is defending against the case where
 		// file_data_check_changed_files triggers a re-entrant call back into this file_cache_get.
-		if (entry_iter->checking_if_changed) return TRUE;  // Avoid infinite recursion.
+		if (entry_iter->checking_if_changed) return true;  // Avoid infinite recursion.
 		entry_iter->checking_if_changed = TRUE;
 	}
 
 	// We assume that file_data_check_changed_files may invalidate fc iterators.
-	const gboolean fd_changed = file_data_check_changed_files(fd);
+	const bool fd_changed = file_data_check_changed_files(fd);
 
 	// Now we re-acquire entry_iter to take the appropriate action, if it still exists.
-	const auto maybe_entry_iter = file_cache_find_by_fd(fc, fd);
-	if (!maybe_entry_iter) return FALSE;
+	const auto maybe_entry_iter = find_by_fd(fd);
+	if (!maybe_entry_iter) return false;
 	auto &entry_iter = *maybe_entry_iter;
 
 	// Doing this here for correctness, even though we might immediately evict the entry.
-	entry_iter->checking_if_changed = FALSE;
+	entry_iter->checking_if_changed = false;
 
 	if (fd_changed)
 		{
 		// Underlying file has been changed.  Evict the cache entry.
-		file_cache_dump(fc);
-		file_cache_remove_entry(fc, entry_iter);
-		return FALSE;
+		dump();
+		remove_entry(entry_iter);
+		return false;
 		}
 
-	file_cache_dump(fc);
-	return TRUE;
+	dump();
+	return true;
+}
+
+void FileCache::put(FileData *fd, size_t size)
+{
+	if (get(fd)) return;
+
+	DEBUG_2("cache add: fc=%p %s", (void *)this, fd->path);
+	contents_.emplace_front(file_data_ref(fd), size);
+	size_ += size;
+
+	shrink_to_max_size();
+}
+
+void FileCache::set_max_size(size_t size)
+{
+	max_size_ = size;
+	shrink_to_max_size();
+}
+
+// Trampoline implementation of C-style API.
+FileCacheData *file_cache_new(FileCacheReleaseFunc release, size_t max_size)
+{
+	return new FileCache(release, max_size);
+}
+
+bool file_cache_get(FileCacheData *fc, FileData *fd)
+{
+	return fc->get(fd);
 }
 
 void file_cache_put(FileCacheData *fc, FileData *fd, size_t size)
 {
-	if (file_cache_get(fc, fd)) return;
-
-	DEBUG_2("cache add: fc=%p %s", (void *)fc, fd->path);
-	// TODO[xsdg]: Switch to an stl container and do this initialization in a constructor.
-	FileCacheEntry entry;
-	entry.fd = file_data_ref(fd);
-	entry.size = size;
-	entry.checking_if_changed = FALSE;
-	fc->list->push_front(std::move(entry));
-	fc->size += size;
-
-	file_cache_shrink_to_max_size(fc);
+	fc->put(fd, size);
 }
 
 void file_cache_set_max_size(FileCacheData *fc, size_t size)
 {
-	fc->max_size = size;
-	file_cache_shrink_to_max_size(fc);
+	fc->set_max_size(size);
 }
+
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/filecache.cc
+++ b/src/filecache.cc
@@ -21,17 +21,13 @@
 #include "filecache.h"
 
 #include <config.h>
+#include <algorithm>
+#include <list>
+#include <optional>
 
 #include "filedata.h"
 
 /* this implements a simple LRU algorithm */
-
-struct FileCacheData {
-	FileCacheReleaseFunc release;
-	GList *list;
-	gulong max_size;
-	gulong size;
-};
 
 namespace
 {
@@ -41,6 +37,21 @@ struct FileCacheEntry {
 	gulong size;
 	gboolean checking_if_changed;
 };
+
+}  // namespace
+
+struct FileCacheData {
+	using ListIterT = std::list<FileCacheEntry>::iterator;
+
+	// TODO[xsdg]: turn file_cache_new into a c++ constructor.
+	FileCacheReleaseFunc release;
+	std::list<FileCacheEntry> *list;
+	gulong max_size;
+	gulong size;
+};
+
+namespace
+{
 
 #ifdef DEBUG
 constexpr bool debug_file_cache = false; /* Set to true to add file cache dumps to the debug output */
@@ -52,41 +63,45 @@ void file_cache_dump(FileCacheData *fc)
 	DEBUG_1("cache dump: fc=%p max size:%lu size:%lu", (void *)fc, fc->max_size, fc->size);
 
 	gulong n = 0;
-	for (GList *work = fc->list; work; work = work->next)
+	for (const auto &entry : *fc->list)
 		{
-		auto fe = static_cast<FileCacheEntry *>(work->data);
-		DEBUG_1("cache entry: fc=%p [%lu] %s %lu", (void *)fc, ++n, fe->fd->path, fe->size);
+		DEBUG_1("cache entry: fc=%p [%lu] %s %lu", (void *)fc, ++n, entry.fd->path, entry.size);
 		}
 }
 #else
 #  define file_cache_dump(fc)
 #endif
 
-gint file_cache_entry_compare_fd(const FileCacheEntry *fe, const FileData *fd)
+gboolean file_cache_remove_entry(FileCacheData *fc, FileCacheData::ListIterT entry_iter)
 {
-	return (fe->fd == fd) ? 0 : 1;
-}
-
-gboolean file_cache_remove_entry(FileCacheData *fc, GList *link)
-{
-	auto *fe = static_cast<FileCacheEntry *>(link->data);
+	auto &entry = *entry_iter;
 
 	// Avoid evicting a FileCacheEntry that implicitly triggered this removal attempt.
-	if (fe->checking_if_changed)
+	if (entry.checking_if_changed)
 		{
-		DEBUG_1("deferring cache remove: fc=%p %s", (void *)fc, fe->fd->path);
+		DEBUG_1("deferring cache remove: fc=%p %s", (void *)fc, entry.fd->path);
 		return FALSE;
 		}
 
-	DEBUG_1("cache remove: fc=%p %s", (void *)fc, fe->fd->path);
+	DEBUG_1("cache remove: fc=%p %s", (void *)fc, entry.fd->path);
 
-	fc->list = g_list_delete_link(fc->list, link);
-	fc->size -= fe->size;
-	fc->release(fe->fd);
-	file_data_unref(fe->fd);
-	g_free(fe);
+	fc->size -= entry.size;
+	fc->release(entry.fd);
+	file_data_unref(entry.fd);
+	fc->list->erase(entry_iter);
 
 	return TRUE;
+}
+
+std::optional<FileCacheData::ListIterT> file_cache_find_by_fd(FileCacheData *fc, FileData *fd)
+{
+	const auto entry_iter = std::find_if(
+		fc->list->begin(),
+		fc->list->end(),
+		[fd](const FileCacheEntry &entry) { return entry.fd == fd; });
+
+	if (entry_iter != fc->list->end()) return entry_iter;
+	return std::nullopt;
 }
 
 void file_cache_notify_cb(FileData *fd, NotifyType type, gpointer data)
@@ -99,26 +114,41 @@ void file_cache_notify_cb(FileData *fd, NotifyType type, gpointer data)
 	auto *fc = static_cast<FileCacheData *>(data);
 	file_cache_dump(fc);
 
-	GList *work = g_list_find_custom(fc->list, fd, reinterpret_cast<GCompareFunc>(file_cache_entry_compare_fd));
-	if (!work) return;
+	const auto maybe_iter = file_cache_find_by_fd(fc, fd);
+	if (!maybe_iter) return;
 
-	file_cache_remove_entry(fc, work);
+	file_cache_remove_entry(fc, *maybe_iter);
 }
 
 void file_cache_shrink_to_max_size(FileCacheData *fc)
 {
 	file_cache_dump(fc);
 
-	GList *work = g_list_last(fc->list);
-	while (fc->size > fc->max_size && work)
+	g_assert((fc->size == 0) == fc->list->empty());  // Assert that size is consistent with emptiness.
+
+	if (fc->list->empty()) return;
+	auto entry_iter = std::prev(fc->list->end());
+	while(fc->size > fc->max_size && entry_iter != fc->list->begin())
 		{
-		GList *prev = work->prev;
+		// This is valid since the list is guaranteed non-empty.
+		auto evict_iter = entry_iter;
+		--entry_iter;
+
 		// This may fail to remove the specified entry if this resize was implicitly
 		// triggered during a file_cache_get call.  Any file_cache_put after the
 		// file_cache_get will re-trigger the shrink and correct the cache size, if needed.
-		file_cache_remove_entry(fc, work);
-		work = prev;
+		file_cache_remove_entry(fc, evict_iter);
 		}
+
+	g_assert((fc->size == 0) == fc->list->empty());  // Assert that size is consistent with emptiness.
+
+	// At this point, the loop won't have been able to evict the begin() entry.  Maybe do so now.
+	if (fc->size > fc->max_size && !fc->list->empty())
+		{
+		file_cache_remove_entry(fc, fc->list->begin());
+		}
+
+	g_assert((fc->size == 0) == fc->list->empty());  // Assert that size is consistent with emptiness.
 }
 
 } // namespace
@@ -128,7 +158,7 @@ FileCacheData *file_cache_new(FileCacheReleaseFunc release, gulong max_size)
 	auto fc = g_new(FileCacheData, 1);
 
 	fc->release = release;
-	fc->list = nullptr;
+	fc->list = new std::list<FileCacheEntry>();  // TODO[xsdg]: This is never freed.
 	fc->max_size = max_size;
 	fc->size = 0;
 
@@ -159,52 +189,51 @@ gboolean file_cache_get(FileCacheData *fc, FileData *fd)
 
 	g_assert(fc && fd);
 
-	GList *work = g_list_find_custom(fc->list, fd, reinterpret_cast<GCompareFunc>(file_cache_entry_compare_fd));
-	if (!work)
-		{
-		DEBUG_2("cache miss: fc=%p %s", (void *)fc, fd->path);
-		return FALSE;
-		}
-
-	// Entry exists.
-	DEBUG_2("cache hit: fc=%p %s", (void *)fc, fd->path);
-
-	// Move it to the beginning, if needed.
-	if (work != fc->list)
-		{
-		DEBUG_2("cache move to front: fc=%p %s", (void *)fc, fd->path);
-		fc->list = g_list_remove_link(fc->list, work);
-		fc->list = g_list_concat(work, fc->list);
-		}
-
-	// Most of the following code is defending against the case where
-	// file_data_check_changed_files triggers a re-entrant call back into this file_cache_get.
+	// We assume that file_data_check_changed_files may invalidate fc iterators.  So we create
+	// a "before" scope, so that the iters will be undefined by the time we make the
+	// invalidating call
 	{
-		auto *entry = static_cast<FileCacheEntry *>(work->data);
-		if (entry->checking_if_changed) return TRUE;  // Avoid infinite recursion.
+		const auto maybe_entry_iter = file_cache_find_by_fd(fc, fd);
+		if (!maybe_entry_iter)
+			{
+			DEBUG_2("cache miss: fc=%p %s", (void *)fc, fd->path);
+			return FALSE;
+			}
+		auto entry_iter = *maybe_entry_iter;
 
-		entry->checking_if_changed = TRUE;
+		// Entry exists.
+		DEBUG_2("cache hit: fc=%p %s", (void *)fc, fd->path);
+
+		// Move it to the beginning, if needed.
+		if (entry_iter != fc->list->begin())
+			{
+			DEBUG_2("cache move to front: fc=%p %s", (void *)fc, fd->path);
+			// Moves entry_iter from fc->list to before fc->list->begin();
+			fc->list->splice(fc->list->begin(), *fc->list, entry_iter);
+			}
+
+		// Most of the following code is defending against the case where
+		// file_data_check_changed_files triggers a re-entrant call back into this file_cache_get.
+		if (entry_iter->checking_if_changed) return TRUE;  // Avoid infinite recursion.
+		entry_iter->checking_if_changed = TRUE;
 	}
 
-	// We assume that file_data_check_changed_files may invalidate work.
-	work = nullptr;
+	// We assume that file_data_check_changed_files may invalidate fc iterators.
 	const gboolean fd_changed = file_data_check_changed_files(fd);
 
-	// Now we re-acquire work to take the appropriate action, if it still exists.
-	work = g_list_find_custom(fc->list, fd, reinterpret_cast<GCompareFunc>(file_cache_entry_compare_fd));
-	if (!work) return FALSE;
+	// Now we re-acquire entry_iter to take the appropriate action, if it still exists.
+	const auto maybe_entry_iter = file_cache_find_by_fd(fc, fd);
+	if (!maybe_entry_iter) return FALSE;
+	auto &entry_iter = *maybe_entry_iter;
 
 	// Doing this here for correctness, even though we might immediately evict the entry.
-	{
-		auto *entry = static_cast<FileCacheEntry *>(work->data);
-		entry->checking_if_changed = FALSE;
-	}
+	entry_iter->checking_if_changed = FALSE;
 
 	if (fd_changed)
 		{
 		// Underlying file has been changed.  Evict the cache entry.
 		file_cache_dump(fc);
-		file_cache_remove_entry(fc, work);
+		file_cache_remove_entry(fc, entry_iter);
 		return FALSE;
 		}
 
@@ -214,17 +243,15 @@ gboolean file_cache_get(FileCacheData *fc, FileData *fd)
 
 void file_cache_put(FileCacheData *fc, FileData *fd, gulong size)
 {
-	FileCacheEntry *fe;
-
 	if (file_cache_get(fc, fd)) return;
 
 	DEBUG_2("cache add: fc=%p %s", (void *)fc, fd->path);
 	// TODO[xsdg]: Switch to an stl container and do this initialization in a constructor.
-	fe = g_new(FileCacheEntry, 1);
-	fe->fd = file_data_ref(fd);
-	fe->size = size;
-	fe->checking_if_changed = FALSE;
-	fc->list = g_list_prepend(fc->list, fe);
+	FileCacheEntry entry;
+	entry.fd = file_data_ref(fd);
+	entry.size = size;
+	entry.checking_if_changed = FALSE;
+	fc->list->push_front(std::move(entry));
 	fc->size += size;
 
 	file_cache_shrink_to_max_size(fc);

--- a/src/filecache.cc
+++ b/src/filecache.cc
@@ -153,6 +153,16 @@ void file_cache_shrink_to_max_size(FileCacheData *fc)
 
 } // namespace
 
+FileCache::FileCache(ReleaseFunc release, size_t max_size) : release_(release), max_size_(max_size)
+{
+	file_data_register_notify_func(file_cache_notify_cb, this, NOTIFY_PRIORITY_HIGH);
+}
+
+FileCache::~FileCache()
+{
+	file_data_unregister_notify_func(file_cache_notify_cb, this);
+}
+
 FileCacheData *file_cache_new(FileCacheReleaseFunc release, size_t max_size)
 {
 	auto fc = g_new(FileCacheData, 1);

--- a/src/filecache.cc
+++ b/src/filecache.cc
@@ -34,7 +34,7 @@ namespace
 
 struct FileCacheEntry {
 	FileData *fd;
-	gulong size;
+	size_t size;
 	gboolean checking_if_changed;
 };
 
@@ -46,8 +46,8 @@ struct FileCacheData {
 	// TODO[xsdg]: turn file_cache_new into a c++ constructor.
 	FileCacheReleaseFunc release;
 	std::list<FileCacheEntry> *list;
-	gulong max_size;
-	gulong size;
+	size_t max_size;
+	size_t size;
 };
 
 namespace
@@ -62,7 +62,7 @@ void file_cache_dump(FileCacheData *fc)
 
 	DEBUG_1("cache dump: fc=%p max size:%lu size:%lu", (void *)fc, fc->max_size, fc->size);
 
-	gulong n = 0;
+	size_t n = 0;
 	for (const auto &entry : *fc->list)
 		{
 		DEBUG_1("cache entry: fc=%p [%lu] %s %lu", (void *)fc, ++n, entry.fd->path, entry.size);
@@ -153,7 +153,7 @@ void file_cache_shrink_to_max_size(FileCacheData *fc)
 
 } // namespace
 
-FileCacheData *file_cache_new(FileCacheReleaseFunc release, gulong max_size)
+FileCacheData *file_cache_new(FileCacheReleaseFunc release, size_t max_size)
 {
 	auto fc = g_new(FileCacheData, 1);
 
@@ -241,7 +241,7 @@ gboolean file_cache_get(FileCacheData *fc, FileData *fd)
 	return TRUE;
 }
 
-void file_cache_put(FileCacheData *fc, FileData *fd, gulong size)
+void file_cache_put(FileCacheData *fc, FileData *fd, size_t size)
 {
 	if (file_cache_get(fc, fd)) return;
 
@@ -257,7 +257,7 @@ void file_cache_put(FileCacheData *fc, FileData *fd, gulong size)
 	file_cache_shrink_to_max_size(fc);
 }
 
-void file_cache_set_max_size(FileCacheData *fc, gulong size)
+void file_cache_set_max_size(FileCacheData *fc, size_t size)
 {
 	fc->max_size = size;
 	file_cache_shrink_to_max_size(fc);

--- a/src/filecache.h
+++ b/src/filecache.h
@@ -28,10 +28,10 @@ class FileData;
 
 using FileCacheReleaseFunc = void (*)(FileData *);
 
-FileCacheData *file_cache_new(FileCacheReleaseFunc release, gulong max_size);
+FileCacheData *file_cache_new(FileCacheReleaseFunc release, size_t max_size);
 gboolean file_cache_get(FileCacheData *fc, FileData *fd);
-void file_cache_put(FileCacheData *fc, FileData *fd, gulong size);
-void file_cache_set_max_size(FileCacheData *fc, gulong size);
+void file_cache_put(FileCacheData *fc, FileData *fd, size_t size);
+void file_cache_set_max_size(FileCacheData *fc, size_t size);
 
 #endif
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/filecache.h
+++ b/src/filecache.h
@@ -26,10 +26,9 @@
 #include <list>
 #include <optional>
 
+// From filedata.h
 class FileData;
-struct FileCacheData;
-
-using FileCacheReleaseFunc = void (*)(FileData *);
+enum NotifyType : gint;
 
 class FileCache {
     public:
@@ -49,9 +48,15 @@ class FileCache {
 
     private:
 	struct Entry {
+		Entry(FileData *fd, size_t size) : fd(fd), size(size) {}
+
+		// Not copyable.
+		Entry(const Entry &other) = delete;
+		Entry &operator=(const Entry &other) = delete;
+
 		FileData *fd;
 		size_t size;
-		bool checking_if_changed;
+		bool checking_if_changed = false;
 	};
 	using ListIterT = std::list<Entry>::iterator;
 
@@ -59,18 +64,21 @@ class FileCache {
 	bool remove_entry(ListIterT entry_iter);
 	std::optional<ListIterT> find_by_fd(FileData *fd);
 	// TODO[xsdg]: Figure out how to define this here without including filedata.h
-	//static notify_cb(FileData *fd, NotifyType type, gpointer data);
+	static void notify_cb(FileData *fd, NotifyType type, gpointer data);
 	void shrink_to_max_size();
 
 	// TODO[xsdg]: turn file_cache_new into a c++ constructor.
 	ReleaseFunc release_;
-	std::list<Entry> list_;
+	std::list<Entry> contents_;
 	size_t max_size_;
 	size_t size_ = 0;
 };
 
+using FileCacheData = FileCache;  // Temporary prior to bulk rename.
+using FileCacheReleaseFunc = FileCache::ReleaseFunc;
+
 FileCacheData *file_cache_new(FileCacheReleaseFunc release, size_t max_size);
-gboolean file_cache_get(FileCacheData *fc, FileData *fd);
+bool file_cache_get(FileCacheData *fc, FileData *fd);
 void file_cache_put(FileCacheData *fc, FileData *fd, size_t size);
 void file_cache_set_max_size(FileCacheData *fc, size_t size);
 

--- a/src/filecache.h
+++ b/src/filecache.h
@@ -23,10 +23,51 @@
 
 #include <glib.h>
 
-struct FileCacheData;
+#include <list>
+#include <optional>
+
 class FileData;
+struct FileCacheData;
 
 using FileCacheReleaseFunc = void (*)(FileData *);
+
+class FileCache {
+    public:
+	using ReleaseFunc = void (*)(FileData *);
+
+	FileCache(ReleaseFunc release, size_t max_size);
+	~FileCache();
+
+	// Not copyable.
+	FileCache(const FileCache &) = delete;
+	FileCache &operator=(const FileCache &) = delete;
+
+	// TODO[xsdg]: The name "get" here is really misleading.  Rename.
+	bool get(FileData *fd);
+	void put(FileData *fd, size_t size);
+	void set_max_size(size_t size);
+
+    private:
+	struct Entry {
+		FileData *fd;
+		size_t size;
+		bool checking_if_changed;
+	};
+	using ListIterT = std::list<Entry>::iterator;
+
+	void dump();
+	bool remove_entry(ListIterT entry_iter);
+	std::optional<ListIterT> find_by_fd(FileData *fd);
+	// TODO[xsdg]: Figure out how to define this here without including filedata.h
+	//static notify_cb(FileData *fd, NotifyType type, gpointer data);
+	void shrink_to_max_size();
+
+	// TODO[xsdg]: turn file_cache_new into a c++ constructor.
+	ReleaseFunc release_;
+	std::list<Entry> list_;
+	size_t max_size_;
+	size_t size_ = 0;
+};
 
 FileCacheData *file_cache_new(FileCacheReleaseFunc release, size_t max_size);
 gboolean file_cache_get(FileCacheData *fc, FileData *fd);

--- a/src/filecache.h
+++ b/src/filecache.h
@@ -63,24 +63,21 @@ class FileCache {
 	void dump();
 	bool remove_entry(ListIterT entry_iter);
 	std::optional<ListIterT> find_by_fd(FileData *fd);
-	// TODO[xsdg]: Figure out how to define this here without including filedata.h
 	static void notify_cb(FileData *fd, NotifyType type, gpointer data);
 	void shrink_to_max_size();
 
-	// TODO[xsdg]: turn file_cache_new into a c++ constructor.
 	ReleaseFunc release_;
 	std::list<Entry> contents_;
 	size_t max_size_;
 	size_t size_ = 0;
 };
 
-using FileCacheData = FileCache;  // Temporary prior to bulk rename.
 using FileCacheReleaseFunc = FileCache::ReleaseFunc;
 
-FileCacheData *file_cache_new(FileCacheReleaseFunc release, size_t max_size);
-bool file_cache_get(FileCacheData *fc, FileData *fd);
-void file_cache_put(FileCacheData *fc, FileData *fd, size_t size);
-void file_cache_set_max_size(FileCacheData *fc, size_t size);
+FileCache *file_cache_new(FileCacheReleaseFunc release, size_t max_size);
+bool file_cache_get(FileCache *fc, FileData *fd);
+void file_cache_put(FileCache *fc, FileData *fd, size_t size);
+void file_cache_set_max_size(FileCache *fc, size_t size);
 
 #endif
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/image.cc
+++ b/src/image.cc
@@ -50,7 +50,7 @@
 #include "ui-fileops.h"
 
 struct ExifData;
-struct FileCacheData;
+class FileCache;
 
 namespace
 {
@@ -769,9 +769,9 @@ static void image_cache_release_cb(FileData *fd)
 	fd->pixbuf = nullptr;
 }
 
-static FileCacheData *image_get_cache()
+static FileCache *image_get_cache()
 {
-	static FileCacheData *cache = file_cache_new(image_cache_release_cb, 1);
+	static FileCache *cache = file_cache_new(image_cache_release_cb, 1);
 	file_cache_set_max_size(cache, static_cast<gulong>(options->image.image_cache_max) * 1048576); /* update from options */
 	return cache;
 }

--- a/tests/filecache.cc
+++ b/tests/filecache.cc
@@ -72,7 +72,7 @@ TEST_F(FileCacheTest, BasicLifecycle)
 	// TODO[xsdg]: Create a mock FileData that acts like the underlying file exists.
 	fd = FileData::file_data_new_simple("/does/not/exist.jpg", &context);
 	fd2 = FileData::file_data_new_simple("/does/not/exist2.jpg", &context);
-	FileCacheData *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
+	FileCache *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
 
 	ASSERT_FALSE(file_cache_get(fc, fd));
 	ASSERT_FALSE(file_cache_get(fc, fd2));
@@ -90,7 +90,7 @@ TEST_F(FileCacheTest, BasicLifecycle)
 
 struct CacheAndFds
 {
-	FileCacheData *fc;
+	FileCache *fc;
 	FileData *fd;
 	FileData *fd2;
 	int trigger_count = 0;
@@ -124,7 +124,7 @@ TEST_F(FileCacheTest, ReentrantCacheGet)
 	// TODO[xsdg]: Create a mock FileData that acts like the underlying file exists.
 	fd = FileData::file_data_new_simple("/does/not/exist.jpg", &context);
 	fd2 = FileData::file_data_new_simple("/does/not/exist2.jpg", &context);
-	FileCacheData *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
+	FileCache *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
 
 	CacheAndFds cache_and_fds = {fc, fd, fd2};
 	register_notify_func_with_cleanup(
@@ -161,7 +161,7 @@ TEST_F(FileCacheTest, ReentrantNotifyPutGet)
 	// TODO[xsdg]: Create a mock FileData that acts like the underlying file exists.
 	fd = FileData::file_data_new_simple("/does/not/exist.jpg", &context);
 	fd2 = FileData::file_data_new_simple("/does/not/exist2.jpg", &context);
-	FileCacheData *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
+	FileCache *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
 
 	CacheAndFds cache_and_fds = {fc, fd, fd2};
 	register_notify_func_with_cleanup(


### PR DESCRIPTION
Among other things, this allows instantiating FileCache on the stack instead of only on the heap, and allows it to be constructed and destructed using C++-style idioms.  This also fully transitions from glib types to C++ types.