### PR TITLE
Switches `ViewData` implementations to use `FileDataRef` for `dir_fd` and temporaries

### DIFF
--- a/src/filedata/ref.h
+++ b/src/filedata/ref.h
@@ -30,6 +30,12 @@ class FileDataRef
 	// In a boolean context, return whether or not we're holding nullptr.
 	operator bool() const { return fd_ != nullptr; }
 
+	// FileDataRef equality means equality of the contained FileData*.
+	// This is aligned with the behavior of `FileDataRef == FileData*`, which is implicitly
+	// converted to `FileData* == FileData*`.
+	bool operator==(const FileDataRef &other) const { return fd_ == other.fd_; }
+	bool operator!=(const FileDataRef &other) const { return !(*this == other); }
+
 	void reset(FileData *new_fd);
 	FileData *release();
 	FileData* operator*() const { return fd_; }

--- a/src/view-dir-list.cc
+++ b/src/view-dir-list.cc
@@ -313,8 +313,7 @@ gboolean vdlist_set_fd(ViewDir *vd, FileData *dir_fd)
 			}
 		}
 
-	file_data_unref(vd->dir_fd);
-	vd->dir_fd = file_data_ref(dir_fd);
+	vd->dir_fd.reset(dir_fd);
 
 	ret = vdlist_populate(vd, TRUE);
 

--- a/src/view-dir-tree.cc
+++ b/src/view-dir-tree.cc
@@ -668,8 +668,7 @@ gboolean vdtree_set_fd(ViewDir *vd, FileData *dir_fd)
 	if (!dir_fd) return FALSE;
 	if (vd->dir_fd == dir_fd) return TRUE;
 
-	file_data_unref(vd->dir_fd);
-	vd->dir_fd = file_data_ref(dir_fd);
+	vd->dir_fd.reset(dir_fd);
 
 	fd = vdtree_populate_path(vd, vd->dir_fd, TRUE, FALSE);
 
@@ -984,13 +983,12 @@ static gboolean vdtree_destroy_node_cb(GtkTreeModel *store, GtkTreePath *, GtkTr
 void vdtree_destroy_cb(GtkWidget *, gpointer data)
 {
 	auto vd = static_cast<ViewDir *>(data);
-	GtkTreeModel *store;
 
 	vdtree_dnd_drop_expand_cancel(vd);
 	vd_dnd_drop_scroll_cancel(vd);
 	widget_auto_scroll_stop(vd->view);
 
-	store = gtk_tree_view_get_model(GTK_TREE_VIEW(vd->view));
+	GtkTreeModel *store = gtk_tree_view_get_model(GTK_TREE_VIEW(vd->view));
 	gtk_tree_model_foreach(store, vdtree_destroy_node_cb, vd);
 }
 

--- a/src/view-dir-tree.cc
+++ b/src/view-dir-tree.cc
@@ -502,9 +502,7 @@ gboolean vdtree_populate_path_by_iter(ViewDir *vd, GtkTreeIter *iter, gboolean f
 	work = list;
 	while (work)
 		{
-		FileData *fd;
-
-		fd = static_cast<FileData *>(work->data);
+		auto *fd = static_cast<FileData *>(work->data);
 		work = work->next;
 
 		if (strcmp(fd->name, ".") == 0 || strcmp(fd->name, "..") == 0)

--- a/src/view-dir.cc
+++ b/src/view-dir.cc
@@ -173,23 +173,22 @@ static void vd_destroy_cb(GtkWidget *widget, gpointer data)
 		}
 
 	switch (vd->type)
-	{
-	case DIRVIEW_LIST: vdlist_destroy_cb(widget, data); break;
-	case DIRVIEW_TREE: vdtree_destroy_cb(widget, data); break;
-	}
+		{
+		case DIRVIEW_LIST: vdlist_destroy_cb(widget, data); break;
+		case DIRVIEW_TREE: vdtree_destroy_cb(widget, data); break;
+		}
 
 	folder_icons_free(vd->pf);
 	file_data_list_free(vd->drop_list);
 
-	file_data_unref(vd->dir_fd);
-	g_free(vd->info);
+	g_clear_pointer(&vd->info, g_free);
 
-	g_free(vd);
+	delete vd;
 }
 
 ViewDir *vd_new(LayoutWindow *lw)
 {
-	auto vd = g_new0(ViewDir, 1);
+	auto *vd = new ViewDir();
 
 	vd->widget = gq_gtk_scrolled_window_new(nullptr, nullptr);
 	gq_gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(vd->widget), GTK_SHADOW_IN);

--- a/src/view-dir.cc
+++ b/src/view-dir.cc
@@ -336,15 +336,13 @@ static gboolean vd_rename_cb(TreeEditData *td, const gchar *, const gchar *new_n
 	{
 		if (!success) return;
 
-		FileData *fd = file_data_new_dir(new_path);
+		auto fd_ref = FileData::new_dir(new_path);
 
 		GtkTreeIter iter;
-		if (vd_find_row(vd, fd, &iter))
+		if (vd_find_row(vd, fd_ref, &iter))
 			{
 			tree_view_row_make_visible(GTK_TREE_VIEW(vd->view), &iter, TRUE);
 			}
-
-		file_data_unref(fd);
 	};
 	file_util_rename_dir(fd, new_path, vd->view, vd_rename_finished_cb);
 
@@ -496,9 +494,8 @@ static void vd_pop_menu_up_cb(GtkWidget *, gpointer data)
 	if (vd->select_func)
 		{
 		g_autofree gchar *path = remove_level_from_path(vd->dir_fd->path);
-		FileData *fd = file_data_new_dir(path);
-		vd->select_func(vd, fd, vd->select_data);
-		file_data_unref(fd);
+		auto fd_ref = FileData::new_dir(path);
+		vd->select_func(vd, fd_ref, vd->select_data);
 		}
 }
 
@@ -790,9 +787,8 @@ void vd_new_folder(ViewDir *vd, FileData *dir_fd)
 				break;
 			case DIRVIEW_TREE:
 				{
-				FileData *new_fd = file_data_new_dir(new_path);
-				fd = vdtree_populate_path(vd, new_fd, TRUE, TRUE);
-				file_data_unref(new_fd);
+				auto new_fd_ref = FileData::new_dir(new_path);
+				fd = vdtree_populate_path(vd, new_fd_ref, TRUE, TRUE);
 				}
 				break;
 			}
