### PR TITLE
GTK4: add smooth scrolling,  fix zoom at cursor position

### DIFF
--- a/src/compat.cc
+++ b/src/compat.cc
@@ -335,7 +335,7 @@ void gq_gtk_widget_destroy(GtkWidget *widget)
 
 	if (GTK_IS_WINDOW(widget))
 		{
-		gtk_window_destroy(GTK_WINDOW(widget));
+		gtk_window_close(GTK_WINDOW(widget));
 		return;
 		}
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -92,5 +92,15 @@ const gchar *stock_id_to_icon_name(const gchar *stock_id);
 GtkWidget *gq_gtk_image_new_from_stock(const gchar *stock_id, gint size);
 GtkWidget *gq_gtk_widget_get_focus_child(GtkWidget *widget);
 
+static inline double sign(double x)
+{
+	if (!isnan(x))
+	{
+	if (x > 0.0) return 1.0;
+	if (x < 0.0) return -1.0;
+	}
+	return x;
+}
+
 #endif /* COMPAT_H */
 /* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/src/image.cc
+++ b/src/image.cc
@@ -1118,7 +1118,7 @@ static void image_focus_in_cb(GtkEventControllerFocus *, gpointer data)
 		}
 }
 
-// Callback для отслеживания движения мыши
+// Mouse Callback
 static void
 image_motion_cb (GtkEventControllerMotion *motion_controller, double x, double y, gpointer data)
 {

--- a/src/image.cc
+++ b/src/image.cc
@@ -1118,6 +1118,17 @@ static void image_focus_in_cb(GtkEventControllerFocus *, gpointer data)
 		}
 }
 
+// Callback для отслеживания движения мыши
+static void
+image_motion_cb (GtkEventControllerMotion *motion_controller, double x, double y, gpointer data)
+{
+	auto imd = static_cast<ImageWindow *>(data);
+
+	// Preserving the current coordinates relative to your widget.
+	imd->mouse_x = x;
+	imd->mouse_y = y;
+}
+
 static gboolean image_scroll_cb(GtkEventControllerScroll *controller, gdouble dx, gdouble dy, gpointer data)
 {
 	auto imd = static_cast<ImageWindow *>(data);
@@ -1128,12 +1139,9 @@ static gboolean image_scroll_cb(GtkEventControllerScroll *controller, gdouble dx
 		return FALSE;
 		}
 
-	gdouble x = 0;
-	gdouble y = 0;
-	//gdouble dx = 0;
-	//gdouble dy = 0;
-	gdk_event_get_position(event, &x, &y);
-	//gdk_scroll_event_get_deltas(event, &dx, &dy);
+	gdouble x = imd->mouse_x;
+	gdouble y = imd->mouse_y;
+
 	const GqScrollEvent scroll_event{
 		x,
 		y,
@@ -2074,6 +2082,8 @@ ImageWindow *image_new(gboolean frame)
 	imd->state = IMAGE_STATE_NONE;
 	imd->orientation = 1;
 
+	imd->mouse_x = 0.0;
+	imd->mouse_y = 0.0;
 	imd->accum_zoom = 0.0;
 	imd->accum_x = 0.0;
 	imd->accum_y = 0.0;
@@ -2098,6 +2108,10 @@ ImageWindow *image_new(gboolean frame)
 			 G_CALLBACK(image_release_cb), imd);
 	g_signal_connect(G_OBJECT(imd->pr), "scroll_notify",
 			 G_CALLBACK(image_scroll_notify_cb), imd);
+
+	GtkEventController *motion = gtk_event_controller_motion_new ();
+	gtk_widget_add_controller (GTK_WIDGET(imd->pr), motion);
+	g_signal_connect (motion, "motion", G_CALLBACK (image_motion_cb), imd);
 
 	GtkEventController *controller = gtk_event_controller_scroll_new(GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES);
 	g_signal_connect(controller, "scroll", G_CALLBACK(image_scroll_cb), imd);

--- a/src/image.cc
+++ b/src/image.cc
@@ -1118,7 +1118,7 @@ static void image_focus_in_cb(GtkEventControllerFocus *, gpointer data)
 		}
 }
 
-static gboolean image_scroll_cb(GtkEventControllerScroll *controller, gdouble, gdouble, gpointer data)
+static gboolean image_scroll_cb(GtkEventControllerScroll *controller, gdouble dx, gdouble dy, gpointer data)
 {
 	auto imd = static_cast<ImageWindow *>(data);
 	GdkEvent *event = gtk_event_controller_get_current_event(GTK_EVENT_CONTROLLER(controller));
@@ -1130,10 +1130,10 @@ static gboolean image_scroll_cb(GtkEventControllerScroll *controller, gdouble, g
 
 	gdouble x = 0;
 	gdouble y = 0;
-	gdouble dx = 0;
-	gdouble dy = 0;
+	//gdouble dx = 0;
+	//gdouble dy = 0;
 	gdk_event_get_position(event, &x, &y);
-	gdk_scroll_event_get_deltas(event, &dx, &dy);
+	//gdk_scroll_event_get_deltas(event, &dx, &dy);
 	const GqScrollEvent scroll_event{
 		x,
 		y,
@@ -1142,7 +1142,7 @@ static gboolean image_scroll_cb(GtkEventControllerScroll *controller, gdouble, g
 		gtk_event_controller_get_current_event_state(GTK_EVENT_CONTROLLER(controller)),
 		gdk_scroll_event_get_direction(event) != GDK_SCROLL_SMOOTH
 			? gdk_scroll_event_get_direction(event)
-			: scroll_direction_from_deltas(dx, dy),
+			: GDK_SCROLL_SMOOTH,
 		gdk_event_get_time(event)
 	};
 
@@ -2073,6 +2073,10 @@ ImageWindow *image_new(gboolean frame)
 	imd->has_frame = -1; /* not initialized; for image_set_frame */
 	imd->state = IMAGE_STATE_NONE;
 	imd->orientation = 1;
