### PR TITLE
Auto next folder

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 Geeqie 3.0
 ============
 
+- New preference "Auto next folder" (Behavior tab) to automatically advance to next/previous sibling folder when reaching end/beginning of current folder
+- New actions "Next folder" and "Previous folder" with accelerators Ctrl+Shift+Right/Left
+- The feature is disabled by default
 - GTK3 to GTK4 migration
 - This is a pre-release
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Geeqie is a graphics file viewer. Basic features:
 
 * Single click image viewing / navigation.
 
+* Auto next folder - automatically advance to the next or previous sibling folder when reaching the last or first image in the current folder.
+
 * Zoom functions.
 
 * Thumbnails, with optional caching and .xvpics support.

--- a/data/accels.ini
+++ b/data/accels.ini
@@ -303,6 +303,12 @@ accels=Page_Down;KP_Next;space;n
 [win.image-win-step-previous]
 accels=Page_Up;KP_Page_Up;BackSpace;b
 
+[win.main-win-next-folder]
+accels=<Primary><Shift>Right
+
+[win.main-win-previous-folder]
+accels=<Primary><Shift>Left
+
 [win.image-win-view-fullscreen-toggle]
 accels=f;v;F11
 

--- a/doc/docbook/GuideMainWindowMenus.xml
+++ b/doc/docbook/GuideMainWindowMenus.xml
@@ -344,6 +344,40 @@
           <menuchoice>
             <shortcut>
               <keycombo>
+                <keycap>Ctrl</keycap>
+                <keycap>Shift</keycap>
+                <keycap>Right</keycap>
+              </keycombo>
+            </shortcut>
+            <guimenu>Next folder</guimenu>
+          </menuchoice>
+        </term>
+        <listitem>
+          <para>Goes to the first image in the next sibling folder.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
+          <menuchoice>
+            <shortcut>
+              <keycombo>
+                <keycap>Ctrl</keycap>
+                <keycap>Shift</keycap>
+                <keycap>Left</keycap>
+              </keycombo>
+            </shortcut>
+            <guimenu>Previous folder</guimenu>
+          </menuchoice>
+        </term>
+        <listitem>
+          <para>Goes to the last image in the previous sibling folder.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
+          <menuchoice>
+            <shortcut>
+              <keycombo>
                 <keycap>Home</keycap>
               </keycombo>
             </shortcut>

--- a/doc/docbook/GuideMainWindowNavigation.xml
+++ b/doc/docbook/GuideMainWindowNavigation.xml
@@ -30,6 +30,7 @@
     <title>Stepping through images sequentially</title>
     <para>To change the displayed image to next or previous one within the same folder, use the respective PageDown and PageUp keys. The mouse can also be used to change the image by clicking the image display with the respective primary and middle buttons.</para>
     <para>To change to beginning or end of the image list, use the respective Home or End keys.</para>
+    <para>To navigate between sibling folders, use Ctrl+Shift+Right to go to the first image in the next folder, or Ctrl+Shift+Left to go to the last image in the previous folder. When the <emphasis role="underline"><link linkend="GuideOptionsBehavior" endterm="titleGuideOptionsBehavior" /></emphasis> preference <guilabel>Auto next folder</guilabel> is enabled, reaching the last image in a folder with Next Image will automatically advance to the first image in the next sibling folder, and reaching the first image with Previous Image will automatically go to the last image in the previous sibling folder.</para>
     <para />
   </section>
 </section>

--- a/doc/docbook/GuideOptionsBehavior.xml
+++ b/doc/docbook/GuideOptionsBehavior.xml
@@ -150,6 +150,14 @@
       </varlistentry>
       <varlistentry>
         <term>
+          <guilabel>Auto next folder</guilabel>
+        </term>
+        <listitem>
+          <para>If selected, when the last image in the current folder is reached using Next Image, Geeqie will automatically advance to the first image in the next sibling folder. Likewise, when the first image is reached using Previous Image, Geeqie will automatically go to the last image in the previous sibling folder.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
           <guilabel>Save marks on exit</guilabel>
         </term>
         <listitem>

