### PR TITLE
Extends `FileDataRef` to be a managed ref-counting shared pointer for `FileData`, and the default storage for `FileData` instances.

### DIFF
--- a/src/filedata.cc
+++ b/src/filedata.cc
@@ -41,7 +41,7 @@ const gchar *text_from_time(time_t t)
  */
 FileData *file_data_new_group(const gchar *path_utf8)
 {
-	return FileData::file_data_new_group(path_utf8);
+	return FileData::new_group(path_utf8).release();
 }
 
 /**
@@ -49,7 +49,7 @@ FileData *file_data_new_group(const gchar *path_utf8)
  */
 FileData *file_data_new_no_grouping(const gchar *path_utf8)
 {
-	return FileData::file_data_new_no_grouping(path_utf8);
+	return FileData::new_no_grouping(path_utf8).release();
 }
 
 /**
@@ -57,13 +57,13 @@ FileData *file_data_new_no_grouping(const gchar *path_utf8)
  */
 FileData *file_data_new_dir(const gchar *path_utf8)
 {
-	return FileData::file_data_new_dir(path_utf8);
+	return FileData::new_dir(path_utf8).release();
 }
 
 
 FileData *file_data_new_simple(const gchar *path_utf8)
 {
-	return FileData::file_data_new_simple(path_utf8);
+	return FileData::new_simple(path_utf8).release();
 }
 
 #ifdef DEBUG_FILEDATA

--- a/src/filedata.h
+++ b/src/filedata.h
@@ -188,6 +188,42 @@ struct FileDataDebugInfo {
 };
 #endif
 
+class FileData;
+
+/**
+ * @class FileDataRef
+ * @brief RAII object that holds a ref to the specified FileData.
+ */
+class FileDataRef
+{
+    public:
+	explicit FileDataRef(FileData *fd);
+	// Not copyable or copy-assignable.
+	FileDataRef(FileDataRef &) = delete;
+	FileDataRef &operator=(const FileDataRef &) = delete;
+
+	// Allow move and move-assignment.
+	FileDataRef(FileDataRef &&) noexcept;
+	FileDataRef &operator=(FileDataRef &&) noexcept;
+
+	~FileDataRef();
+
+	// Allow implicit conversion directly to FileData*.
+	// This allows a FileDataRef to be used anywhere a FileData* is expected.
+	operator FileData*() const { return fd_; }
+
+	// In a boolean context, return whether or not we're holding nullptr.
+	operator bool() const { return fd_ != nullptr; }
+
+	void reset(FileData *new_fd);
+	FileData *release();
+	FileData* operator*() const { return fd_; }
+	FileData* operator->() const { return fd_; }
+
+    private:
+	FileData *fd_ = nullptr;
+};
+
 class FileData {
 private:
 	FileData() = delete;
@@ -271,21 +307,21 @@ public:
 	 * @headerfile file_data_new_group
 	 * scan for sidecar files - expensive
 	 */
-	static FileData *file_data_new_group(const gchar *path_utf8, FileDataContext *context = nullptr);
+	static FileDataRef new_group(const gchar *path_utf8, FileDataContext *context = nullptr);
 
 	/**
 	 * @headerfile file_data_new_no_grouping
 	 * should be used on helper files which can't have sidecars
 	 */
-	static FileData *file_data_new_no_grouping(const gchar *path_utf8, FileDataContext *context = nullptr);
+	static FileDataRef new_no_grouping(const gchar *path_utf8, FileDataContext *context = nullptr);
 
 	/**
 	 * @headerfile file_data_new_dir
 	 * should be used on dirs
 	 */
-	static FileData *file_data_new_dir(const gchar *path_utf8, FileDataContext *context = nullptr);
+	static FileDataRef new_dir(const gchar *path_utf8, FileDataContext *context = nullptr);
 
-	static FileData *file_data_new_simple(const gchar *path_utf8, FileDataContext *context = nullptr);
+	static FileDataRef new_simple(const gchar *path_utf8, FileDataContext *context = nullptr);
 
 #ifdef DEBUG_FILEDATA
 	FileData *file_data_ref(const gchar *file = __builtin_FILE(), gint line = __builtin_LINE());
@@ -408,8 +444,9 @@ public:
 	static void file_data_dump();
 
 protected:
-	static FileData *file_data_new(const gchar *path_utf8, struct stat *st, gboolean disable_sidecars, FileDataContext *context = nullptr);
-	static FileData *file_data_new_local(const gchar *path, struct stat *st, gboolean disable_sidecars, FileDataContext *context = nullptr);
+        // TODO[xsdg]: Renamed this to avoid conflict with "new" keyword.  Better options?
+	static FileDataRef make_new(const gchar *path_utf8, struct stat *st, gboolean disable_sidecars, FileDataContext *context = nullptr);
+	static FileDataRef make_new_local(const gchar *path, struct stat *st, gboolean disable_sidecars, FileDataContext *context = nullptr);
 
 	static GHashTable *file_data_basename_hash_new();
 	static GList *file_data_basename_hash_insert(GHashTable *basename_hash, FileData *fd);
@@ -481,29 +518,6 @@ class FileData::FileList
 	static void recursive_append_full(GList **list, GList *dirs, SortSettings settings);
 };
 
-/**
- * @class FileDataRef
- * @brief RAII object that holds a ref to the specified FileData.
- */
-class FileDataRef
-{
-    public:
-	explicit FileDataRef(FileData *fd, bool skip_initial_ref = false);
-	FileDataRef(FileDataRef &) = delete;  // Not copyable.
-	FileDataRef &operator=(const FileDataRef &) = delete;  // Not assignable.
-	~FileDataRef();
-
-	// Allow implicit conversion directly to FileData*.
-	// This allows a FileDataRef to be used anywhere a FileData* is expected.
-	operator FileData*() const { return fd_; }
-
-	void reset(FileData *new_fd);
-	FileData* operator*() const { return fd_; }
-	FileData* operator->() const { return fd_; }
-
-    private:
-	FileData *fd_;
-};
 
 // C-style compatibility API.
 gchar *text_from_size(gint64 size);