+
+	imd->accum_zoom = 0.0;
+	imd->accum_x = 0.0;
+	imd->accum_y = 0.0;
 
 	imd->pr = GTK_WIDGET(pixbuf_renderer_new());
 	DEBUG_NAME(imd->pr);

--- a/src/image.h
+++ b/src/image.h
@@ -136,6 +136,11 @@ struct ImageWindow
 	StereoPixbufData user_stereo;
 
 	gboolean mouse_wheel_mode;
+
+	/* Fractional values accumulated between events */
+	gdouble accum_zoom;
+	gdouble accum_x;
+	gdouble accum_y;
 };
 
 void image_set_frame(ImageWindow *imd, gboolean frame);

--- a/src/image.h
+++ b/src/image.h
@@ -137,6 +137,8 @@ struct ImageWindow
 
 	gboolean mouse_wheel_mode;
 
+	gdouble mouse_x;
+	gdouble mouse_y;
 	/* Fractional values accumulated between events */
 	gdouble accum_zoom;
 	gdouble accum_x;

--- a/src/img-view.cc
+++ b/src/img-view.cc
@@ -533,6 +533,68 @@ static void scroll_cb(ImageWindow *imd, const GqScrollEvent *event, gpointer dat
 {
 	auto vw = static_cast<ViewWindow *>(data);
 
+	/* --- TouchPad processing start (GDK_SCROLL_SMOOTH) --- */
+	if (event->direction == GDK_SCROLL_SMOOTH)
+	{
+		gdouble delta_x = event->dx;
+		gdouble delta_y = event->dy;
+		
+		/* Zoom with Ctrl */
+		if (event->state & GDK_CONTROL_MASK)
+			{
+			if (delta_y != 0.0)
+				{
+				/* TouchPad zoom sensitivity: Use some default comfort value */
+				/* TODO get_touchpad_sensitivity setting() */
+				constexpr gdouble TOUCHPAD_ZOOM_SENSITIVITY = 10.0;
+
+				const gdouble ZOOM_INCREMENT = get_zoom_increment();
+
+				const gdouble VIEW_SMOOTH_ZOOM_THRESHOLD = ZOOM_INCREMENT;
+
+				/* Zoom direction changed */
+				if (sign(imd->accum_zoom) != sign(delta_y)) imd->accum_zoom = 0.0;
+
+				/* Accumulate micro-zoom */
+				imd->accum_zoom -= delta_y * TOUCHPAD_ZOOM_SENSITIVITY;
+
+				if (fabs(imd->accum_zoom) >=  VIEW_SMOOTH_ZOOM_THRESHOLD)
+					{
+					gdouble increment = sign(imd->accum_zoom) * ZOOM_INCREMENT;
+
+					image_zoom_adjust_at_point(imd, increment, event->x, event->y);
+
+					/* Fractional part for the next zoom */
+					imd->accum_zoom -= increment;
+					}
+				}
+			}
+		/* Pan / Two fingers image scrolling */
+		else
+			{
+			/* TouchPad sensitivity */ 
+			constexpr gdouble TOUCHPAD_SENSITIVITY = 10.0;
+
+			imd->accum_x += delta_x * TOUCHPAD_SENSITIVITY;
+			imd->accum_y += delta_y * TOUCHPAD_SENSITIVITY;
+
+			int x_amount = static_cast<int>(imd->accum_x);
+			int y_amount = static_cast<int>(imd->accum_y);
+
+			/* Check if shift is more then one px */
+			if (x_amount != 0 || y_amount != 0)
+				{
+				image_scroll(imd, x_amount, y_amount);
+
+				/* Fractional parts for the next scroll */
+				imd->accum_x -= x_amount;
+				imd->accum_y -= y_amount;
+				}
+			}
+		return;
+	}
+	/* --- TouchPad processing finish --- */
+
 	if ((event->state & GDK_CONTROL_MASK) ||
 				(imd->mouse_wheel_mode && !options->image_lm_click_nav))
 		{

--- a/src/layout-image.cc
+++ b/src/layout-image.cc
@@ -1821,6 +1821,73 @@ static void layout_image_scroll_cb(ImageWindow *imd, const GqScrollEvent *event,
 		layout_image_activate(lw, i, FALSE);
 		}
 
+	/* --- TouchPad processing start (GDK_SCROLL_SMOOTH) --- */
+	if (event->direction == GDK_SCROLL_SMOOTH)
+		{
+		gdouble delta_x = 0.0;
+		gdouble delta_y = 0.0;
+
+		delta_x = event->dx;
+		delta_y = event->dy;
+			{
+			/* Zoom with Ctrl */
+			if (event->state & GDK_CONTROL_MASK)
+				{
+				if (delta_y != 0.0)
+					{
+					/* TouchPad sensitivity: Use some default comfort value */
+					/* TODO get_touchpad_sensitivity setting() */
+					constexpr gdouble TOUCHPAD_ZOOM_SENSITIVITY = 10.0;
+
+					const gdouble ZOOM_INCREMENT = get_zoom_increment();
+
+					const gdouble LAYOUT_SMOOTH_ZOOM_THRESHOLD = ZOOM_INCREMENT;
+
+					/* Zoom direction changed */
+					if (sign(imd->accum_zoom) != sign(delta_y)) imd->accum_zoom = 0.0;
+
+					/* Accumulate micro-zoom */
+					imd->accum_zoom -= delta_y * TOUCHPAD_ZOOM_SENSITIVITY;
+
+					if (fabs(imd->accum_zoom) >=  LAYOUT_SMOOTH_ZOOM_THRESHOLD)
+						{
+						gdouble increment = sign(imd->accum_zoom) * ZOOM_INCREMENT;
+
+						//image_zoom_adjust_at_point(imd, increment, event->x, event->y);
+						layout_image_zoom_adjust_at_point(lw, increment, event->x, event->y, event->state & GDK_SHIFT_MASK);
+
+						/* Keep fractional part for the mext zoom */
+						imd->accum_zoom -= increment;
+						}
+					}
+				}
+			/* Pan / Two fingers image moving */
+			else
+				{
+				/* TouchPad sensitivity. TODO: create get_touchpad_sensitivity() setting */
+				/* Use some default comfort value */
+				constexpr gdouble TOUCHPAD_SENSITIVITY = 10.0;
+
+				imd->accum_x += delta_x * TOUCHPAD_SENSITIVITY;
+				imd->accum_y += delta_y * TOUCHPAD_SENSITIVITY;
+
+				int x_amount = static_cast<int>(imd->accum_x);
+				int y_amount = static_cast<int>(imd->accum_y);
+
+				if (x_amount != 0 || y_amount != 0)
+					{
+					// Should we check lw->options.split_pane_sync?
+					layout_image_scroll(lw, x_amount, y_amount, (event->state & GDK_SHIFT_MASK));
+
+					/* Keep fractional parts for the next scroll */
+					imd->accum_x -= x_amount;
+					imd->accum_y -= y_amount;
+					}
+				}
+			}
+		return;
+		}
+	/* --- TouchPad processing finish --- */
 
 	if ((event->state & GDK_CONTROL_MASK) ||
 				(imd->mouse_wheel_mode && !options->image_lm_click_nav))

--- a/src/pan-view/pan-types.h
+++ b/src/pan-view/pan-types.h
@@ -199,6 +199,11 @@ struct PanWindow
 	PanItem *search_pi;
 
 	gint idle_id;
+
+	gdouble accum_zoom;
+
+	gdouble accum_x;
+	gdouble accum_y;
 };
 
 #endif

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -1342,7 +1342,6 @@ static void scroll_cb(ImageWindow *imd, const GqScrollEvent *event, gpointer dat
 				break;
 			case GDK_SCROLL_SMOOTH:
 				{
-				{
 				gdouble delta_y = event->dy;
 
 				if (delta_y != 0.0)

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -1342,24 +1342,27 @@ static void scroll_cb(ImageWindow *imd, const GqScrollEvent *event, gpointer dat
 				break;
 			case GDK_SCROLL_SMOOTH:
 				{
+				{
 				gdouble delta_y = event->dy;
 
 				if (delta_y != 0.0)
 					{
 					auto pw = static_cast<PanWindow *>(data);
 					/* Touchpad zoom sensitivity */
-					constexpr gdouble TOUCHPAD_ZOOM_SENSITIVITY = 0.001;
+					constexpr gdouble TOUCHPAD_ZOOM_SENSITIVITY = 0.1;
 
-					constexpr gdouble PAN_VIEW_SMOOTH_ZOOM_THRESHOLD = ZOOM_INCREMENT;
-
+					constexpr gdouble PAN_VIEW_SMOOTH_ZOOM_THRESHOLD = TOUCHPAD_ZOOM_SENSITIVITY * ZOOM_INCREMENT;
+					// Touchpad direction changed
 					if (sign(pw->accum_zoom) != sign(delta_y)) pw->accum_zoom = 0.0;
 
 					/* Accumulate micro-zoom */
-					pw->accum_zoom -= delta_y * TOUCHPAD_ZOOM_SENSITIVITY;
+					pw->accum_zoom += delta_y * TOUCHPAD_ZOOM_SENSITIVITY;
 
-					if (fabs(imd->accum_zoom) >=  PAN_VIEW_SMOOTH_ZOOM_THRESHOLD)
+					if (fabs(pw->accum_zoom) >=  PAN_VIEW_SMOOTH_ZOOM_THRESHOLD)
 						{
-						gdouble increment = sign(delta_y) * ZOOM_INCREMENT;
+						/* We are using 0.1 * ZOOM_INCREMENT for smooth zoom */
+						/* Use ZOOM_INCREMENT for step zoom */
+						gdouble increment = sign(delta_y) * PAN_VIEW_SMOOTH_ZOOM_THRESHOLD; //ZOOM_INCREMENT;
 
 						pixbuf_renderer_zoom_adjust_at_point(pr, increment, event->x, event->y);
 

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -1315,7 +1315,7 @@ static void button_cb(PixbufRenderer *pr, GqMouseButtonEvent *event, gpointer da
 		}
 }
 
-static void scroll_cb(ImageWindow *imd, const GqScrollEvent *event, gpointer)
+static void scroll_cb(ImageWindow *imd, const GqScrollEvent *event, gpointer data)
 {
 	gint w;
 	gint h;

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -1340,6 +1340,35 @@ static void scroll_cb(ImageWindow *imd, const GqScrollEvent *event, gpointer)
 			case GDK_SCROLL_DOWN:
 				pixbuf_renderer_zoom_adjust_at_point(pr, -ZOOM_INCREMENT, event->x, event->y);
 				break;
+			case GDK_SCROLL_SMOOTH:
+				{
+				gdouble delta_y = event->dy;
+
+				if (delta_y != 0.0)
+					{
+					auto pw = static_cast<PanWindow *>(data);
+					/* Touchpad zoom sensitivity */
+					constexpr gdouble TOUCHPAD_ZOOM_SENSITIVITY = 0.001;
+
+					constexpr gdouble PAN_VIEW_SMOOTH_ZOOM_THRESHOLD = ZOOM_INCREMENT;
+
+					if (sign(pw->accum_zoom) != sign(delta_y)) pw->accum_zoom = 0.0;
+
+					/* Accumulate micro-zoom */
+					pw->accum_zoom -= delta_y * TOUCHPAD_ZOOM_SENSITIVITY;
+
+					if (fabs(imd->accum_zoom) >=  PAN_VIEW_SMOOTH_ZOOM_THRESHOLD)
+						{
+						gdouble increment = sign(delta_y) * ZOOM_INCREMENT;
+
+						pixbuf_renderer_zoom_adjust_at_point(pr, increment, event->x, event->y);
+
+						/* Keep fractional part for the next zoom */
+						pw->accum_zoom -= increment;
+						}
+					}
+				}
+				break;
 			default:
 				break;
 			}
@@ -1359,6 +1388,32 @@ static void scroll_cb(ImageWindow *imd, const GqScrollEvent *event, gpointer)
 				break;
 			case GDK_SCROLL_RIGHT:
 				pixbuf_renderer_scroll(pr, w, 0);
+				break;
+			case GDK_SCROLL_SMOOTH:
+				{
+				auto pw = static_cast<PanWindow *>(data);
+
+				gdouble delta_x = event->dx;
+				gdouble delta_y = event->dy;
+
+				/* TouchPad scroll sensitivity */
+				constexpr gdouble TOUCHPAD_SENSITIVITY = 25.0;
+
+				pw->accum_x += delta_x * TOUCHPAD_SENSITIVITY;
+				pw->accum_y += delta_y * TOUCHPAD_SENSITIVITY;
+
+				int x_amount = static_cast<int>(pw->accum_x);
+				int y_amount = static_cast<int>(pw->accum_y);
+
+				if (x_amount != 0 || y_amount != 0)
+					{
+					pixbuf_renderer_scroll(pr, x_amount, y_amount);
+
+					/* Fractional part for the next scroll */
+					pw->accum_x -= x_amount;
+					pw->accum_y -= y_amount;
+					}
+				}
 				break;
 			default:
 				break;

--- a/src/pan-view/pan-view.cc
+++ b/src/pan-view/pan-view.cc
@@ -1592,7 +1592,7 @@ static gboolean pan_window_delete_cb(GtkWidget *, gpointer data)
 	auto pw = static_cast<PanWindow *>(data);
 
 	pan_window_close(pw);
-	return TRUE;
+	return FALSE;
 }
 
 /*


### PR DESCRIPTION
1. Added smooth touchpad scrolling and panning support (`GDK_SCROLL_SMOOTH`).
2. Fixed an issue where gdk_event_get_position() returned `nan:nan` for scroll events because `GdkScrollEvent` does not contain position data in GTK 4. Implemented `GtkEventControllerMotion` to track active mouse coordinates and use them during zoom tracking.
3. Some crash fixes.