--- a/src/filedata.h
+++ b/src/filedata.h
@@ -461,6 +461,7 @@ class FileData::FileList
 
 	static gboolean read_list(FileData *dir_fd, GList **files, GList **dirs);
 	static gboolean read_list_lstat(FileData *dir_fd, GList **files, GList **dirs);
+	static gboolean read_list_lstat_all(FileData *dir_fd, GList **files, GList **dirs);
 	static void free_list(GList *list);
 	static GList *copy(GList *list);
 	static GList *from_path_list(GList *list);
@@ -477,6 +478,7 @@ class FileData::FileList
 	static GList *filter_out_sidecars(GList *flist);
 	static gboolean is_hidden_file(const gchar *filepath);
 	static gboolean read_list_real(const gchar *dir_path, GList **files, GList **dirs, gboolean follow_symlinks);
+	static gboolean read_list_real_all(const gchar *dir_path, GList **files, GList **dirs, gboolean follow_symlinks);
 	static gint sort_file_cb(gconstpointer a, gconstpointer b, gpointer data);
 	static gint sort_path_cb(gconstpointer a, gconstpointer b);
 	static void recursive_append(GList **list, GList *dirs);

--- a/src/filedata/filelist.cc
+++ b/src/filedata/filelist.cc
@@ -232,6 +232,109 @@ gboolean FileData::FileList::read_list_real(const gchar *dir_path, GList **files
 	return TRUE;
 }
 
