### PR TITLE
Refactors `FileDataRef` into its own header file

### DIFF
--- a/src/filedata.h
+++ b/src/filedata.h
@@ -31,6 +31,7 @@
 
 #include <config.h>
 
+#include "filedata/ref.h"
 #include "sort-type.h"
 
 enum FileFormatClass : gint;
@@ -187,42 +188,6 @@ struct FileDataDebugInfo {
 	};
 };
 #endif
-
-class FileData;
-
-/**
- * @class FileDataRef
- * @brief RAII object that holds a ref to the specified FileData.
- */
-class FileDataRef
-{
-    public:
-	explicit FileDataRef(FileData *fd);
-	// Not copyable or copy-assignable.
-	FileDataRef(FileDataRef &) = delete;
-	FileDataRef &operator=(const FileDataRef &) = delete;
-
-	// Allow move and move-assignment.
-	FileDataRef(FileDataRef &&) noexcept;
-	FileDataRef &operator=(FileDataRef &&) noexcept;
-
-	~FileDataRef();
-
-	// Allow implicit conversion directly to FileData*.
-	// This allows a FileDataRef to be used anywhere a FileData* is expected.
-	operator FileData*() const { return fd_; }
-
-	// In a boolean context, return whether or not we're holding nullptr.
-	operator bool() const { return fd_ != nullptr; }
-
-	void reset(FileData *new_fd);
-	FileData *release();
-	FileData* operator*() const { return fd_; }
-	FileData* operator->() const { return fd_; }
-
-    private:
-	FileData *fd_ = nullptr;
-};
 
 class FileData {
 private:

--- a/src/filedata/filedata.cc
+++ b/src/filedata/filedata.cc
@@ -2994,44 +2994,6 @@ bool FileData::supports_exif_orientation() const
 	    && (g_strcmp0(format_name, "jxl") != 0);
 }
 
-FileDataRef::FileDataRef(FileData *fd) : fd_(fd)
-{
-	if (fd_ != nullptr) fd_->file_data_ref();
-}
-
-FileDataRef::FileDataRef(FileDataRef &&other) noexcept
-{
-	*this = std::move(other);
-}
-
-FileDataRef &FileDataRef::operator=(FileDataRef &&other) noexcept
-{
-	fd_ = other.fd_;
-	other.fd_ = nullptr;
-
-	return *this;
-}
-
-FileDataRef::~FileDataRef()
-{
-	if(fd_ != nullptr) fd_->file_data_unref();
-}
-
-void FileDataRef::reset(FileData *new_fd)
-{
-	if(new_fd != nullptr) new_fd->file_data_ref();
-
-	FileData *old_fd = fd_;
-	fd_ = new_fd;
-
-	if (old_fd != nullptr) old_fd->file_data_unref();
-}
-
-FileData *FileDataRef::release()
-{
-	return g_steal_pointer(&fd_);
-}
-
 // NOLINTEND(readability-convert-member-functions-to-static)
 
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/filedata/meson.build
+++ b/src/filedata/meson.build
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 filedata_sources = files('filedata.cc',
-'filelist.cc')
+'filelist.cc',
+'ref.cc',
+'ref.h')
 
 code_sources += filedata_sources

