### PR TITLE
Present the window on activation

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -809,7 +809,7 @@ void activate_cb(GtkApplication *, gpointer)
 	 */
 	if (lw->window)
 		{
-		gtk_widget_show(lw->window);
+		gtk_window_present(GTK_WINDOW(lw->window));
 
 		/** @FIXME This is not a fix - it is a workaround
 		 * https://github.com/BestImageViewer/geeqie/issues/1765


### PR DESCRIPTION
This ensures that the window brings to the front if already open.