### PR TITLE
Updates `PanCacheData` to use `FileDataRef` to manage its contained `FileData *`

### DIFF
--- a/build-aux/trigger-panview-test.py
+++ b/build-aux/trigger-panview-test.py
@@ -1,0 +1,37 @@
+#!/bin/python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import re
+import sys
+import traceback
+
+from lib import geeqie_scripted_test as gst
+
+
+def main(argv) -> int:
+    test_runner = gst.GeeqieScriptedTest(argv)
+
+    container_dir = test_runner.container_dir
+    imgs_dir = test_runner.symlink_images_dir
+
+    empty_re = re.compile(r"^$")
+    some_class_re = re.compile(r"Class: \S")
+
+    script = [
+        (f"--file={imgs_dir}", None),
+        ("--get-file-info",    some_class_re),
+        ("--action=PanView",   None),
+        ("--get-file-info",    some_class_re),
+    ]
+
+    test_runner.run(script)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        exit(main(sys.argv))
+
+    except gst.GeeqieTestError as e:
+        traceback.print_exception(e)
+        exit(e.exit_code)

--- a/meson.build
+++ b/meson.build
@@ -758,6 +758,16 @@ else
     summary({'FileData refcount test' : ['Test runs:', false]}, section : 'Testing', bool_yn : true)
 endif
 
+# Pan-view test
+if should_run_image_tests
+    trigger_panview_test_py = find_program('trigger-panview-test.py', dirs : buildauxdir, required : true)
+    test_cmd = [trigger_panview_test_py.full_path(), geeqie_exe.full_path(), test_image_dir]
+    test('Pan-view execution test', isolate_test_sh, args: test_cmd, timeout: 100, suite: ['functional', 'image'])
+    summary({'Pan-view execution test' : ['Test runs:', true]}, section : 'Testing', bool_yn : true)
+else
+    summary({'Pan-view execution test' : ['Test runs:', false]}, section : 'Testing', bool_yn : true)
+endif
+
 # Code correctness checks
 clang_tidy_exe = find_program('clang-tidy', required : false)
 if running_from_git and clang_tidy_exe.found()

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -79,7 +79,7 @@ namespace
 {
 
 struct PanCacheData {
-	FileData *fd;
+	FileDataRef fd_ref{nullptr};
 	std::unique_ptr<CacheData> cd;
 };
 
@@ -107,14 +107,6 @@ constexpr gint PAN_POPUP_BORDER = 1;
 constexpr guint8 PAN_POPUP_ALPHA = 255;
 constexpr GqColor PAN_POPUP_COLOR{255, 255, 225, PAN_POPUP_ALPHA};
 constexpr GqColor PAN_POPUP_BORDER_COLOR{0, 0, 0, PAN_POPUP_ALPHA};
-
-void pan_cache_data_free(PanCacheData *pc)
-{
-	if (!pc) return;
-
-	file_data_unref(pc->fd);
-	delete pc;
-}
 
 } // namespace
 
@@ -216,8 +208,7 @@ static void pan_queue_thumb_done_cb(ThumbLoader *tl, gpointer data)
 
 	g_clear_pointer(&pw->tl, thumb_loader_free);
 
-	while (pan_queue_step(pw))
-		;
+	while (pan_queue_step(pw)) {}
 }
 
 static void pan_queue_image_done_cb(ImageLoader *il, gpointer data)
@@ -497,7 +488,7 @@ static gint pan_cache_sort_file_cb(gconstpointer a, gconstpointer b, gpointer da
 	auto pca = static_cast<const PanCacheData *>(a);
 	auto pcb = static_cast<const PanCacheData *>(b);
 	auto settings = static_cast<FileData::FileList::SortSettings *>(data);
-	return filelist_sort_compare_filedata(pca->fd, pcb->fd, settings);
+	return filelist_sort_compare_filedata(pca->fd_ref, pcb->fd_ref, settings);
 }
 
 static void pan_cache_sort(PanWindow *pw, FileData::FileList::SortSettings settings)
@@ -507,8 +498,7 @@ static void pan_cache_sort(PanWindow *pw, FileData::FileList::SortSettings setti
 
 static void pan_cache_free(PanWindow *pw)
 {
-	g_list_free_full(pw->cache_list, reinterpret_cast<GDestroyNotify>(pan_cache_data_free));
-	pw->cache_list = nullptr;
+	g_clear_list(&pw->cache_list, delete_cb<PanCacheData>);
 
 	file_data_list_free(pw->cache_todo);
 	pw->cache_todo = nullptr;
@@ -563,7 +553,7 @@ static gboolean pan_cache_step(PanWindow *pw)
 	pw->cache_todo = g_list_remove(pw->cache_todo, fd);
 
 	auto *pc = new PanCacheData();
-	pc->fd = file_data_ref(fd);
+	pc->fd_ref.reset(fd);
 
 	pw->cache_list = g_list_prepend(pw->cache_list, pc);
 
@@ -572,7 +562,7 @@ static gboolean pan_cache_step(PanWindow *pw)
 	load_mask = CACHE_LOADER_NONE;
 	if (pw->size > PAN_IMAGE_SIZE_THUMB_LARGE) load_mask = static_cast<CacheDataType>(load_mask | CACHE_LOADER_DIMENSIONS);
 	if (pw->exif_date_enable) load_mask = static_cast<CacheDataType>(load_mask | CACHE_LOADER_DATE);
-	pw->cache_cl = cache_loader_new(pc->fd, load_mask,
+	pw->cache_cl = cache_loader_new(pc->fd_ref, load_mask,
 					pan_cache_step_done_cb, pw);
 	return (pw->cache_cl == nullptr);
 }
@@ -583,7 +573,7 @@ static void pan_cache_sync_date(const PanWindow *pw, GList *list)
 	static const auto pan_cache_data_compare_fd = [](gconstpointer data, gconstpointer user_data)
 	{
 		auto *pc = static_cast<const PanCacheData *>(data);
-		return (pc->fd == user_data) ? 0 : 1;
+		return (*(pc->fd_ref) == user_data) ? 0 : 1;
 	};
 
 	g_autoptr(GList) haystack = g_list_copy(pw->cache_list);
@@ -637,7 +627,7 @@ std::optional<GqSize> pan_cache_get_image_size(PanWindow *pw, const FileData *fd
 	const auto pan_cache_data_cd_dimensions_compare_fd = [](gconstpointer data, gconstpointer user_data)
 	{
 		auto *pc = static_cast<const PanCacheData *>(data);
-		return (pc->cd && pc->cd->dimensions && pc->fd == user_data) ? 0 : 1;
+		return (pc->cd && pc->cd->dimensions && *(pc->fd_ref) == user_data) ? 0 : 1;
 	};
 
 	GList *work = g_list_find_custom(pw->cache_list, fd, pan_cache_data_cd_dimensions_compare_fd);
@@ -649,7 +639,7 @@ std::optional<GqSize> pan_cache_get_image_size(PanWindow *pw, const FileData *fd
 	const GqSize size = pc->cd->dimensions.value(); // NOLINT(bugprone-unchecked-optional-access)
 
 	pw->cache_list = g_list_remove(pw->cache_list, pc);
-	pan_cache_data_free(pc);
+	delete pc;
 
 	return size;
 }


### PR DESCRIPTION
(Stacked atop PR #2412)
Also creates a scripted test to trigger pan-view, along with performing some other minor code cleanups.

The scripted test doesn't do much, but should at least make sure that panview doesn't have any major runtime crashes.

(Replaces PR #2407, and incorporates feedback from that PR)