--- a/src/filedata/ref.cc
+++ b/src/filedata/ref.cc
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#include "filedata.h"
+#include "ref.h"
+
+FileDataRef::FileDataRef(FileData *fd) : fd_(fd)
+{
+	if (fd_ != nullptr) fd_->file_data_ref();
+}
+
+FileDataRef::FileDataRef(FileDataRef &&other) noexcept
+{
+	*this = std::move(other);
+}
+
+FileDataRef &FileDataRef::operator=(FileDataRef &&other) noexcept
+{
+	fd_ = other.fd_;
+	other.fd_ = nullptr;
+
+	return *this;
+}
+
+FileDataRef::~FileDataRef()
+{
+	if(fd_ != nullptr) fd_->file_data_unref();
+}
+
+void FileDataRef::reset(FileData *new_fd)
+{
+	if(new_fd != nullptr) new_fd->file_data_ref();
+
+	FileData *old_fd = fd_;
+	fd_ = new_fd;
+
+	if (old_fd != nullptr) old_fd->file_data_unref();
+}
+
+FileData *FileDataRef::release()
+{
+	return g_steal_pointer(&fd_);
+}
+
+/* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/filedata/ref.h
+++ b/src/filedata/ref.h
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#ifndef FILEDATA_REF_H
+#define FILEDATA_REF_H
+
+class FileData;
+
+/**
+ * @class FileDataRef
+ * @brief RAII object that holds a ref to the specified FileData.
+ */
+class FileDataRef
+{
+    public:
+	explicit FileDataRef(FileData *fd);
+	// Not copyable or copy-assignable.
+	FileDataRef(FileDataRef &) = delete;
+	FileDataRef &operator=(const FileDataRef &) = delete;
+
+	// Allow move and move-assignment.
+	FileDataRef(FileDataRef &&) noexcept;
+	FileDataRef &operator=(FileDataRef &&) noexcept;
+
+	~FileDataRef();
+
+	// Allow implicit conversion directly to FileData*.
+	// This allows a FileDataRef to be used anywhere a FileData* is expected.
+	operator FileData*() const { return fd_; }
+
+	// In a boolean context, return whether or not we're holding nullptr.
+	operator bool() const { return fd_ != nullptr; }
+
+	void reset(FileData *new_fd);
+	FileData *release();
+	FileData* operator*() const { return fd_; }
+	FileData* operator->() const { return fd_; }
+
+    private:
+	FileData *fd_ = nullptr;
+};
+
+#endif  // FILEDATA_REF_H
+
+/* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/tests/filedata/filedata.cc
+++ b/tests/filedata/filedata.cc
@@ -38,7 +38,6 @@ namespace {
 // For convenience.
 namespace t = ::testing;
 
-
 class FileDataTest : public t::Test
 {
     protected:
@@ -54,9 +53,6 @@ class FileDataTest : public t::Test
 	FileData *fd2 = nullptr;
 	FileData *parent_fd = nullptr;
 };
-
-// Used to group and report tests separately, even though it's the same fixture implementation.
-class FileDataRefTest : public FileDataTest {};
 
 TEST_F(FileDataTest, text_from_size_test)
 {
@@ -145,159 +141,6 @@ TEST_F(FileDataTest, BasicIncrementVersionWithParent)
 	ASSERT_EQ(0x0, fd->valid_marks);
 	ASSERT_EQ(1, parent_fd->version);
 	ASSERT_EQ(0x0, parent_fd->valid_marks);
-}
-
-TEST_F(FileDataRefTest, NonOwningRefCount)
-{
-	fd = g_new0(FileData, 1);
-	fd->magick = FD_MAGICK;
-	// Avoids having the FileData object automatically freed when its
-	// refcount drops back to zero.
-	file_data_lock(fd);
-
-	// Refcount is 0 outside of the FileDataRef scope.
-	ASSERT_EQ(0, fd->ref);
-
-	{
-		// Refcount is 0 inside of the FileDataRef scope, but before it's defined.
-		ASSERT_EQ(0, fd->ref);
-
-		// Refcount should increase by 1 after the FileDataRef is created.
-		FileDataRef fd_ref(fd);
-		ASSERT_EQ(1, fd->ref);
-
-		// Refcount should increase by 1 more with the second FileDataRef.
-		FileDataRef fd_ref2(fd);
-		ASSERT_EQ(2, fd->ref);
-	}
-
-	// And refcount drops back down to 0 after both of the FileDataRefs go out of scope.
-	ASSERT_EQ(0, fd->ref);
-}
-
-TEST_F(FileDataRefTest, Reset)
-{
-	fd = g_new0(FileData, 1);
-	fd->magick = FD_MAGICK;
-	fd2 = g_new0(FileData, 1);
-	fd2->magick = FD_MAGICK;
-
-	// Avoids having the FileData objects automatically freed when its
-	// refcount drops back to zero.
-	file_data_lock(fd);
-	file_data_lock(fd2);
-
-	// Start off with no refs.
-	ASSERT_EQ(0, fd->ref);
-	ASSERT_EQ(0, fd2->ref);
-
-	// This should ref fd.
-	FileDataRef fd_ref(fd);
-
-	ASSERT_EQ(1, fd->ref);
-	ASSERT_EQ(0, fd2->ref);
-	ASSERT_EQ(fd, static_cast<FileData *>(fd_ref));
-
-	// This should ref fd2 and unref fd.
-	fd_ref.reset(fd2);
-
-	ASSERT_EQ(0, fd->ref);
-	ASSERT_EQ(1, fd2->ref);
-	ASSERT_EQ(fd2, static_cast<FileData *>(fd_ref));
-}
-
-TEST_F(FileDataRefTest, ResetToNull)
-{
-	fd = g_new0(FileData, 1);
-	fd->magick = FD_MAGICK;
-
-	// Avoids having the FileData objects automatically freed when its
-	// refcount drops back to zero.
-	file_data_lock(fd);
-
-	FileDataRef fd_ref(fd);
-	ASSERT_EQ(1, fd->ref);
-
-	// Reset to nullptr shouldn't crash, and should unref the previously held fd.
-	fd_ref.reset(nullptr);
-	ASSERT_EQ(0, fd->ref);
-	ASSERT_EQ(nullptr, static_cast<FileData *>(fd_ref));
-
-	// And we should be able to re-ref the original fd without crashing.
-	fd_ref.reset(fd);
-	ASSERT_EQ(1, fd->ref);
-	ASSERT_EQ(fd, static_cast<FileData *>(fd_ref));
-}
-
-TEST_F(FileDataRefTest, Release)
-{
-#ifdef DEBUG_FILEDATA
-	ASSERT_EQ(0, context.global_file_data_count);
-	FileData *fd_ptr = nullptr;
-
-	{
-		auto fd_ref = FileData::new_simple("/does/not/exist.jpg", &context);
-		ASSERT_EQ(1, context.global_file_data_count);
-		ASSERT_EQ(1, fd_ref->ref);
-
-		fd_ptr = fd_ref.release();
-		ASSERT_EQ(1, context.global_file_data_count);
-		ASSERT_EQ(nullptr, *fd_ref);
-		ASSERT_NE(nullptr, fd_ptr);
-		ASSERT_EQ(1, fd_ptr->ref);
-	}
-
-	// fd_ref should have been empty, so it going out of scope should be a no-op.
-	ASSERT_EQ(1, context.global_file_data_count);
-	ASSERT_NE(nullptr, fd_ptr);
-	ASSERT_EQ(1, fd_ptr->ref);
-
-	fd_ptr->file_data_unref();
-	ASSERT_EQ(0, context.global_file_data_count);
-#else
-	GTEST_SKIP() << "Test requires DEBUG_FILEDATA";
-#endif
-}
-
-TEST_F(FileDataRefTest, AnonymousReturn)
-{
-	const auto &make_ref = []() -> FileDataRef {
-		auto *fd = g_new0(FileData, 1);
-		fd->magick = FD_MAGICK;
-		// Avoids having the FileData objects automatically freed when its
-		// refcount drops back to zero.
-		file_data_lock(fd);
-
-		return FileDataRef{fd};
-	};
-
-	// This ensures that the post-move anonymous FileDataRef can be destructed without crashing.
-	FileDataRef fd_ref = make_ref();
-	ASSERT_EQ(1, fd_ref->ref);
-
-	// We need to manually free the FileData* since it doesn't have a context.
-	g_free(fd_ref.release());
-}
-
-/**
- * Validates a common compatibility pattern for interacting with code that stores FileData*.
- */
-TEST_F(FileDataRefTest, AnonymousReturnAndRelease)
-{
-	const auto &make_ref = []() -> FileDataRef {
-		auto *_fd = g_new0(FileData, 1);
-		_fd->magick = FD_MAGICK;
-		// Avoids having the FileData objects automatically freed when its
-		// refcount drops back to zero.
-		file_data_lock(_fd);
-
-		return FileDataRef{_fd};
-	};
-
-	// This ensures that the post-move anonymous FileDataRef can be destructed without crashing.
-	fd = make_ref().release();
-	ASSERT_NE(nullptr, fd);
-	ASSERT_EQ(1, fd->ref);
 }
 
 }  // anonymous namespace