--- a/src/filedata.h
+++ b/src/filedata.h
@@ -488,13 +488,21 @@ class FileData::FileList
 class FileDataRef
 {
     public:
-	explicit FileDataRef(FileData &fd, gboolean skip_ref = FALSE);
+	explicit FileDataRef(FileData *fd, bool skip_initial_ref = false);
 	FileDataRef(FileDataRef &) = delete;  // Not copyable.
 	FileDataRef &operator=(const FileDataRef &) = delete;  // Not assignable.
 	~FileDataRef();
 
+	// Allow implicit conversion directly to FileData*.
+	// This allows a FileDataRef to be used anywhere a FileData* is expected.
+	operator FileData*() const { return fd_; }
+
+	void reset(FileData *new_fd);
+	FileData* operator*() const { return fd_; }
+	FileData* operator->() const { return fd_; }
+
     private:
-	FileData &fd_;
+	FileData *fd_;
 };
 
 // C-style compatibility API.

--- a/src/filedata/filedata.cc
+++ b/src/filedata/filedata.cc
@@ -1582,7 +1582,7 @@ gboolean FileData::file_data_add_ci(FileData *fd, FileDataChangeType type, const
 void FileData::planned_change_remove()
 {
         // Avoids potentially having the class destructed out from under us.
-        FileDataRef this_ref(*this);
+        FileDataRef this_ref(this);
 
 	if (g_hash_table_size(context->planned_change_map) != 0 &&
 	    (change->type == FILEDATA_CHANGE_MOVE || change->type == FILEDATA_CHANGE_RENAME))
@@ -1858,7 +1858,7 @@ void FileData::file_data_sc_free_ci_list(GList *fd_list)
 void FileData::update_planned_change_hash(const gchar *old_path, gchar *new_path)
 {
         // Avoids potentially having the class destructed out from under us.
-        FileDataRef this_ref(*this);
+        FileDataRef this_ref(this);
 
 	FileDataChangeType type = change->type;
 
@@ -3010,14 +3010,24 @@ bool FileData::supports_exif_orientation() const
 	    && (g_strcmp0(format_name, "jxl") != 0);
 }
 
-FileDataRef::FileDataRef(FileData &fd, gboolean skip_ref) : fd_(fd)
+FileDataRef::FileDataRef(FileData *fd, bool skip_initial_ref) : fd_(fd)
 {
-        if (!skip_ref) fd_.file_data_ref();
+	if (!skip_initial_ref && fd != nullptr) fd_->file_data_ref();
 }
 
 FileDataRef::~FileDataRef()
 {
-        fd_.file_data_unref();
+	if(fd_ != nullptr) fd_->file_data_unref();
+}
+
+void FileDataRef::reset(FileData *new_fd)
+{
+	if(new_fd != nullptr) new_fd->file_data_ref();
+
+	FileData *old_fd = fd_;
+	fd_ = new_fd;
+
+	if (old_fd != nullptr) old_fd->file_data_unref();
 }
 
 // NOLINTEND(readability-convert-member-functions-to-static)

--- a/src/filedata/filedata.cc
+++ b/src/filedata/filedata.cc
@@ -353,57 +353,51 @@ GlobalFileDataContext &GlobalFileDataContext::get_instance()
  * create or reuse Filedata
  *-----------------------------------------------------------------------------
  */
-FileData *FileData::file_data_new(const gchar *path_utf8, struct stat *st, gboolean disable_sidecars, FileDataContext *context)
+FileDataRef FileData::make_new(const gchar *path_utf8, struct stat *st, gboolean disable_sidecars, FileDataContext *context)
 {
 	if (context == nullptr)
 		{
 		context = FileData::DefaultFileDataContext();
 		}
 
-	FileData *fd;
-
 	DEBUG_2("file_data_new: '%s' %d", path_utf8, disable_sidecars);
 
 	if (S_ISDIR(st->st_mode)) disable_sidecars = TRUE;
 
-	fd = static_cast<FileData *>(g_hash_table_lookup(context->file_data_pool, path_utf8));
-	if (fd)
+	FileDataRef fd_ref{
+		static_cast<FileData *>(g_hash_table_lookup(context->file_data_pool, path_utf8))};
+	if (!fd_ref)
 		{
-		::file_data_ref(fd);
-		}
-	else
-		{
-		fd = static_cast<FileData *>(g_hash_table_lookup(context->planned_change_map, path_utf8));
-		if (fd)
+		fd_ref.reset(static_cast<FileData *>(g_hash_table_lookup(context->planned_change_map, path_utf8)));
+		if (fd_ref)
 			{
-			DEBUG_1("planned change: using %s -> %s", path_utf8, fd->path);
-			if (!isfile(fd->path))
+			DEBUG_1("planned change: using %s -> %s", path_utf8, fd_ref->path);
+			if (!isfile(fd_ref->path))
 				{
-				::file_data_ref(fd);
-				::file_data_apply_ci(fd);
+				::file_data_apply_ci(fd_ref);
 				}
 			else
 				{
-				fd = nullptr;
+				fd_ref.reset(nullptr);
 				}
 			}
 		}
 
-	if (fd)
+	if (fd_ref)
 		{
-		if (disable_sidecars) ::file_data_disable_grouping(fd, TRUE);
+		if (disable_sidecars) ::file_data_disable_grouping(fd_ref, TRUE);
 
 #ifdef DEBUG_FILEDATA
 		gboolean changed =
 #endif
-		file_data_check_changed_single_file(fd, st);
+		file_data_check_changed_single_file(fd_ref, st);
 
-		DEBUG_2("file_data_pool hit: '%s' %s", fd->path, changed ? "(changed)" : "");
+		DEBUG_2("file_data_pool hit: '%s' %s", fd_ref->path, changed ? "(changed)" : "");
 
-		return fd;
+		return fd_ref;
 		}
 
-	fd = g_new0(FileData, 1);
+	auto *fd = g_new0(FileData, 1);
 #ifdef DEBUG_FILEDATA
 	context->global_file_data_count++;
 	DEBUG_2("file data count++: %d", context->global_file_data_count);
@@ -414,7 +408,7 @@ FileData *FileData::file_data_new(const gchar *path_utf8, struct stat *st, gbool
 	fd->date = st->st_mtime;
 	fd->cdate = st->st_ctime;
 	fd->mode = st->st_mode;
-	fd->ref = 1;
+	fd->ref = 0;  // Will be reffed by the FileDataRef.
 	fd->magick = FD_MAGICK;
 	fd->exifdate = 0;
 	fd->rating = STAR_RATING_NOT_READ;
@@ -425,17 +419,19 @@ FileData *FileData::file_data_new(const gchar *path_utf8, struct stat *st, gbool
 
 	fd->set_path(path_utf8); /* set path, name, collate_key_*, original_path */
 
-	return fd;
+	return FileDataRef{fd};
 }
 
-FileData *FileData::file_data_new_local(const gchar *path, struct stat *st, gboolean disable_sidecars, FileDataContext *context)
+// static
+FileDataRef FileData::make_new_local(const gchar *path, struct stat *st, gboolean disable_sidecars, FileDataContext *context)
 {
 	g_autofree gchar *path_utf8 = path_to_utf8(path);
 
-	return file_data_new(path_utf8, st, disable_sidecars, context);
+	return make_new(path_utf8, st, disable_sidecars, context);
 }
 
-FileData *FileData::file_data_new_simple(const gchar *path_utf8, FileDataContext *context)
+// static
+FileDataRef FileData::new_simple(const gchar *path_utf8, FileDataContext *context)
 {
 	struct stat st{};
 
@@ -451,16 +447,9 @@ FileData *FileData::file_data_new_simple(const gchar *path_utf8, FileDataContext
 		}
 
 	auto *fd = static_cast<FileData *>(g_hash_table_lookup(context->file_data_pool, path_utf8));
-	if (!fd)
-		{
-		fd = file_data_new(path_utf8, &st, TRUE, context);
-		}
-	else
-		{
-		::file_data_ref(fd);
-		}
+	if (fd) return FileDataRef{fd};
 
-	return fd;
+	return make_new(path_utf8, &st, TRUE, context);
 }
 
 void FileData::read_exif_time_data(FileData *file)
@@ -533,7 +522,7 @@ void FileData::read_rating_data(FileData *file)
 		}
 }
 
-FileData *FileData::file_data_new_no_grouping(const gchar *path_utf8, FileDataContext *context)
+FileDataRef FileData::new_no_grouping(const gchar *path_utf8, FileDataContext *context)
 {
 	struct stat st;
 
@@ -543,10 +532,10 @@ FileData *FileData::file_data_new_no_grouping(const gchar *path_utf8, FileDataCo
 		st.st_mtime = 0;
 		}
 
-	return file_data_new(path_utf8, &st, TRUE, context);
+	return FileData::make_new(path_utf8, &st, TRUE, context);
 }
 
-FileData *FileData::file_data_new_dir(const gchar *path_utf8, FileDataContext *context)
+FileDataRef FileData::new_dir(const gchar *path_utf8, FileDataContext *context)
 {
 	struct stat st;
 
@@ -559,7 +548,7 @@ FileData *FileData::file_data_new_dir(const gchar *path_utf8, FileDataContext *c
 		/* dir or non-existing yet */
 		g_assert(S_ISDIR(st.st_mode));
 
-	return file_data_new(path_utf8, &st, TRUE, context);
+	return FileData::make_new(path_utf8, &st, TRUE, context);
 }
 
 /*
@@ -1125,7 +1114,7 @@ void FileData::file_data_basename_hash_to_sidecars(gpointer, gpointer value, gpo
 }
 
 
-FileData *FileData::file_data_new_group(const gchar *path_utf8, FileDataContext *context)
+FileDataRef FileData::new_group(const gchar *path_utf8, FileDataContext *context)
 {
 	if (context == nullptr)
 		{
@@ -1140,7 +1129,7 @@ FileData *FileData::file_data_new_group(const gchar *path_utf8, FileDataContext 
 		}
 
 	if (S_ISDIR(st.st_mode))
-		return file_data_new(path_utf8, &st, TRUE, context);
+		return FileData::make_new(path_utf8, &st, TRUE, context);
 
 	g_autofree gchar *dir = remove_level_from_path(path_utf8);
 
@@ -1148,16 +1137,9 @@ FileData *FileData::file_data_new_group(const gchar *path_utf8, FileDataContext 
 	FileList::read_list_real(dir, &files, nullptr, TRUE);
 
 	auto *fd = static_cast<FileData *>(g_hash_table_lookup(context->file_data_pool, path_utf8));
-	if (!fd)
-		{
-		fd = file_data_new(path_utf8, &st, TRUE, context);
-		}
-	else
-		{
-		::file_data_ref(fd);
-		}
+	if (fd) return FileDataRef{fd};
 
-	return fd;
+	return FileData::make_new(path_utf8, &st, TRUE, context);
 }
 
 /*
@@ -2896,6 +2878,8 @@ gboolean FileData::marks_list_load(const gchar *path)
 		const gchar *marks_str = strtok(nullptr, ",");
 		const gint marks_value = atoi(marks_str); // marks_str is guaranteed to contain a non-zero number
 
+		// TODO[xsdg]: This looks like it leaks a bunch of FileDatas.  Are these cleaned
+		// up anywhere?
 		FileData *fd = file_data_new_no_grouping(file_path);
 		::file_data_ref(fd);
 
@@ -3010,9 +2994,22 @@ bool FileData::supports_exif_orientation() const
 	    && (g_strcmp0(format_name, "jxl") != 0);
 }
 
-FileDataRef::FileDataRef(FileData *fd, bool skip_initial_ref) : fd_(fd)
+FileDataRef::FileDataRef(FileData *fd) : fd_(fd)
 {
-	if (!skip_initial_ref && fd != nullptr) fd_->file_data_ref();
+	if (fd_ != nullptr) fd_->file_data_ref();
+}
+
+FileDataRef::FileDataRef(FileDataRef &&other) noexcept
+{
+	*this = std::move(other);
+}
+
+FileDataRef &FileDataRef::operator=(FileDataRef &&other) noexcept
+{
+	fd_ = other.fd_;
+	other.fd_ = nullptr;
+
+	return *this;
 }
 
 FileDataRef::~FileDataRef()
@@ -3028,6 +3025,11 @@ void FileDataRef::reset(FileData *new_fd)
 	fd_ = new_fd;
 
 	if (old_fd != nullptr) old_fd->file_data_unref();
+}
+
+FileData *FileDataRef::release()
+{
+	return g_steal_pointer(&fd_);
 }
 
 // NOLINTEND(readability-convert-member-functions-to-static)

--- a/src/filedata/filelist.cc
+++ b/src/filedata/filelist.cc
@@ -183,14 +183,14 @@ gboolean FileData::FileList::read_list_real(const gchar *dir_path, GList **files
 				    strcmp(name, GQ_CACHE_LOCAL_METADATA) != 0 &&
 				    strcmp(name, THUMB_FOLDER_LOCAL) != 0)
 					{
-					dlist = g_list_prepend(dlist, file_data_new_local(filepath, &ent_sbuf, TRUE));
+					dlist = g_list_prepend(dlist, FileData::make_new_local(filepath, &ent_sbuf, TRUE).release());
 					}
 				}
 			else
 				{
 				if (files && filter_name_exists(name))
 					{
-					FileData *fd = file_data_new_local(filepath, &ent_sbuf, FALSE);
+					FileData *fd = FileData::make_new_local(filepath, &ent_sbuf, FALSE).release();
 					flist = g_list_prepend(flist, fd);
 					if (fd->sidecar_priority && !fd->disable_grouping)
 						{

--- a/tests/filecache.cc
+++ b/tests/filecache.cc
@@ -39,8 +39,9 @@ class FileCacheTest : public t::Test
     protected:
 	void TearDown() override
 	{
-		g_clear_pointer(&fd, g_free);
-		g_clear_pointer(&fd2, g_free);
+		// Free Refs before cleaning up fd_funcs
+		fd.reset(nullptr);
+		fd2.reset(nullptr);
 
 		// We have to clean this up by hand since the notify funcs are stored in a global.
 		for (const auto notify_func_pair : unregister_fd_funcs_at_teardown)
@@ -60,9 +61,9 @@ class FileCacheTest : public t::Test
 		std::cerr << "released " << static_cast<void *>(fd) << " (" << fd->path << ")\n";
 	}
 
-	FileData *fd = nullptr;
-	FileData *fd2 = nullptr;
-	FileDataContext context;
+	FileDataContext context;  // Needs to be constructed before Refs.
+	FileDataRef fd{nullptr};
+	FileDataRef fd2{nullptr};
 	std::vector<std::pair<FileData::NotifyFunc, gpointer>> unregister_fd_funcs_at_teardown;
 };
 
@@ -70,8 +71,8 @@ class FileCacheTest : public t::Test
 TEST_F(FileCacheTest, BasicLifecycle)
 {
 	// TODO[xsdg]: Create a mock FileData that acts like the underlying file exists.
-	fd = FileData::file_data_new_simple("/does/not/exist.jpg", &context);
-	fd2 = FileData::file_data_new_simple("/does/not/exist2.jpg", &context);
+	fd = FileData::new_simple("/does/not/exist.jpg", &context);
+	fd2 = FileData::new_simple("/does/not/exist2.jpg", &context);
 	FileCache *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
 
 	ASSERT_FALSE(file_cache_get(fc, fd));
@@ -122,8 +123,8 @@ void reentrant_cache_notify_cb(FileData *fd, NotifyType, gpointer data)
 TEST_F(FileCacheTest, ReentrantCacheGet)
 {
 	// TODO[xsdg]: Create a mock FileData that acts like the underlying file exists.
-	fd = FileData::file_data_new_simple("/does/not/exist.jpg", &context);
-	fd2 = FileData::file_data_new_simple("/does/not/exist2.jpg", &context);
+	fd = FileData::new_simple("/does/not/exist.jpg", &context);
+	fd2 = FileData::new_simple("/does/not/exist2.jpg", &context);
 	FileCache *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
 
 	CacheAndFds cache_and_fds = {fc, fd, fd2};
@@ -159,8 +160,8 @@ void notify_put_get_cache_notify_cb(FileData *fd, NotifyType, gpointer data)
 TEST_F(FileCacheTest, ReentrantNotifyPutGet)
 {
 	// TODO[xsdg]: Create a mock FileData that acts like the underlying file exists.
-	fd = FileData::file_data_new_simple("/does/not/exist.jpg", &context);
-	fd2 = FileData::file_data_new_simple("/does/not/exist2.jpg", &context);
+	fd = FileData::new_simple("/does/not/exist.jpg", &context);
+	fd2 = FileData::new_simple("/does/not/exist2.jpg", &context);
 	FileCache *fc = file_cache_new(&FileCacheTest::cache_release, /*max_size=*/5);
 
 	CacheAndFds cache_and_fds = {fc, fd, fd2};

--- a/tests/filedata/filedata.cc
+++ b/tests/filedata/filedata.cc
@@ -44,19 +44,13 @@ class FileDataTest : public t::Test
     protected:
 	void TearDown() override
 	{
-		if (fd != nullptr)
-		{
-			g_free(fd);
-			fd = nullptr;
-		}
-		if (parent_fd != nullptr)
-		{
-			g_free(parent_fd);
-			parent_fd = nullptr;
-		}
+		g_clear_pointer(&fd, g_free);
+		g_clear_pointer(&fd2, g_free);
+		g_clear_pointer(&parent_fd, g_free);
 	}
 
 	FileData *fd = nullptr;
+	FileData *fd2 = nullptr;
 	FileData *parent_fd = nullptr;
 	FileDataContext context;
 };
@@ -160,16 +154,70 @@ TEST_F(FileDataTest, FileDataRef)
 		ASSERT_EQ(0, fd->ref);
 
 		// Refcount should increase by 1 after the FileDataRef is created.
-		FileDataRef fd_ref(*fd);
+		FileDataRef fd_ref(fd);
 		ASSERT_EQ(1, fd->ref);
 
 		// Refcount should increase by 1 more with the second FileDataRef.
-		FileDataRef fd_ref2(*fd);
+		FileDataRef fd_ref2(fd);
 		ASSERT_EQ(2, fd->ref);
 	}
 
 	// And refcount drops back down to 0 after both of the FileDataRefs go out of scope.
 	ASSERT_EQ(0, fd->ref);