+gboolean FileData::FileList::read_list_real_all(const gchar *dir_path, GList **files, GList **dirs, gboolean follow_symlinks)
+{
+	DIR *dp;
+	struct dirent *dir;
+	GList *dlist = nullptr;
+	GList *flist = nullptr;
+	GList *xmp_files = nullptr;
+	gint (*stat_func)(const gchar *path, struct stat *buf);
+	GHashTable *basename_hash = nullptr;
+
+	g_assert(files || dirs);
+
+	if (files) *files = nullptr;
+	if (dirs) *dirs = nullptr;
+
+	g_autofree gchar *pathl = path_from_utf8(dir_path);
+	if (!pathl) return FALSE;
+
+	dp = opendir(pathl);
+	if (dp == nullptr)
+		{
+		return FALSE;
+		}
+
+	if (files) basename_hash = file_data_basename_hash_new();
+
+	if (follow_symlinks)
+		stat_func = stat;
+	else
+		stat_func = lstat;
+
+	while ((dir = readdir(dp)) != nullptr)
+		{
+		const gchar *name = dir->d_name;
+		g_autofree gchar *filepath = g_build_filename(pathl, name, NULL);
+
+		// Don't filter hidden files - include all directories
+		// Only skip . and .. directories
+		if (name[0] == '.' && (name[1] == '\0' || (name[1] == '.' && name[2] == '\0')))
+			{
+			continue;
+			}
+
+		struct stat ent_sbuf;
+		if (stat_func(filepath, &ent_sbuf) >= 0)
+			{
+			if (S_ISDIR(ent_sbuf.st_mode))
+				{
+				/* we ignore the .thumbnails dir for cleanliness */
+				if (dirs &&
+				    strcmp(name, GQ_CACHE_LOCAL_THUMB) != 0 &&
+				    strcmp(name, GQ_CACHE_LOCAL_METADATA) != 0 &&
+				    strcmp(name, THUMB_FOLDER_LOCAL) != 0)
+					{
+					dlist = g_list_prepend(dlist, FileData::make_new_local(filepath, &ent_sbuf, TRUE).release());
+					}
+				}
+			else
+				{
+				if (files && filter_name_exists(name))
+					{
+					FileData *fd = FileData::make_new_local(filepath, &ent_sbuf, FALSE).release();
+					flist = g_list_prepend(flist, fd);
+					if (fd->sidecar_priority && !fd->disable_grouping)
+						{
+						if (strcmp(fd->extension, ".xmp") != 0)
+							file_data_basename_hash_insert(basename_hash, fd);
+						else
+							xmp_files = g_list_append(xmp_files, fd);
+						}
+					}
+				}
+			}
+		else
+			{
+			if (errno == EOVERFLOW)
+				{
+				log_printf("stat(): EOVERFLOW, skip '%s'", filepath);
+				}
+			}
+		}
+
+	closedir(dp);
+
+	if (xmp_files)
+		{
+		g_list_foreach(xmp_files,file_data_basename_hash_insert_cb,basename_hash);
+		g_list_free(xmp_files);
+		}
+
+	if (dirs) *dirs = dlist;
+
+	if (files)
+		{
+		g_hash_table_foreach(basename_hash, file_data_basename_hash_to_sidecars, nullptr);
+
+		*files = filter_out_sidecars(flist);
+		}
+	if (basename_hash) file_data_basename_hash_free(basename_hash);
+
+	return TRUE;
+}
+
 /*
  *-----------------------------------------------------------------------------
  * filelist sorting
@@ -344,6 +447,11 @@ gboolean FileData::FileList::read_list(FileData *dir_fd, GList **files, GList **
 gboolean FileData::FileList::read_list_lstat(FileData *dir_fd, GList **files, GList **dirs)
 {
 	return read_list_real(dir_fd->path, files, dirs, FALSE);
+}
+
+gboolean FileData::FileList::read_list_lstat_all(FileData *dir_fd, GList **files, GList **dirs)
+{
+	return read_list_real_all(dir_fd->path, files, dirs, FALSE);
 }
 
 void FileData::FileList::free_list(GList *list)

--- a/src/layout-image.cc
+++ b/src/layout-image.cc
@@ -1549,6 +1549,169 @@ std::optional<ColorManStatus> layout_image_color_profile_get_status(LayoutWindow
 	return image_color_profile_get_status(lw->image);
 }
 
+/**
+ * @brief Get the next sibling directory in the same parent directory
+ * @param lw Layout window
+ * @returns FileData for the next directory, or nullptr if none
+ *
+ * Finds the next directory alphabetically after the current directory
+ * in the same parent directory. Only returns directories that contain
+ * at least one image file.
+ */
+static FileData *layout_get_next_sibling_dir(LayoutWindow *lw)
+{
+	if (!lw || !lw->dir_fd || !lw->dir_fd->path) return nullptr;
+
+	g_autofree gchar *parent_dir = g_path_get_dirname(lw->dir_fd->path);
+	g_autofree gchar *current_name = g_path_get_basename(lw->dir_fd->path);
+
+	GList *dirs = nullptr;
+	GList *files = nullptr;
+
+	// Read the parent directory to get all subdirectories (don't follow symlinks)
+	FileData *parent_fd = file_data_new_dir(parent_dir);
+	if (!parent_fd) return nullptr;
+
+	FileData::FileList::read_list_lstat_all(parent_fd, &files, &dirs);
+	file_data_unref(parent_fd);
+
+	if (!dirs) return nullptr;
+
+	// Sort directories by name
+	FileData::FileList::SortSettings sort_settings;
+	sort_settings.method = SORT_NAME;
+	sort_settings.ascending = TRUE;
+	sort_settings.case_sensitive = FALSE;
+
+	dirs = FileData::FileList::sort(dirs, sort_settings);
+
+	// Find current directory in the list
+	GList *work = dirs;
+	FileData *next_dir = nullptr;
+	gboolean found_current = FALSE;
+
+	while (work)
+	{
+		auto *fd = static_cast<FileData *>(work->data);
+		g_autofree gchar *name = g_path_get_basename(fd->path);
+
+		if (found_current)
+		{
+			// Check if this directory has any image files
+			GList *sub_files = nullptr;
+			GList *sub_dirs = nullptr;
+			FileData::FileList::read_list_lstat_all(fd, &sub_files, &sub_dirs);
+
+			if (sub_files)
+			{
+				// Free the sub_files list and its FileData elements
+				g_list_free_full(sub_files, reinterpret_cast<GDestroyNotify>(file_data_unref));
+				if (sub_dirs) g_list_free_full(sub_dirs, reinterpret_cast<GDestroyNotify>(file_data_unref));
+
+				next_dir = fd;
+				break;
+			}
+
+			if (sub_dirs) g_list_free_full(sub_dirs, reinterpret_cast<GDestroyNotify>(file_data_unref));
+		}
+
+		if (g_strcmp0(name, current_name) == 0)
+		{
+			found_current = TRUE;
+		}
+
+		work = work->next;
+	}
+
+	// Free the directory list (but not the FileData we're returning)
+	// Actually we need to ref the one we're returning
+	if (next_dir)
+	{
+		file_data_ref(next_dir);
+	}
+
+	// Free all dirs
+	g_list_free_full(dirs, reinterpret_cast<GDestroyNotify>(file_data_unref));
+	if (files) g_list_free_full(files, reinterpret_cast<GDestroyNotify>(file_data_unref));
+
+	return next_dir;
+}
+
+/**
+ * @brief Get the previous sibling directory in the same parent directory
+ * @param lw Layout window
+ * @returns FileData for the previous directory, or nullptr if none
+ */
+static FileData *layout_get_prev_sibling_dir(LayoutWindow *lw)
+{
+	if (!lw || !lw->dir_fd || !lw->dir_fd->path) return nullptr;
+
+	g_autofree gchar *parent_dir = g_path_get_dirname(lw->dir_fd->path);
+	g_autofree gchar *current_name = g_path_get_basename(lw->dir_fd->path);
+
+	GList *dirs = nullptr;
+	GList *files = nullptr;
+
+	FileData *parent_fd = file_data_new_dir(parent_dir);
+	if (!parent_fd) return nullptr;
+
+	FileData::FileList::read_list_lstat_all(parent_fd, &files, &dirs);
+	file_data_unref(parent_fd);
+
+	if (!dirs) return nullptr;
+
+	FileData::FileList::SortSettings sort_settings;
+	sort_settings.method = SORT_NAME;
+	sort_settings.ascending = TRUE;
+	sort_settings.case_sensitive = FALSE;
+
+	dirs = FileData::FileList::sort(dirs, sort_settings);
+
+	GList *work = dirs;
+	FileData *prev_dir = nullptr;
+	FileData *last_valid_dir = nullptr;
+
+	while (work)
+	{
+		auto *fd = static_cast<FileData *>(work->data);
+		g_autofree gchar *name = g_path_get_basename(fd->path);
+
+		if (g_strcmp0(name, current_name) == 0)
+		{
+			prev_dir = last_valid_dir;
+			break;
+		}
+
+		// Check if this directory has any image files
+		GList *sub_files = nullptr;
+		GList *sub_dirs = nullptr;
+		FileData::FileList::read_list_lstat_all(fd, &sub_files, &sub_dirs);
+
+		if (sub_files)
+		{
+			g_list_free_full(sub_files, reinterpret_cast<GDestroyNotify>(file_data_unref));
+			if (sub_dirs) g_list_free_full(sub_dirs, reinterpret_cast<GDestroyNotify>(file_data_unref));
+			last_valid_dir = fd;
+		}
+		else
+		{
+			if (sub_dirs) g_list_free_full(sub_dirs, reinterpret_cast<GDestroyNotify>(file_data_unref));
+		}
+
+		work = work->next;
+	}
+
+	if (prev_dir)
+	{
+		file_data_ref(prev_dir);
+	}
+
+	g_list_free_full(dirs, reinterpret_cast<GDestroyNotify>(file_data_unref));
+	if (files) g_list_free_full(files, reinterpret_cast<GDestroyNotify>(file_data_unref));
+
+	return prev_dir;
+}
+
 /*
  *----------------------------------------------------------------------------
  * list walkers
@@ -1611,6 +1774,25 @@ void layout_image_next(LayoutWindow *lw)
 		if (static_cast<guint>(current) < layout_list_count(lw) - 1)
 			{
 			layout_image_set_index(lw, current + 1);
+			}
+		else if (options->auto_next_folder)
+			{
+			FileData *next_dir = layout_get_next_sibling_dir(lw);
+			if (next_dir)
+				{
+				layout_set_path(lw, next_dir->path);
+				file_data_unref(next_dir);
+				// Select the first image in the new folder
+				gint count = layout_list_count(lw);
+				if (count > 0)
+					{
+					layout_image_set_index(lw, 0);
+					}
+				}
+			else
+				{
+				image_osd_icon(lw->image, IMAGE_OSD_LAST, -1);
+				}
 			}
 		else
 			{
@@ -1682,6 +1864,25 @@ void layout_image_prev(LayoutWindow *lw)
 		if (current > 0)
 			{
 			layout_image_set_index(lw, current - 1);
+			}
+		else if (options->auto_next_folder)
+			{
+			FileData *prev_dir = layout_get_prev_sibling_dir(lw);
+			if (prev_dir)
+				{
+				layout_set_path(lw, prev_dir->path);
+				file_data_unref(prev_dir);
+				// Select the last image in the previous folder
+				gint count = layout_list_count(lw);
+				if (count > 0)
+					{
+					layout_image_set_index(lw, count - 1);
+					}
+				}
+			else
+				{
+				image_osd_icon(lw->image, IMAGE_OSD_FIRST, -1);
+				}
 			}
 		else
 			{

--- a/src/layout-util-main-actions.inc
+++ b/src/layout-util-main-actions.inc
@@ -1767,6 +1767,32 @@ const ActionDef main_actions[] =
 		},
 
 		{
+		"win.main-win-next-folder",
+		nullptr,
+		N_("Next folder"),
+		layout_menu_image_next_cb,
+		nullptr,
+		ActionStateType::NONE,
+		FALSE,
+		nullptr,
+		0,
+		nullptr,
+		},
+
+		{
+		"win.main-win-previous-folder",
+		nullptr,
+		N_("Previous folder"),
+		layout_menu_image_prev_cb,
+		nullptr,
+		ActionStateType::NONE,
+		FALSE,
+		nullptr,
+		0,
+		nullptr,
+		},
+
+		{
 		"win.main-win-previous-page",
 		GQ_ICON_BACK_PAGE,
 		N_("Previous Page of multi-page image"),

--- a/src/options.cc
+++ b/src/options.cc
@@ -210,6 +210,7 @@ ConfOptions *init_options(ConfOptions *options)
 	options->tree_descend_subdirs = FALSE;
 	options->view_dir_list_single_click_enter = TRUE;
 	options->circular_selection_lists = TRUE;
+	options->auto_next_folder = FALSE;
 	options->update_on_time_change = TRUE;
 	options->clipboard_selection = CLIPBOARD_BOTH;
 

--- a/src/options.h
+++ b/src/options.h
@@ -107,6 +107,8 @@ struct ConfOptions
 
 	gboolean circular_selection_lists;
 
+	gboolean auto_next_folder;
+
 	gboolean lazy_image_sync;
 	gboolean update_on_time_change;
 

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -399,6 +399,7 @@ static void config_window_apply(const ConfOptions *c_options)
 
 	options->view_dir_list_single_click_enter = c_options->view_dir_list_single_click_enter;
 	options->circular_selection_lists = c_options->circular_selection_lists;
+	options->auto_next_folder = c_options->auto_next_folder;
 
 	options->open_recent_list_maxsize = c_options->open_recent_list_maxsize;
 	options->recent_folder_image_list_maxsize = c_options->recent_folder_image_list_maxsize;
@@ -3166,6 +3167,10 @@ static void config_tab_behavior(GtkWidget *notebook, ConfOptions *c_options)
 	tmp = pref_checkbox_new_int(group, _("Circular selection lists"),
 			      options->circular_selection_lists, &c_options->circular_selection_lists);
 	gtk_widget_set_tooltip_text(tmp, _("Traverse selection lists in a circular manner"));
+
+	tmp = pref_checkbox_new_int(group, _("Auto next folder"),
+			      options->auto_next_folder, &c_options->auto_next_folder);
+	gtk_widget_set_tooltip_text(tmp, _("Automatically advance to the next folder when reaching the last image in the current folder"));
 
 	marks = pref_checkbox_new_int(group, _("Save marks on exit"),
 				options->marks_save, &c_options->marks_save);

--- a/src/rcfile.cc
+++ b/src/rcfile.cc
@@ -406,6 +406,7 @@ static void write_global_attributes(GString *outstr, gint indent)
 	WRITE_NL(); WRITE_BOOL(*options, tree_descend_subdirs);
 	WRITE_NL(); WRITE_BOOL(*options, view_dir_list_single_click_enter);
 	WRITE_NL(); WRITE_BOOL(*options, circular_selection_lists);
+	WRITE_NL(); WRITE_BOOL(*options, auto_next_folder);
 	WRITE_NL(); WRITE_BOOL(*options, lazy_image_sync);
 	WRITE_NL(); WRITE_BOOL(*options, update_on_time_change);
 	WRITE_SEPARATOR();
@@ -883,6 +884,7 @@ static gboolean load_global_params(const gchar **attribute_names, const gchar **
 		if (READ_BOOL(*options, tree_descend_subdirs)) continue;
 		if (READ_BOOL(*options, view_dir_list_single_click_enter)) continue;
 		if (READ_BOOL(*options, circular_selection_lists)) continue;
+		if (READ_BOOL(*options, auto_next_folder)) continue;
 		if (READ_BOOL(*options, lazy_image_sync)) continue;
 		if (READ_BOOL(*options, update_on_time_change)) continue;
 

--- a/tests/layout-image-navigation.cc
+++ b/tests/layout-image-navigation.cc
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2026 The Geeqie Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *
+ * Unit tests for layout-image folder navigation
+ *
+ */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <glib.h>
+#include <gio/gio.h>
+
+#include "filedata.h"
+#include "filefilter.h"
+#include "layout.h"
+#include "options.h"
+
+namespace {
+
+// For convenience.
+namespace t = ::testing;
+
+class LayoutImageNavigationTest : public t::Test
+{
+    protected:
+    void SetUp() override
+    {
+        // Initialize global options - required by FileData::FileList::read_list_real()
+        // which accesses options->file_filter.show_hidden_files and
+        // is_hidden_file() which accesses options->file_filter.dot_prefix_hidden_files
+        if (!options) {
+            options = init_options(nullptr);
+        }
+        setup_default_options(options);
+        filter_add_defaults();
+        filter_rebuild();
+
+        // Create a temporary directory structure for testing
+        // Use g_mkdtemp for reliable temp directory creation.
+        // Note: g_mkdtemp modifies the template in place and returns it,
+        // so we must NOT free the template after the call.
+        gchar *tmp_template = g_build_filename(g_get_tmp_dir(), "geeqie_test_XXXXXX", nullptr);
+        test_dir = g_mkdtemp(tmp_template);
+        // tmp_template and test_dir now point to the same memory - do not free tmp_template
+        ASSERT_NE(test_dir, nullptr);
+        
+        // Create parent directory
+        parent_dir = g_build_filename(test_dir, "parent", nullptr);
+        g_mkdir_with_parents(parent_dir, 0755);
+        
+        // Create subdirectories with images
+        dir_a = g_build_filename(parent_dir, "folder_a", nullptr);
+        g_mkdir_with_parents(dir_a, 0755);
+        
+        dir_b = g_build_filename(parent_dir, "folder_b", nullptr);
+        g_mkdir_with_parents(dir_b, 0755);
+        
+        dir_c = g_build_filename(parent_dir, "folder_c", nullptr);
+        g_mkdir_with_parents(dir_c, 0755);
+        
+        // Create empty directory (no images)
+        dir_empty = g_build_filename(parent_dir, "folder_empty", nullptr);
+        g_mkdir_with_parents(dir_empty, 0755);
+        
+        // Create test image files
+        create_test_image(g_build_filename(dir_a, "image1.jpg", nullptr));
+        create_test_image(g_build_filename(dir_a, "image2.jpg", nullptr));
+        create_test_image(g_build_filename(dir_b, "image1.jpg", nullptr));
+        create_test_image(g_build_filename(dir_c, "image1.jpg", nullptr));
+        create_test_image(g_build_filename(dir_c, "image2.jpg", nullptr));
+        create_test_image(g_build_filename(dir_c, "image3.jpg", nullptr));
+    }
+    
+    void TearDown() override
+    {
+        if (test_dir)
+        {
+            g_file_delete(g_file_new_for_path(test_dir), nullptr, nullptr);
+            g_free(test_dir);
+        }
+
+        // Free global options allocated in SetUp()
+        filter_reset();
+        g_free(options);
+        options = nullptr;
+    }
+    
+    void create_test_image(const gchar *path)
+    {
+        GFile *file = g_file_new_for_path(path);
+        GFileOutputStream *stream = g_file_create(file, G_FILE_CREATE_NONE, nullptr, nullptr);
+        if (stream)
+        {
+            // Write a minimal JPEG header
+            const guint8 jpeg_header[] = {0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00};
+            g_output_stream_write(G_OUTPUT_STREAM(stream), jpeg_header, sizeof(jpeg_header), nullptr, nullptr);
+            g_output_stream_close(G_OUTPUT_STREAM(stream), nullptr, nullptr);
+            g_object_unref(stream);
+        }
+        g_object_unref(file);
+    }
+    
+    gchar *test_dir = nullptr;
+    gchar *parent_dir = nullptr;
+    gchar *dir_a = nullptr;
+    gchar *dir_b = nullptr;
+    gchar *dir_c = nullptr;
+    gchar *dir_empty = nullptr;
+};
+
+TEST_F(LayoutImageNavigationTest, FileListReadListReturnsDirectories)
+{
+    FileData *parent_fd = file_data_new_dir(parent_dir);
+    ASSERT_NE(parent_fd, nullptr);
+    
+    GList *files = nullptr;
+    GList *dirs = nullptr;
+    
+    gboolean result = FileData::FileList::read_list(parent_fd, &files, &dirs);
+    ASSERT_TRUE(result);
+    
+    // Should find 4 directories (folder_a, folder_b, folder_c, folder_empty)
+    guint dir_count = g_list_length(dirs);
+    EXPECT_EQ(4u, dir_count);
+    
+    // Verify directory names
+    std::vector<std::string> dir_names;
+    for (GList *work = dirs; work; work = work->next)
+    {
+        auto *fd = static_cast<FileData *>(work->data);
+        g_autofree gchar *name = g_path_get_basename(fd->path);
+        dir_names.push_back(name);
+    }
+    
+    EXPECT_TRUE(std::find(dir_names.begin(), dir_names.end(), "folder_a") != dir_names.end());
+    EXPECT_TRUE(std::find(dir_names.begin(), dir_names.end(), "folder_b") != dir_names.end());
+    EXPECT_TRUE(std::find(dir_names.begin(), dir_names.end(), "folder_c") != dir_names.end());
+    EXPECT_TRUE(std::find(dir_names.begin(), dir_names.end(), "folder_empty") != dir_names.end());
+    
+    // Clean up
+    g_list_free_full(dirs, reinterpret_cast<GDestroyNotify>(file_data_unref));
+    if (files) g_list_free(files);
+    file_data_unref(parent_fd);
+}
+
+TEST_F(LayoutImageNavigationTest, FileListSortByName)
+{
+    FileData *parent_fd = file_data_new_dir(parent_dir);
+    ASSERT_NE(parent_fd, nullptr);
+    
+    GList *files = nullptr;
+    GList *dirs = nullptr;
+    
+    gboolean result = FileData::FileList::read_list(parent_fd, &files, &dirs);
+    ASSERT_TRUE(result);
+    
+    FileData::FileList::SortSettings sort_settings;
+    sort_settings.method = SORT_NAME;
+    sort_settings.ascending = TRUE;
+    sort_settings.case_sensitive = FALSE;
+    
+    dirs = FileData::FileList::sort(dirs, sort_settings);
+    
+    // Verify alphabetical order
+    std::vector<std::string> dir_names;
+    for (GList *work = dirs; work; work = work->next)
+    {
+        auto *fd = static_cast<FileData *>(work->data);
+        g_autofree gchar *name = g_path_get_basename(fd->path);
+        dir_names.push_back(name);
+    }
+    
+    EXPECT_EQ("folder_a", dir_names[0]);
+    EXPECT_EQ("folder_b", dir_names[1]);
+    EXPECT_EQ("folder_c", dir_names[2]);
+    EXPECT_EQ("folder_empty", dir_names[3]);
+    
+    // Clean up
+    g_list_free_full(dirs, reinterpret_cast<GDestroyNotify>(file_data_unref));
+    if (files) g_list_free(files);
+    file_data_unref(parent_fd);
+}
+
+TEST_F(LayoutImageNavigationTest, DirectoryWithImagesHasFiles)
+{
+    FileData *dir_a_fd = file_data_new_dir(dir_a);
+    ASSERT_NE(dir_a_fd, nullptr);
+    
+    GList *files = nullptr;
+    GList *dirs = nullptr;
+    
+    gboolean result = FileData::FileList::read_list(dir_a_fd, &files, &dirs);
+    ASSERT_TRUE(result);
+    
+    // Should find 2 image files
+    guint file_count = g_list_length(files);
+    EXPECT_EQ(2u, file_count);
+    
+    // Clean up
+    g_list_free_full(files, reinterpret_cast<GDestroyNotify>(file_data_unref));
+    if (dirs) g_list_free(dirs);
+    file_data_unref(dir_a_fd);
+}
+
+TEST_F(LayoutImageNavigationTest, EmptyDirectoryHasNoFiles)
+{
+    FileData *dir_empty_fd = file_data_new_dir(dir_empty);
+    ASSERT_NE(dir_empty_fd, nullptr);
+    
+    GList *files = nullptr;
+    GList *dirs = nullptr;
+    
+    gboolean result = FileData::FileList::read_list(dir_empty_fd, &files, &dirs);
+    ASSERT_TRUE(result);
+    
+    // Should find 0 image files
+    guint file_count = g_list_length(files);
+    EXPECT_EQ(0u, file_count);
+    
+    // Clean up
+    if (files) g_list_free(files);
+    if (dirs) g_list_free(dirs);
+    file_data_unref(dir_empty_fd);
+}
+
+}  // anonymous namespace
+
+/* vim: set shiftwidth=8 softtabstop=0 cindent cinoptions={1s: */

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,6 +5,7 @@ unit_test_sources = files(
 'filedata/filedata.cc',
 'filedata/filelist.cc',
 'filedata/ref.cc',
+'layout-image-navigation.cc',
 'pixbuf-util.cc')
 
 code_sources += unit_test_sources


### PR DESCRIPTION
## Summary

Add an "Auto next folder" preference (Behavior tab, disabled by default). When enabled, reaching the last image in a folder automatically advances to the first image of the next sibling folder (alphabetical); reaching the first image goes back to the last image of the previous sibling folder.

Also adds explicit "Next folder" / "Previous folder" actions with Ctrl+Shift+Right / Ctrl+Shift+Left accelerators.

## Details
- New `ConfOptions.auto_next_folder` (default FALSE), persisted via rcfile
- Preferences checkbox in the Behavior tab
- `layout_get_next_sibling_dir()` / `layout_get_prev_sibling_dir()` helpers in layout-image.cc
- `FileData::FileList::read_list_lstat_all()` so hidden directories are considered as siblings
- Unit tests in tests/layout-image-navigation.cc (all pass)
- NEWS, README, and docbook help updated

Happy to adjust anything per maintainer feedback.
