### PR TITLE
Adds a simple feature to allow capturing screenshots during the image tests

### DIFF
--- a/build-aux/image-test.py
+++ b/build-aux/image-test.py
@@ -25,12 +25,16 @@ import subprocess
 import sys
 import time
 import traceback
+from lib import screenshot
 from typing import Optional
+
+# Change this to True to enable screenshots.
+# Requires "psutil" import, plus `import` command from ImageMagick/GraphicsMagick.
+SHOULD_TAKE_SCREENSHOT = False
 
 MAX_GEEQIE_INIT_TIME_S = 10
 MAX_REMOTE_CMD_TIME_S = 10
 MAX_GEEQIE_SHUTDOWN_TIME_S = 10
-
 
 class GeeqieTestError(Exception):
     """A custom exception type that forwards the geeqie exit code.
@@ -94,6 +98,8 @@ def main(argv) -> int:
     if not symlink_image_file.exists():
         raise RuntimeError("symlinking image file failed")
 
+    gq_sshot = screenshot.GeeqieScreenshot() if SHOULD_TAKE_SCREENSHOT else None
+
     # All geeqie commands start with this.
     geeqie_cmd_prefix = ["xvfb-run", "--auto-servernum", geeqie_exe]
 
@@ -128,6 +134,13 @@ def main(argv) -> int:
         time.sleep(1)
         if geeqie_proc.poll() is not None:
             raise GeeqieTestError("remote command processing", geeqie_proc)
+
+        if gq_sshot:
+            ss_result = gq_sshot.capture(symlink_image_file.name, geeqie_proc)
+            if ss_result:
+                print(f"\nCAPTURED SCREENSHOT: {ss_result}\n")
+            else:
+                print("FAILED TO CAPTURE SCREENSHOT")
 
         # Request shutdown
         subprocess.run(args=[*geeqie_cmd_prefix, "--quit"],

--- a/build-aux/lib/screenshot.py
+++ b/build-aux/lib/screenshot.py
@@ -1,0 +1,51 @@
+#!/bin/python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import pathlib
+import subprocess
+import time
+from typing import Optional
+
+MAX_SSHOT_CAPTURE_TIME_S = 10
+
+class GeeqieScreenshot:
+    def __init__(self, sshot_dir: Optional[pathlib.Path] = None):
+        """Initializes GeeqieScreenshot
+
+        May raise ImportError.
+        """
+        # We run this here to make it easier to use this as an optional, best-effort dependency
+        import psutil
+
+        if sshot_dir:
+            self._sshot_dir = sshot_dir
+        else:
+            self._sshot_dir = pathlib.Path("/tmp/gq_test_screenshots/")
+
+    def capture(self, base_filename: str, xvfb_run_process: subprocess.Popen) -> Optional[pathlib.Path]:
+        import psutil
+
+        self._sshot_dir.mkdir(parents=True, exist_ok=True)
+        escaped_name = base_filename.replace('.', '_')
+        sshot_name = f"{int(time.time())}_{escaped_name}.png"
+        sshot_file = self._sshot_dir / sshot_name
+
+        # We borrow the geeqie process's environment, to pick up the appropriate DISPLAY and
+        # XAUTHORITY values from xvfb.
+        geeqie_env = None
+
+        xvfb_process = psutil.Process(xvfb_run_process.pid)
+        for child in xvfb_process.children():
+            if not child.name().endswith("geeqie"):
+                continue
+
+            # Found the geeqie process.  Now find the environment variables we care about.
+            geeqie_env = child.environ()
+            break
+
+        if not geeqie_env:
+            return None
+
+        # Attempt to take the screenshot
+        subprocess.run(args=["import", "-window", "root", str(sshot_file)], timeout=MAX_SSHOT_CAPTURE_TIME_S, env=geeqie_env)
+        return sshot_file


### PR DESCRIPTION
The goal is to make it easier to see what Geeqie is doing, without conflicting with other Geeqie instances that might be running on the same host.

Sample screenshot:
<img width="1280" height="1024" alt="1783013292_IMG_0483_craw_CR3" src="https://github.com/user-attachments/assets/015ebef5-c4a5-449e-b235-1ab028a1556f" />