+}
+
+TEST_F(FileDataTest, FileDataRefReset)
+{
+	fd = g_new0(FileData, 1);
+	fd->magick = FD_MAGICK;
+	fd2 = g_new0(FileData, 1);
+	fd2->magick = FD_MAGICK;
+
+	// Avoids having the FileData objects automatically freed when its
+	// refcount drops back to zero.
+	file_data_lock(fd);
+	file_data_lock(fd2);
+
+	// Start off with no refs.
+	ASSERT_EQ(0, fd->ref);
+	ASSERT_EQ(0, fd2->ref);
+
+	// This should ref fd.
+	FileDataRef fd_ref(fd);
+
+	ASSERT_EQ(1, fd->ref);
+	ASSERT_EQ(0, fd2->ref);
+	ASSERT_EQ(fd, static_cast<FileData *>(fd_ref));
+
+	// This should ref fd2 and unref fd.
+	fd_ref.reset(fd2);
+
+	ASSERT_EQ(0, fd->ref);
+	ASSERT_EQ(1, fd2->ref);
+	ASSERT_EQ(fd2, static_cast<FileData *>(fd_ref));
+}
+
+TEST_F(FileDataTest, FileDataRefResetToNull)
+{
+	fd = g_new0(FileData, 1);
+	fd->magick = FD_MAGICK;
+
+	// Avoids having the FileData objects automatically freed when its
+	// refcount drops back to zero.
+	file_data_lock(fd);
+
+	FileDataRef fd_ref(fd);
+	ASSERT_EQ(1, fd->ref);
+
+	// Reset to nullptr shouldn't crash, and should unref the previously held fd.
+	fd_ref.reset(nullptr);
+	ASSERT_EQ(0, fd->ref);
+	ASSERT_EQ(nullptr, static_cast<FileData *>(fd_ref));
+
+	// And we should be able to re-ref the original fd without crashing.
+	fd_ref.reset(fd);
+	ASSERT_EQ(1, fd->ref);
+	ASSERT_EQ(fd, static_cast<FileData *>(fd_ref));
 }
 
 }  // anonymous namespace