@@ -1326,14 +1322,12 @@ static void vd_notify_cb(FileData *fd, NotifyType type, gpointer data)
 	if (vd->type == DIRVIEW_TREE)
 		{
 		GtkTreeIter iter;
-		FileData *base_fd = file_data_new_dir(base);
+		auto base_fd_ref = FileData::new_dir(base);
 
-		if (vd_find_row(vd, base_fd, &iter))
+		if (vd_find_row(vd, base_fd_ref, &iter))
 			{
 			vdtree_populate_path_by_iter(vd, &iter, TRUE, vd->dir_fd);
 			}
-
-		file_data_unref(base_fd);
 		}
 }
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/view-dir.h
+++ b/src/view-dir.h
@@ -27,8 +27,8 @@
 #include <gtk/gtk.h>
 
 #include "compat.h"
+#include "filedata/ref.h"
 
-class FileData;
 struct LayoutWindow;
 
 enum DirViewType : guint {
@@ -61,31 +61,31 @@ struct PixmapFolders
 struct ViewDir
 {
 	DirViewType type;
-	gpointer info;
+	gpointer info = nullptr;
 
-	GtkWidget *widget;
-	GtkWidget *view;
+	GtkWidget *widget = nullptr;
+	GtkWidget *view = nullptr;
 
-	FileData *dir_fd;
+	FileDataRef dir_fd{nullptr};
 
-	FileData *click_fd;
+	FileData *click_fd = nullptr;
 
-	FileData *drop_fd;
-	GList *drop_list;
+	FileData *drop_fd = nullptr;
+	GList *drop_list = nullptr;
 	guint drop_scroll_id; /**< event source id */
 
 	/* func list */
 	void (*select_func)(ViewDir *vd, FileData *fd, gpointer data);
-	gpointer select_data;
+	gpointer select_data = nullptr;
 
 	void (*dnd_drop_update_func)(ViewDir *vd);
 	void (*dnd_drop_leave_func)(ViewDir *vd);
 
-	LayoutWindow *layout;
+	LayoutWindow *layout = nullptr;
 
-	GtkWidget *popup;
+	GtkWidget *popup = nullptr;
 
-	PixmapFolders *pf;
+	PixmapFolders *pf = nullptr;
 };
 
 ViewDir *vd_new(LayoutWindow *lw);

--- a/tests/filedata/ref.cc
+++ b/tests/filedata/ref.cc
@@ -179,6 +179,53 @@ TEST_F(FileDataRefTest, AnonymousReturnAndRelease)
 	ASSERT_EQ(1, fd->ref);
 }
 
+
+/**
+ * Ensures that equality comparisons are consistent and correct against either FileData* or FileDataRef.
+ */
+TEST_F(FileDataRefTest, FileDataEquality)
+{
+	fd = g_new0(FileData, 1);
+	fd->magick = FD_MAGICK;
+
+	// Avoids having the FileData objects automatically freed when its
+	// refcount drops back to zero.
+	file_data_lock(fd);
+	FileData *null_fd = nullptr;
+
+	FileDataRef fd_ref{fd};
+	FileDataRef fd_ref2{fd};
+	FileDataRef fd_null_ref{nullptr};
+
+	// Using ASSERT_TRUE instead of ASSERT_EQ to ensure the macro isn't affecting implicit behavior.
+	// We evaluate == and !=
+	ASSERT_TRUE(fd_ref == fd);
+	ASSERT_TRUE(fd_ref2 == fd);
+	ASSERT_TRUE(fd_ref == fd_ref2);
+	ASSERT_TRUE(*fd_ref == fd);
+	ASSERT_TRUE(*fd_ref2 == fd);
+	ASSERT_TRUE(*fd_ref == *fd_ref2);
+	ASSERT_TRUE(fd_ref == fd_ref);
+	ASSERT_TRUE(fd_ref2 == fd_ref2);
+
+	ASSERT_TRUE(fd_null_ref == null_fd);
+	ASSERT_TRUE(fd_null_ref == fd_null_ref);
+
+	ASSERT_TRUE(fd_ref != null_fd);
+	ASSERT_TRUE(fd_null_ref != fd);
+	ASSERT_TRUE(fd_ref != fd_null_ref);
+	ASSERT_TRUE(fd_null_ref != fd_ref2);
+
+	ASSERT_FALSE(fd_ref == null_fd);
+	ASSERT_FALSE(fd_null_ref == fd);
+	ASSERT_FALSE(fd_ref == fd_null_ref);
+
+	FileDataRef fd_ref3{nullptr};
+	fd_ref3.reset(fd_ref.release());
+	ASSERT_TRUE(fd_ref3 == fd);
+	ASSERT_TRUE(fd_ref == null_fd);
+}
+
 }  // anonymous namespace
 
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */


### PR DESCRIPTION
Also establishes and tests the `FileDataRef` equality behavior

This simplifies ref management, and fixes one of the missing `dir_fd` null checks in `view-data.cc` (which is now properly handled by the destructor)

Related to #2424