### PR TITLE
Removes constructor arguments that haven't been used in a long time

### DIFF
--- a/src/view-dir-list.cc
+++ b/src/view-dir-list.cc
@@ -426,7 +426,7 @@ void vdlist_destroy_cb(GtkWidget *, gpointer data)
 	file_data_list_free(VDLIST(vd)->list);
 }
 
-ViewDir *vdlist_new(ViewDir *vd, FileData *)
+ViewDir *vdlist_new(ViewDir *vd)
 {
 	GtkListStore *store;
 	GtkTreeSelection *selection;

--- a/src/view-dir-list.h
+++ b/src/view-dir-list.h
@@ -31,7 +31,7 @@
 class FileData;
 struct ViewDir;
 
-ViewDir *vdlist_new(ViewDir *vd, FileData *dir_fd);
+ViewDir *vdlist_new(ViewDir *vd);
 
 gboolean vdlist_set_fd(ViewDir *vd, FileData *dir_fd);
 void vdlist_refresh(ViewDir *vd);

--- a/src/view-dir-tree.cc
+++ b/src/view-dir-tree.cc
@@ -994,7 +994,7 @@ void vdtree_destroy_cb(GtkWidget *, gpointer data)
 	gtk_tree_model_foreach(store, vdtree_destroy_node_cb, vd);
 }
 
-ViewDir *vdtree_new(ViewDir *vd, FileData *)
+ViewDir *vdtree_new(ViewDir *vd)
 {
 	GtkTreeStore *store;
 	GtkTreeSelection *selection;

--- a/src/view-dir-tree.h
+++ b/src/view-dir-tree.h
@@ -41,7 +41,7 @@ struct NodeData
 	gint version;
 };
 
-ViewDir *vdtree_new(ViewDir *vd, FileData *dir_fd);
+ViewDir *vdtree_new(ViewDir *vd);
 
 gboolean vdtree_set_fd(ViewDir *vd, FileData *dir_fd);
 void vdtree_refresh(ViewDir *vd);

--- a/src/view-dir.cc
+++ b/src/view-dir.cc
@@ -201,8 +201,8 @@ ViewDir *vd_new(LayoutWindow *lw)
 
 	switch (lw->options.dir_view_type)
 		{
-		case DIRVIEW_LIST: vd = vdlist_new(vd, lw->dir_fd); break;
-		case DIRVIEW_TREE: vd = vdtree_new(vd, lw->dir_fd); break;
+		case DIRVIEW_LIST: vd = vdlist_new(vd); break;
+		case DIRVIEW_TREE: vd = vdtree_new(vd); break;
 		}
 
 	gq_gtk_container_add(vd->widget, vd->view);


### PR DESCRIPTION
The intent here is to make `vd_new` easier to reason about (and particularly, the fact that `dir_fd` may remain uninitialized after `vd_new` returns.

The code that origially used this was refactored from `view_dir_{tree,list}.c` into `view_dir.c` in 5add0a6fd3900ca0c6ea0ed8989e74780f27a8c7

Pertains to #2424 