--- a/tests/filedata/filedata.cc
+++ b/tests/filedata/filedata.cc
@@ -55,6 +55,9 @@ class FileDataTest : public t::Test
 	FileData *parent_fd = nullptr;
 };
 
+// Used to group and report tests separately, even though it's the same fixture implementation.
+class FileDataRefTest : public FileDataTest {};
+
 TEST_F(FileDataTest, text_from_size_test)
 {
 	std::vector<std::pair<gint64, std::string>> test_cases = {
@@ -144,7 +147,7 @@ TEST_F(FileDataTest, BasicIncrementVersionWithParent)
 	ASSERT_EQ(0x0, parent_fd->valid_marks);
 }
 
-TEST_F(FileDataTest, FileDataRef)
+TEST_F(FileDataRefTest, NonOwningRefCount)
 {
 	fd = g_new0(FileData, 1);
 	fd->magick = FD_MAGICK;
@@ -172,7 +175,7 @@ TEST_F(FileDataTest, FileDataRef)
 	ASSERT_EQ(0, fd->ref);
 }
 
-TEST_F(FileDataTest, FileDataRefReset)
+TEST_F(FileDataRefTest, Reset)
 {
 	fd = g_new0(FileData, 1);
 	fd->magick = FD_MAGICK;
@@ -203,7 +206,7 @@ TEST_F(FileDataTest, FileDataRefReset)
 	ASSERT_EQ(fd2, static_cast<FileData *>(fd_ref));
 }
 
-TEST_F(FileDataTest, FileDataRefResetToNull)
+TEST_F(FileDataRefTest, ResetToNull)
 {
 	fd = g_new0(FileData, 1);
 	fd->magick = FD_MAGICK;
@@ -226,7 +229,7 @@ TEST_F(FileDataTest, FileDataRefResetToNull)
 	ASSERT_EQ(fd, static_cast<FileData *>(fd_ref));
 }
 
-TEST_F(FileDataTest, FileDataRefRelease)
+TEST_F(FileDataRefTest, Release)
 {
 #ifdef DEBUG_FILEDATA
 	ASSERT_EQ(0, context.global_file_data_count);
@@ -256,7 +259,7 @@ TEST_F(FileDataTest, FileDataRefRelease)
 #endif
 }
 
-TEST_F(FileDataTest, ReturnFileDataRef)
+TEST_F(FileDataRefTest, AnonymousReturn)
 {
 	const auto &make_ref = []() -> FileDataRef {
 		auto *fd = g_new0(FileData, 1);
@@ -276,23 +279,25 @@ TEST_F(FileDataTest, ReturnFileDataRef)
 	g_free(fd_ref.release());
 }
 
-TEST_F(FileDataTest, ReturnFileDataRefAndRelease)
+/**
+ * Validates a common compatibility pattern for interacting with code that stores FileData*.
+ */
+TEST_F(FileDataRefTest, AnonymousReturnAndRelease)
 {
 	const auto &make_ref = []() -> FileDataRef {
-		auto *fd = g_new0(FileData, 1);
-		fd->magick = FD_MAGICK;
+		auto *_fd = g_new0(FileData, 1);
+		_fd->magick = FD_MAGICK;
 		// Avoids having the FileData objects automatically freed when its
 		// refcount drops back to zero.
-		file_data_lock(fd);
+		file_data_lock(_fd);
 
-		return FileDataRef{fd};
+		return FileDataRef{_fd};
 	};
 
 	// This ensures that the post-move anonymous FileDataRef can be destructed without crashing.
-	FileData *fd_ptr = make_ref().release();
-	ASSERT_NE(nullptr, fd_ptr);
-	ASSERT_EQ(1, fd_ptr->ref);
-	g_free(fd_ptr);
+	fd = make_ref().release();
+	ASSERT_NE(nullptr, fd);
+	ASSERT_EQ(1, fd->ref);
 }
 
 }  // anonymous namespace

--- a/tests/filedata/filedata.cc
+++ b/tests/filedata/filedata.cc
@@ -49,10 +49,10 @@ class FileDataTest : public t::Test
 		g_clear_pointer(&parent_fd, g_free);
 	}
 
