### PR TITLE
Add missing header.

### DIFF
--- a/src/cellrenderericon.cc
+++ b/src/cellrenderericon.cc
@@ -20,6 +20,7 @@
 #include "cellrenderericon.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 
 #include <cairo.h>


### PR DESCRIPTION
Fixes this build problem on NetBSD:

```
../src/cellrenderericon.cc: In function 'gint gqv_cell_renderer_icon_mark_at(GtkCellRenderer*, GtkWidget*, const GdkRectangle*, gdouble, gdouble)':
../src/cellrenderericon.cc:101:50: error: 'floor' is not a member of 'std'; did you mean 'floor'?
  101 |         return std::clamp(static_cast<gint>(std::floor(((x - first_center) / TOGGLE_SPACING) + 0.5)),
      |                                                  ^~~~~
```