### PR TITLE
Fixes `FD_VERBOSE_DEBUG` tests to switch on value, rather than presence.

### DIFF
--- a/src/filedata.h
+++ b/src/filedata.h
@@ -42,7 +42,7 @@ struct HistMap;
 #define DEBUG_FILEDATA
 #endif
 
-#ifdef FD_VERBOSE_DEBUG
+#if FD_VERBOSE_DEBUG
 #include <sstream>
 #include <vector>
 #endif
@@ -160,7 +160,7 @@ class GlobalFileDataContext
 	FileDataContext context_;
 };
 
-#ifdef FD_VERBOSE_DEBUG
+#if FD_VERBOSE_DEBUG
 struct FileDataDebugInfo {
 	std::vector<std::string> ref_unref_history;
 
@@ -263,7 +263,7 @@ public:
 	static gchar *text_from_size_abrev(gint64 size);
 	static const gchar *text_from_time(time_t t);
 
-	#ifdef FD_VERBOSE_DEBUG
+	#if FD_VERBOSE_DEBUG
 	FileDataDebugInfo debug_info;
 	#endif
 

--- a/src/filedata/filedata.cc
+++ b/src/filedata/filedata.cc
@@ -586,7 +586,7 @@ FileData *FileData::file_data_ref()
 
 #ifdef DEBUG_FILEDATA
 	DEBUG_2("file_data_ref fd=%p (%d): '%s' @ %s:%d", (void *)fd, fd->ref, fd->path, file, line);
-        #ifdef FD_VERBOSE_DEBUG
+        #if FD_VERBOSE_DEBUG
         fd->debug_info.record_ref(file, line, fd->ref);
         #endif
 #else
@@ -619,7 +619,7 @@ void FileData::file_data_dump()
 		auto *fd = static_cast<FileData *>(work->data);
 		log_printf("%-4d %s", fd->ref, fd->path);
 
-		#ifdef FD_VERBOSE_DEBUG
+		#if FD_VERBOSE_DEBUG
 		for (const auto &record : fd->debug_info.ref_unref_history) {
 			log_printf("    %s", record.c_str());
 		}
@@ -728,7 +728,7 @@ void FileData::file_data_unref()
 	DEBUG_2("file_data_unref fd=%p (%d:%d): '%s' @ %s:%d", (void *)fd, fd->ref, fd->locked, fd->path,
 		file, line);
 
-	#ifdef FD_VERBOSE_DEBUG
+	#if FD_VERBOSE_DEBUG
 	fd->debug_info.record_unref(file, line, fd->ref);
 	#endif
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -524,7 +524,7 @@ void exit_program_final()
 		g_object_unref(archive_file);
 		}
 
-	#ifdef FD_VERBOSE_DEBUG
+	#if FD_VERBOSE_DEBUG
 	DEBUG_FD();  // Comment to disable debug check (see debug_check.sh)
 	#endif
 


### PR DESCRIPTION
Without this change, `FD_VERBOSE_DEBUG` behaves as if equivalent to `DEBUG_FILEDATA` (which is set in all debug builds)