+	FileDataContext context;
 	FileData *fd = nullptr;
 	FileData *fd2 = nullptr;
 	FileData *parent_fd = nullptr;
-	FileDataContext context;
 };
 
 TEST_F(FileDataTest, text_from_size_test)
@@ -79,37 +79,43 @@ TEST_F(FileDataTest, text_from_size_test)
 	}
 }
 
-#ifdef DEBUG_FILEDATA
 TEST_F(FileDataTest, FileDataNewSimpleAndFree)
 {
-	ASSERT_EQ(0, context.global_file_data_count);
-
-	auto *_fd = FileData::file_data_new_simple("/does/not/exist.jpg", &context);
-	ASSERT_NE(_fd, nullptr);
-	ASSERT_EQ(1, context.global_file_data_count);
-	ASSERT_EQ(1, _fd->ref);
-
-	_fd->file_data_unref();
-	_fd = nullptr;
-	ASSERT_EQ(0, context.global_file_data_count);
-}
-#endif
-
 #ifdef DEBUG_FILEDATA
+	ASSERT_EQ(0, context.global_file_data_count);
+
+	{
+		auto _fd = FileData::new_simple("/does/not/exist.jpg", &context);
+		ASSERT_NE(*_fd, nullptr);
+		ASSERT_EQ(1, context.global_file_data_count);
+		ASSERT_EQ(1, _fd->ref);
+	}
+
+	// _fd should have been unreffed and freed after going out of scope.
+	ASSERT_EQ(0, context.global_file_data_count);
+#else
+	GTEST_SKIP() << "Test requires DEBUG_FILEDATA";
+#endif
+}
+
 TEST_F(FileDataTest, FileDataNewGroupAndFree)
 {
+#ifdef DEBUG_FILEDATA
 	ASSERT_EQ(0, context.global_file_data_count);
 
-	auto *_fd = FileData::file_data_new_group("/does/not/exist/file.jpg", &context);
-	ASSERT_NE(_fd, nullptr);
-	EXPECT_EQ(1, context.global_file_data_count);
-	ASSERT_EQ(1, _fd->ref);
+	{
+		auto _fd = FileData::new_group("/does/not/exist/file.jpg", &context);
+		ASSERT_NE(*_fd, nullptr);
+		EXPECT_EQ(1, context.global_file_data_count);
+		ASSERT_EQ(1, _fd->ref);
+	}
 
-	_fd->file_data_unref();
-	_fd = nullptr;
+	// _fd should have been unreffed and freed after going out of scope.
 	ASSERT_EQ(0, context.global_file_data_count);
-}
+#else
+	GTEST_SKIP() << "Test requires DEBUG_FILEDATA";
 #endif
