### PR TITLE
Ignore -Wclobbered only for gcc

### DIFF
--- a/src/image-load-jpeg.cc
+++ b/src/image-load-jpeg.cc
@@ -25,7 +25,9 @@
  */
 
 /** This is a Will Not Fix */
-#pragma GCC diagnostic ignored "-Wclobbered"
+#if defined(__GNUC__) && !defined(__clang__)
+#  pragma GCC diagnostic ignored "-Wclobbered"
+#endif
 
 #include "image-load-jpeg.h"
 


### PR DESCRIPTION
Clang doesn't support -Wclobbered.