--- a/tests/filedata/ref.cc
+++ b/tests/filedata/ref.cc
@@ -1,0 +1,184 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "filedata.h"
+#include "filedata/ref.h"
+
+namespace {
+
+// For convenience.
+namespace t = ::testing;
+
+
+class FileDataRefTest : public t::Test
+{
+    protected:
+	void TearDown() override
+	{
+		g_clear_pointer(&fd, g_free);
+		g_clear_pointer(&fd2, g_free);
+	}
+
+	FileDataContext context;
+	FileData *fd = nullptr;
+	FileData *fd2 = nullptr;
+};
+
+TEST_F(FileDataRefTest, NonOwningRefCount)
+{
+	fd = g_new0(FileData, 1);
+	fd->magick = FD_MAGICK;
+	// Avoids having the FileData object automatically freed when its
+	// refcount drops back to zero.
+	file_data_lock(fd);
+
+	// Refcount is 0 outside of the FileDataRef scope.
+	ASSERT_EQ(0, fd->ref);
+
+	{
+		// Refcount is 0 inside of the FileDataRef scope, but before it's defined.
+		ASSERT_EQ(0, fd->ref);
+
+		// Refcount should increase by 1 after the FileDataRef is created.
+		FileDataRef fd_ref(fd);
+		ASSERT_EQ(1, fd->ref);
+
+		// Refcount should increase by 1 more with the second FileDataRef.
+		FileDataRef fd_ref2(fd);
+		ASSERT_EQ(2, fd->ref);
+	}
+
+	// And refcount drops back down to 0 after both of the FileDataRefs go out of scope.
+	ASSERT_EQ(0, fd->ref);
+}
+
+TEST_F(FileDataRefTest, Reset)
+{
+	fd = g_new0(FileData, 1);
+	fd->magick = FD_MAGICK;
+	fd2 = g_new0(FileData, 1);
+	fd2->magick = FD_MAGICK;
+
+	// Avoids having the FileData objects automatically freed when its
+	// refcount drops back to zero.
+	file_data_lock(fd);
+	file_data_lock(fd2);
+
+	// Start off with no refs.
+	ASSERT_EQ(0, fd->ref);
+	ASSERT_EQ(0, fd2->ref);
+
+	// This should ref fd.
+	FileDataRef fd_ref(fd);
+
+	ASSERT_EQ(1, fd->ref);
+	ASSERT_EQ(0, fd2->ref);
+	ASSERT_EQ(fd, static_cast<FileData *>(fd_ref));
+
+	// This should ref fd2 and unref fd.
+	fd_ref.reset(fd2);
+
+	ASSERT_EQ(0, fd->ref);
+	ASSERT_EQ(1, fd2->ref);
+	ASSERT_EQ(fd2, static_cast<FileData *>(fd_ref));
+}
+
+TEST_F(FileDataRefTest, ResetToNull)
+{
+	fd = g_new0(FileData, 1);
+	fd->magick = FD_MAGICK;
+
+	// Avoids having the FileData objects automatically freed when its
+	// refcount drops back to zero.
+	file_data_lock(fd);
+
+	FileDataRef fd_ref(fd);
+	ASSERT_EQ(1, fd->ref);
+
+	// Reset to nullptr shouldn't crash, and should unref the previously held fd.
+	fd_ref.reset(nullptr);
+	ASSERT_EQ(0, fd->ref);
+	ASSERT_EQ(nullptr, static_cast<FileData *>(fd_ref));
+
+	// And we should be able to re-ref the original fd without crashing.
+	fd_ref.reset(fd);
+	ASSERT_EQ(1, fd->ref);
+	ASSERT_EQ(fd, static_cast<FileData *>(fd_ref));
+}
+
+TEST_F(FileDataRefTest, Release)
+{
+#ifdef DEBUG_FILEDATA
+	ASSERT_EQ(0, context.global_file_data_count);
+	FileData *fd_ptr = nullptr;
+
+	{
+		auto fd_ref = FileData::new_simple("/does/not/exist.jpg", &context);
+		ASSERT_EQ(1, context.global_file_data_count);
+		ASSERT_EQ(1, fd_ref->ref);
+
+		fd_ptr = fd_ref.release();
+		ASSERT_EQ(1, context.global_file_data_count);
+		ASSERT_EQ(nullptr, *fd_ref);
+		ASSERT_NE(nullptr, fd_ptr);
+		ASSERT_EQ(1, fd_ptr->ref);
+	}
+
+	// fd_ref should have been empty, so it going out of scope should be a no-op.
+	ASSERT_EQ(1, context.global_file_data_count);
+	ASSERT_NE(nullptr, fd_ptr);
+	ASSERT_EQ(1, fd_ptr->ref);
+
+	fd_ptr->file_data_unref();
+	ASSERT_EQ(0, context.global_file_data_count);
+#else
+	GTEST_SKIP() << "Test requires DEBUG_FILEDATA";
+#endif
+}
+
+TEST_F(FileDataRefTest, AnonymousReturn)
+{
+	const auto &make_ref = []() -> FileDataRef {
+		auto *fd = g_new0(FileData, 1);
+		fd->magick = FD_MAGICK;
+		// Avoids having the FileData objects automatically freed when its
+		// refcount drops back to zero.
+		file_data_lock(fd);
+
+		return FileDataRef{fd};
+	};
+
+	// This ensures that the post-move anonymous FileDataRef can be destructed without crashing.
+	FileDataRef fd_ref = make_ref();
+	ASSERT_EQ(1, fd_ref->ref);
+
+	// We need to manually free the FileData* since it doesn't have a context.
+	g_free(fd_ref.release());
+}
+
+/**
+ * Validates a common compatibility pattern for interacting with code that stores FileData*.
+ */
+TEST_F(FileDataRefTest, AnonymousReturnAndRelease)
+{
+	const auto &make_ref = []() -> FileDataRef {
+		auto *_fd = g_new0(FileData, 1);
+		_fd->magick = FD_MAGICK;
+		// Avoids having the FileData objects automatically freed when its
+		// refcount drops back to zero.
+		file_data_lock(_fd);
+
+		return FileDataRef{_fd};
+	};
+
+	// This ensures that the post-move anonymous FileDataRef can be destructed without crashing.
+	fd = make_ref().release();
+	ASSERT_NE(nullptr, fd);
+	ASSERT_EQ(1, fd->ref);
+}
+
+}  // anonymous namespace
+
+/* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4,6 +4,7 @@ unit_test_sources = files(
 'filecache.cc',
 'filedata/filedata.cc',
 'filedata/filelist.cc',
+'filedata/ref.cc',
 'pixbuf-util.cc')
 
 code_sources += unit_test_sources


### PR DESCRIPTION
This is to make it easily usable from header files that forward-declare `FileData` instead of `#include`ing `filedata.h`.