+}
 
 TEST_F(FileDataTest, BasicIncrementVersion)
 {
@@ -218,6 +224,75 @@ TEST_F(FileDataTest, FileDataRefResetToNull)
 	fd_ref.reset(fd);
 	ASSERT_EQ(1, fd->ref);
 	ASSERT_EQ(fd, static_cast<FileData *>(fd_ref));
+}
+
+TEST_F(FileDataTest, FileDataRefRelease)
+{
+#ifdef DEBUG_FILEDATA
+	ASSERT_EQ(0, context.global_file_data_count);
+	FileData *fd_ptr = nullptr;
+
+	{
+		auto fd_ref = FileData::new_simple("/does/not/exist.jpg", &context);
+		ASSERT_EQ(1, context.global_file_data_count);
+		ASSERT_EQ(1, fd_ref->ref);
+
+		fd_ptr = fd_ref.release();
+		ASSERT_EQ(1, context.global_file_data_count);
+		ASSERT_EQ(nullptr, *fd_ref);
+		ASSERT_NE(nullptr, fd_ptr);
+		ASSERT_EQ(1, fd_ptr->ref);
+	}
+
+	// fd_ref should have been empty, so it going out of scope should be a no-op.
+	ASSERT_EQ(1, context.global_file_data_count);
+	ASSERT_NE(nullptr, fd_ptr);
+	ASSERT_EQ(1, fd_ptr->ref);
+
+	fd_ptr->file_data_unref();
+	ASSERT_EQ(0, context.global_file_data_count);
+#else
+	GTEST_SKIP() << "Test requires DEBUG_FILEDATA";
+#endif
+}
+
+TEST_F(FileDataTest, ReturnFileDataRef)
+{
+	const auto &make_ref = []() -> FileDataRef {
+		auto *fd = g_new0(FileData, 1);
+		fd->magick = FD_MAGICK;
+		// Avoids having the FileData objects automatically freed when its
+		// refcount drops back to zero.
+		file_data_lock(fd);
+
+		return FileDataRef{fd};
+	};
+
+	// This ensures that the post-move anonymous FileDataRef can be destructed without crashing.
+	FileDataRef fd_ref = make_ref();
+	ASSERT_EQ(1, fd_ref->ref);
+
+	// We need to manually free the FileData* since it doesn't have a context.
+	g_free(fd_ref.release());
+}
+
+TEST_F(FileDataTest, ReturnFileDataRefAndRelease)
+{
+	const auto &make_ref = []() -> FileDataRef {
+		auto *fd = g_new0(FileData, 1);
+		fd->magick = FD_MAGICK;
+		// Avoids having the FileData objects automatically freed when its
+		// refcount drops back to zero.
+		file_data_lock(fd);
+
+		return FileDataRef{fd};
+	};
+
+	// This ensures that the post-move anonymous FileDataRef can be destructed without crashing.
+	FileData *fd_ptr = make_ref().release();
+	ASSERT_NE(nullptr, fd_ptr);
+	ASSERT_EQ(1, fd_ptr->ref);
+	g_free(fd_ptr);
 }
 
 }  // anonymous namespace

