### PR TITLE
Fixes recent check-build errors

### DIFF
--- a/src/advanced-exif.cc
+++ b/src/advanced-exif.cc
@@ -353,7 +353,7 @@ static gboolean advanced_exif_keypress(GtkWidget *, GdkEventKey *event, gpointer
 	const GdkModifierType event_state = state;
 #else
 	const guint event_keyval = event->keyval;
-	const GdkModifierType event_state = static_cast<GdkModifierType>(event->state);
+	const auto event_state = static_cast<GdkModifierType>(event->state);
 #endif
 
 	if (event_state & GDK_CONTROL_MASK)

--- a/src/bar-keywords.cc
+++ b/src/bar-keywords.cc
@@ -21,7 +21,9 @@
 
 #include "bar-keywords.h"
 
-#if HAVE_GTK4
+#define DISABLE_FILE_WITH_GTK4 HAVE_GTK4
+
+#if DISABLE_FILE_WITH_GTK4
 #else
 
 #include <array>


### PR DESCRIPTION
```
./src/bar-keywords.cc:1331:2: error: nested redundant #if; consider removing it [readability-redundant-preprocessor,-warnings-as-errors]
 1331 | #if HAVE_GTK4
      |  ^
```

And

```
../src/advanced-exif.cc:356:8: error: use auto when initializing with a cast to avoid duplicating the type name [modernize-use-auto,-warnings-as-errors]
  356 |         const GdkModifierType event_state = static_cast<GdkModifierType>(event->state);
      |               ^~~~~~~~~~~~~~~
      |               auto
```