### PR TITLE
meson: bump gtk4 dep to 4.20

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,7 @@ fs = import('fs')
 configuration_inc = include_directories('.')
 
 # Main library dependencies
-gtk_dep = dependency('gtk4', version : '>=4.18', required : true)
+gtk_dep = dependency('gtk4', version : '>=4.20', required : true)
 glib_dep = dependency('glib-2.0', version : '>=2.66', required: true)
 pango_dep = dependency('pango', version : '>=1.46', required: true)
 


### PR DESCRIPTION
It is required for `GDK_ACTION_NONE`, see https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gdk/gdkenums.h#L295