--- a/tests/filedata/filelist.cc
+++ b/tests/filedata/filelist.cc
@@ -169,16 +169,15 @@ TEST_F(FileDataSortTest, NumberSort)
 	// Convenience alias.
 	auto &sort_compare_filedata = FileData::FileList::sort_compare_filedata;
 
-	// We create multiple filedatas which only differ in the path name (plus
-	// ref holders that will clean them up when they go out of scope)
-	FileData *fd_1 = FileData::file_data_new_simple("/noexist/noexist/1_image.jpg", &context);
-	FileDataRef fd_1_ref(*fd_1, /*skip_ref=*/TRUE);
-	FileData *fd_5 = FileData::file_data_new_simple("/noexist/noexist/5_image.jpg", &context);
-	FileDataRef fd_5_ref(*fd_5, /*skip_ref=*/TRUE);
-	FileData *fd_10 = FileData::file_data_new_simple("/noexist/noexist/10_image.jpg", &context);
-	FileDataRef fd_10_ref(*fd_10, /*skip_ref=*/TRUE);
-	FileData *fd_50 = FileData::file_data_new_simple("/noexist/noexist/50_image.jpg", &context);
-	FileDataRef fd_50_ref(*fd_50, /*skip_ref=*/TRUE);
+	// We create multiple filedatas which only differ in the path name
+	FileDataRef fd_1(FileData::file_data_new_simple("/noexist/noexist/1_image.jpg", &context),
+			    /*skip_initial_ref=*/TRUE);
+	FileDataRef fd_5(FileData::file_data_new_simple("/noexist/noexist/5_image.jpg", &context),
+			    /*skip_initial_ref=*/TRUE);
+	FileDataRef fd_10(FileData::file_data_new_simple("/noexist/noexist/10_image.jpg", &context),
+			     /*skip_initial_ref=*/TRUE);
+	FileDataRef fd_50(FileData::file_data_new_simple("/noexist/noexist/50_image.jpg", &context),
+			     /*skip_initial_ref=*/TRUE);
 
 	FileData::FileList::SortSettings number_sort = {SORT_NUMBER, TRUE, TRUE};
 
@@ -212,8 +211,8 @@ TEST_F(FileDataSortTest, TieBreakerFallbackBehavior)
 	auto &sort_compare_filedata = FileData::FileList::sort_compare_filedata;
 
 	// Create a FileData that is identical to fd_middle except for original_path.
-	FileData *fd_other_middle = FileData::file_data_new_simple("/noexist/otherdir/2_middle.jpg", &context);
-	FileDataRef fd_other_middle_ref(*fd_other_middle, /*skip_ref=*/TRUE);
+	FileDataRef fd_other_middle(FileData::file_data_new_simple("/noexist/otherdir/2_middle.jpg", &context),
+				       /*skip_initial_ref=*/TRUE);
 	fd_other_middle->size = fd_middle->size;
 	fd_other_middle->date = fd_middle->date;
 	fd_other_middle->cdate = fd_middle->cdate;
@@ -249,14 +248,14 @@ TEST_F(FileDataSortTest, CaseSensitivity)
 	auto &sort_compare_filedata = FileData::FileList::sort_compare_filedata;
 	using SortSettings = FileData::FileList::SortSettings;
 
-	FileData *fd_lower_1 = FileData::file_data_new_simple("/noexist/noexist/1_image.jpg", &context);
-	FileDataRef fd_lower_1_ref(*fd_lower_1, /*skip_ref=*/TRUE);
-	FileData *fd_upper_1 = FileData::file_data_new_simple("/noexist/noexist/1_IMAGE.JPG", &context);
-	FileDataRef fd_upper_1_ref(*fd_upper_1, /*skip_ref=*/TRUE);
-	FileData *fd_lower_10 = FileData::file_data_new_simple("/noexist/noexist/10_image.jpg", &context);
-	FileDataRef fd_lower_10_ref(*fd_lower_10, /*skip_ref=*/TRUE);
-	FileData *fd_upper_10 = FileData::file_data_new_simple("/noexist/noexist/10_IMAGE.JPG", &context);
-	FileDataRef fd_upper_10_ref(*fd_upper_10, /*skip_ref=*/TRUE);
+	FileDataRef fd_lower_1(FileData::file_data_new_simple("/noexist/noexist/1_image.jpg", &context),
+				  /*skip_initial_ref=*/TRUE);
+	FileDataRef fd_upper_1(FileData::file_data_new_simple("/noexist/noexist/1_IMAGE.JPG", &context),
+				  /*skip_initial_ref=*/TRUE);
+	FileDataRef fd_lower_10(FileData::file_data_new_simple("/noexist/noexist/10_image.jpg", &context),
+				   /*skip_initial_ref=*/TRUE);
+	FileDataRef fd_upper_10(FileData::file_data_new_simple("/noexist/noexist/10_IMAGE.JPG", &context),
+				   /*skip_initial_ref=*/TRUE);
 
 	// To avoid inadvertently relying on the original_path fallthrough behavior,
 	// we set all of the original_paths to be identical.

--- a/tests/filedata/filelist.cc
+++ b/tests/filedata/filelist.cc
@@ -45,21 +45,21 @@ class FileDataSortTest : public t::Test
 	{
 		// We construct these so that fd_first < fd_middle < f_last in
 		// every sortable attribute.
-		fd_first = FileData::file_data_new_simple("/noexist/noexist/1_first.jpg", &context);
+		fd_first = FileData::new_simple("/noexist/noexist/1_first.jpg", &context);
 		fd_first->size = 11;
 		fd_first->date = fd_first->cdate = 1111111111;
 		fd_first->exifdate = fd_first->exifdate_digitized = 1111111111;
 		fd_first->rating = 1;
 		fd_first->format_class = FORMAT_CLASS_IMAGE;
 
-		fd_middle = FileData::file_data_new_simple("/noexist/noexist/2_middle.jpg", &context);
+		fd_middle = FileData::new_simple("/noexist/noexist/2_middle.jpg", &context);
 		fd_middle->size = 222;
 		fd_middle->date = fd_middle->cdate = 2222222222;
 		fd_middle->exifdate = fd_middle->exifdate_digitized = 2222222222;
 		fd_middle->rating = 2;
 		fd_middle->format_class = FORMAT_CLASS_RAWIMAGE;
 
-		fd_last = FileData::file_data_new_simple("/noexist/noexist/3_last.jpg", &context);
+		fd_last = FileData::new_simple("/noexist/noexist/3_last.jpg", &context);
 		fd_last->size = 3333;
 		fd_last->date = fd_last->cdate = 3333333333;
 		fd_last->exifdate = fd_last->exifdate_digitized = 3333333333;
@@ -67,22 +67,10 @@ class FileDataSortTest : public t::Test
 		fd_last->format_class = FORMAT_CLASS_META;
 	}
 
-	void TearDown() override
-	{
-		file_data_unref(fd_last);
-		fd_last = nullptr;
-
-		file_data_unref(fd_middle);
-		fd_middle = nullptr;
-
-		file_data_unref(fd_first);
-		fd_first = nullptr;
-	}
-
-	FileData *fd_first = nullptr;
-	FileData *fd_middle = nullptr;
-	FileData *fd_last = nullptr;
-	FileDataContext context;
+	FileDataContext context;  // Needs to be constructed before RefPtrs.
+	FileDataRef fd_first{nullptr};
+	FileDataRef fd_middle{nullptr};
+	FileDataRef fd_last{nullptr};
 
 	FileData::FileList::SortSettings default_sort = {SORT_NAME, TRUE, TRUE};
 	FileData::FileList::SortSettings reverse_sort = {SORT_NAME, FALSE, TRUE};
@@ -170,14 +158,10 @@ TEST_F(FileDataSortTest, NumberSort)
 	auto &sort_compare_filedata = FileData::FileList::sort_compare_filedata;
 
 	// We create multiple filedatas which only differ in the path name
-	FileDataRef fd_1(FileData::file_data_new_simple("/noexist/noexist/1_image.jpg", &context),
-			    /*skip_initial_ref=*/TRUE);
-	FileDataRef fd_5(FileData::file_data_new_simple("/noexist/noexist/5_image.jpg", &context),
-			    /*skip_initial_ref=*/TRUE);
-	FileDataRef fd_10(FileData::file_data_new_simple("/noexist/noexist/10_image.jpg", &context),
-			     /*skip_initial_ref=*/TRUE);
-	FileDataRef fd_50(FileData::file_data_new_simple("/noexist/noexist/50_image.jpg", &context),
-			     /*skip_initial_ref=*/TRUE);
+	auto fd_1 = FileData::new_simple("/noexist/noexist/1_image.jpg", &context);
+	auto fd_5 = FileData::new_simple("/noexist/noexist/5_image.jpg", &context);
+	auto fd_10 = FileData::new_simple("/noexist/noexist/10_image.jpg", &context);
+	auto fd_50 = FileData::new_simple("/noexist/noexist/50_image.jpg", &context);
 
 	FileData::FileList::SortSettings number_sort = {SORT_NUMBER, TRUE, TRUE};
 
@@ -211,8 +195,7 @@ TEST_F(FileDataSortTest, TieBreakerFallbackBehavior)
 	auto &sort_compare_filedata = FileData::FileList::sort_compare_filedata;
 
 	// Create a FileData that is identical to fd_middle except for original_path.
-	FileDataRef fd_other_middle(FileData::file_data_new_simple("/noexist/otherdir/2_middle.jpg", &context),
-				       /*skip_initial_ref=*/TRUE);
+	auto fd_other_middle = FileData::new_simple("/noexist/otherdir/2_middle.jpg", &context);
 	fd_other_middle->size = fd_middle->size;
 	fd_other_middle->date = fd_middle->date;
 	fd_other_middle->cdate = fd_middle->cdate;
@@ -248,14 +231,10 @@ TEST_F(FileDataSortTest, CaseSensitivity)
 	auto &sort_compare_filedata = FileData::FileList::sort_compare_filedata;
 	using SortSettings = FileData::FileList::SortSettings;
 
-	FileDataRef fd_lower_1(FileData::file_data_new_simple("/noexist/noexist/1_image.jpg", &context),
-				  /*skip_initial_ref=*/TRUE);
-	FileDataRef fd_upper_1(FileData::file_data_new_simple("/noexist/noexist/1_IMAGE.JPG", &context),
-				  /*skip_initial_ref=*/TRUE);
-	FileDataRef fd_lower_10(FileData::file_data_new_simple("/noexist/noexist/10_image.jpg", &context),
-				   /*skip_initial_ref=*/TRUE);
-	FileDataRef fd_upper_10(FileData::file_data_new_simple("/noexist/noexist/10_IMAGE.JPG", &context),
-				   /*skip_initial_ref=*/TRUE);
+	auto fd_lower_1 = FileData::new_simple("/noexist/noexist/1_image.jpg", &context);
+	auto fd_upper_1 = FileData::new_simple("/noexist/noexist/1_IMAGE.JPG", &context);
+	auto fd_lower_10 = FileData::new_simple("/noexist/noexist/10_image.jpg", &context);
+	auto fd_upper_10 = FileData::new_simple("/noexist/noexist/10_IMAGE.JPG", &context);
 
 	// To avoid inadvertently relying on the original_path fallthrough behavior,
 	// we set all of the original_paths to be identical.


### PR DESCRIPTION
This makes it easier to hold a `FileData *` (whether persistently in an object or within a given scope) while avoiding `FileData` leaks.

Note that this will only `unref` correctly when created on the stack, or when the containing object uses `new/delete` semantics -- the destructor will **not** be called by any variant of `g_free`.

This is in response to discussion in #2293 