### PR TITLE
Use gdk_pixbuf_read_pixels() for read-only pixbufs

### DIFF
--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -168,13 +168,12 @@ static gboolean histmap_read(HistMap *histmap, gboolean whole)
 	gint has_alpha;
 	gint step;
 	gint end_line;
-	guchar *s_pix;
-	GdkPixbuf *imgpixbuf = histmap->pixbuf;
+	const GdkPixbuf *imgpixbuf = histmap->pixbuf;
 
 	w = gdk_pixbuf_get_width(imgpixbuf);
 	h = gdk_pixbuf_get_height(imgpixbuf);
 	srs = gdk_pixbuf_get_rowstride(imgpixbuf);
-	s_pix = gdk_pixbuf_get_pixels(imgpixbuf);
+	const guchar *s_pix = gdk_pixbuf_read_pixels(imgpixbuf);
 	has_alpha = gdk_pixbuf_get_has_alpha(imgpixbuf);
 
 	if (whole)
@@ -191,7 +190,7 @@ static gboolean histmap_read(HistMap *histmap, gboolean whole)
 	step = 3 + !!(has_alpha);
 	for (i = histmap->y; i < end_line; i++)
 		{
-		guchar *sp = s_pix + (i * srs); /* 8bit */
+		const guchar *sp = s_pix + (i * srs); /* 8bit */
 		for (j = 0; j < w; j++)
 			{
 			guint max = std::max({sp[0], sp[1], sp[2]});

--- a/src/pixbuf-renderer.cc
+++ b/src/pixbuf-renderer.cc
@@ -2375,18 +2375,15 @@ static void pr_create_anaglyph_color(GdkPixbuf *pixbuf, GdkPixbuf *right, gint x
 {
 	gint srs;
 	gint drs;
-	guchar *s_pix;
 	guchar *d_pix;
-	guchar *sp;
 	guchar *dp;
-	guchar *spi;
 	guchar *dpi;
 	gint i;
 	gint j;
 
 	srs = gdk_pixbuf_get_rowstride(right);
-	s_pix = gdk_pixbuf_get_pixels(right);
-	spi = s_pix + (x * COLOR_BYTES);
+	const guchar *s_pix = gdk_pixbuf_read_pixels(right);
+	const guchar *spi = s_pix + (x * COLOR_BYTES);
 
 	drs = gdk_pixbuf_get_rowstride(pixbuf);
 	d_pix = gdk_pixbuf_get_pixels(pixbuf);
@@ -2394,7 +2391,7 @@ static void pr_create_anaglyph_color(GdkPixbuf *pixbuf, GdkPixbuf *right, gint x
 
 	for (i = y; i < y + h; i++)
 		{
-		sp = spi + (i * srs);
+		const guchar *sp = spi + (i * srs);
 		dp = dpi + (i * drs);
 		for (j = 0; j < w; j++)
 			{
@@ -2423,19 +2420,16 @@ static void pr_create_anaglyph_gray(GdkPixbuf *pixbuf, GdkPixbuf *right, gint x,
 {
 	gint srs;
 	gint drs;
-	guchar *s_pix;
 	guchar *d_pix;
-	guchar *sp;
 	guchar *dp;
-	guchar *spi;
 	guchar *dpi;
 	gint i;
 	gint j;
 	const double gc[3] = {0.299, 0.587, 0.114};
 
 	srs = gdk_pixbuf_get_rowstride(right);
-	s_pix = gdk_pixbuf_get_pixels(right);
-	spi = s_pix + (x * COLOR_BYTES);
+	const guchar *s_pix = gdk_pixbuf_read_pixels(right);
+	const guchar *spi = s_pix + (x * COLOR_BYTES);
 
 	drs = gdk_pixbuf_get_rowstride(pixbuf);
 	d_pix = gdk_pixbuf_get_pixels(pixbuf);
@@ -2443,7 +2437,7 @@ static void pr_create_anaglyph_gray(GdkPixbuf *pixbuf, GdkPixbuf *right, gint x,
 
 	for (i = y; i < y + h; i++)
 		{
-		sp = spi + (i * srs);
+		const guchar *sp = spi + (i * srs);
 		dp = dpi + (i * drs);
 		for (j = 0; j < w; j++)
 			{
@@ -2479,11 +2473,8 @@ static void pr_create_anaglyph_dubois(GdkPixbuf *pixbuf, GdkPixbuf *right, gint 
 {
 	gint srs;
 	gint drs;
-	guchar *s_pix;
 	guchar *d_pix;
-	guchar *sp;
 	guchar *dp;
-	guchar *spi;
 	guchar *dpi;
 	gint i;
 	gint j;
@@ -2518,8 +2509,8 @@ static void pr_create_anaglyph_dubois(GdkPixbuf *pixbuf, GdkPixbuf *right, gint 
 		}
 
 	srs = gdk_pixbuf_get_rowstride(right);
-	s_pix = gdk_pixbuf_get_pixels(right);
-	spi = s_pix + (x * COLOR_BYTES);
+	const guchar *s_pix = gdk_pixbuf_read_pixels(right);
+	const guchar *spi = s_pix + (x * COLOR_BYTES);
 
 	drs = gdk_pixbuf_get_rowstride(pixbuf);
 	d_pix = gdk_pixbuf_get_pixels(pixbuf);
@@ -2527,7 +2518,7 @@ static void pr_create_anaglyph_dubois(GdkPixbuf *pixbuf, GdkPixbuf *right, gint 
 
 	for (i = y; i < y + h; i++)
 		{
-		sp = spi + (i * srs);
+		const guchar *sp = spi + (i * srs);
 		dp = dpi + (i * drs);
 		for (j = 0; j < w; j++)
 			{
@@ -2987,7 +2978,7 @@ std::optional<GqColor> pixbuf_renderer_get_pixel_colors(PixbufRenderer *pr, GqPo
 
 	const gboolean p_alpha = gdk_pixbuf_get_has_alpha(pr->pixbuf);
 	const gint p_rs = gdk_pixbuf_get_rowstride(pr->pixbuf);
-	const guchar *p_pix = gdk_pixbuf_get_pixels(pr->pixbuf);
+	const guint8 *p_pix = gdk_pixbuf_read_pixels(pr->pixbuf);
 
 	const auto xoff = static_cast<size_t>(map_rect.x) * (p_alpha ? 4 : 3);
 	const auto yoff = static_cast<size_t>(map_rect.y) * p_rs;

--- a/src/renderer-tiles.cc
+++ b/src/renderer-tiles.cc
@@ -686,20 +686,17 @@ void rt_tile_rotate_90_clockwise(RendererTiles *rt, GdkPixbuf **tile, gint x, gi
 	GdkPixbuf *dest;
 	gint srs;
 	gint drs;
-	guchar *s_pix;
 	guchar *d_pix;
-	guchar *sp;
 	guchar *dp;
 	guchar *ip;
-	guchar *spi;
 	guchar *dpi;
 	gint i;
 	gint j;
 	gint tw = rt->tile_width;
 
 	srs = gdk_pixbuf_get_rowstride(src);
-	s_pix = gdk_pixbuf_get_pixels(src);
-	spi = s_pix + (x * COLOR_BYTES);
+	const guchar *s_pix = gdk_pixbuf_read_pixels(src);
+	const guchar *spi = s_pix + (x * COLOR_BYTES);
 
 	dest = rt_get_spare_tile(rt);
 	drs = gdk_pixbuf_get_rowstride(dest);
@@ -708,7 +705,7 @@ void rt_tile_rotate_90_clockwise(RendererTiles *rt, GdkPixbuf **tile, gint x, gi
 
 	for (i = y; i < y + h; i++)
 		{
-		sp = spi + (i * srs);
+		const guchar *sp = spi + (i * srs);
 		ip = dpi - (i * COLOR_BYTES);
 		for (j = x; j < x + w; j++)
 			{
@@ -728,20 +725,17 @@ void rt_tile_rotate_90_counter_clockwise(RendererTiles *rt, GdkPixbuf **tile, gi
 	GdkPixbuf *dest;
 	gint srs;
 	gint drs;
-	guchar *s_pix;
 	guchar *d_pix;
-	guchar *sp;
 	guchar *dp;
 	guchar *ip;
-	guchar *spi;
 	guchar *dpi;
 	gint i;
 	gint j;
 	gint th = rt->tile_height;
 
 	srs = gdk_pixbuf_get_rowstride(src);
-	s_pix = gdk_pixbuf_get_pixels(src);
-	spi = s_pix + (x * COLOR_BYTES);
+	const guchar *s_pix = gdk_pixbuf_read_pixels(src);
+	const guchar *spi = s_pix + (x * COLOR_BYTES);
 
 	dest = rt_get_spare_tile(rt);
 	drs = gdk_pixbuf_get_rowstride(dest);
@@ -750,7 +744,7 @@ void rt_tile_rotate_90_counter_clockwise(RendererTiles *rt, GdkPixbuf **tile, gi
 
 	for (i = y; i < y + h; i++)
 		{
-		sp = spi + (i * srs);
+		const guchar *sp = spi + (i * srs);
 		ip = dpi + (i * COLOR_BYTES);
 		for (j = x; j < x + w; j++)
 			{
@@ -770,11 +764,8 @@ void rt_tile_mirror_only(RendererTiles *rt, GdkPixbuf **tile, gint x, gint y, gi
 	GdkPixbuf *dest;
 	gint srs;
 	gint drs;
-	guchar *s_pix;
 	guchar *d_pix;
-	guchar *sp;
 	guchar *dp;
-	guchar *spi;
 	guchar *dpi;
 	gint i;
 	gint j;
@@ -782,8 +773,8 @@ void rt_tile_mirror_only(RendererTiles *rt, GdkPixbuf **tile, gint x, gint y, gi
 	gint tw = rt->tile_width;
 
 	srs = gdk_pixbuf_get_rowstride(src);
-	s_pix = gdk_pixbuf_get_pixels(src);
-	spi = s_pix + (x * COLOR_BYTES);
+	const guchar *s_pix = gdk_pixbuf_read_pixels(src);
+	const guchar *spi = s_pix + (x * COLOR_BYTES);
 
 	dest = rt_get_spare_tile(rt);
 	drs = gdk_pixbuf_get_rowstride(dest);
@@ -792,7 +783,7 @@ void rt_tile_mirror_only(RendererTiles *rt, GdkPixbuf **tile, gint x, gint y, gi
 
 	for (i = y; i < y + h; i++)
 		{
-		sp = spi + (i * srs);
+		const guchar *sp = spi + (i * srs);
 		dp = dpi + (i * drs);
 		for (j = 0; j < w; j++)
 			{
@@ -812,9 +803,7 @@ void rt_tile_mirror_and_flip(RendererTiles *rt, GdkPixbuf **tile, gint x, gint y
 	GdkPixbuf *dest;
 	gint srs;
 	gint drs;
-	guchar *s_pix;
 	guchar *d_pix;
-	guchar *sp;
 	guchar *dp;
 	guchar *dpi;
 	gint i;
@@ -823,7 +812,7 @@ void rt_tile_mirror_and_flip(RendererTiles *rt, GdkPixbuf **tile, gint x, gint y
 	gint th = rt->tile_height;
 
 	srs = gdk_pixbuf_get_rowstride(src);
-	s_pix = gdk_pixbuf_get_pixels(src);
+	const guchar *s_pix = gdk_pixbuf_read_pixels(src);
 
 	dest = rt_get_spare_tile(rt);
 	drs = gdk_pixbuf_get_rowstride(dest);
@@ -832,7 +821,7 @@ void rt_tile_mirror_and_flip(RendererTiles *rt, GdkPixbuf **tile, gint x, gint y
 
 	for (i = y; i < y + h; i++)
 		{
-		sp = s_pix + (i * srs) + (x * COLOR_BYTES);
+		const guchar *sp = s_pix + (i * srs) + (x * COLOR_BYTES);
 		dp = dpi - (i * drs) - (x * COLOR_BYTES);
 		for (j = 0; j < w; j++)
 			{
@@ -852,18 +841,15 @@ void rt_tile_flip_only(RendererTiles *rt, GdkPixbuf **tile, gint x, gint y, gint
 	GdkPixbuf *dest;
 	gint srs;
 	gint drs;
-	guchar *s_pix;
 	guchar *d_pix;
-	guchar *sp;
 	guchar *dp;
-	guchar *spi;
 	guchar *dpi;
 	gint i;
 	gint th = rt->tile_height;
 
 	srs = gdk_pixbuf_get_rowstride(src);
-	s_pix = gdk_pixbuf_get_pixels(src);
-	spi = s_pix + (x * COLOR_BYTES);
+	const guchar *s_pix = gdk_pixbuf_read_pixels(src);
+	const guchar *spi = s_pix + (x * COLOR_BYTES);
 
 	dest = rt_get_spare_tile(rt);
 	drs = gdk_pixbuf_get_rowstride(dest);
@@ -872,7 +858,7 @@ void rt_tile_flip_only(RendererTiles *rt, GdkPixbuf **tile, gint x, gint y, gint
 
 	for (i = y; i < y + h; i++)
 		{
-		sp = spi + (i * srs);
+		const guchar *sp = spi + (i * srs);
 		dp = dpi - (i * drs);
 		memcpy(dp, sp, w * COLOR_BYTES);
 		}
@@ -1081,7 +1067,7 @@ void rt_tile_get_region_wide(gboolean ignore_alpha,
 	const gint src_height = gdk_pixbuf_get_height(src);
 	const gint src_channels = gdk_pixbuf_get_n_channels(src);
 	const gint src_rowstride = gdk_pixbuf_get_rowstride(src);
-	const guchar *src_pixels = gdk_pixbuf_get_pixels(src);
+	const guchar *src_pixels = gdk_pixbuf_read_pixels(src);
 
 	const gint dest_channels = gdk_pixbuf_get_n_channels(dest);
 	const gint dest_rowstride = gdk_pixbuf_get_rowstride(dest);

--- a/src/similar.cc
+++ b/src/similar.cc
@@ -147,7 +147,7 @@ static void image_sim_channel_norm(ImageSimilarityData::Avg &pix)
 		}
 }
 
-ImageSimilarityData::ImageSimilarityData(GdkPixbuf *pixbuf)
+ImageSimilarityData::ImageSimilarityData(const GdkPixbuf *pixbuf)
 	: ImageSimilarityData()
 {
 	fill_data(pixbuf);
@@ -183,14 +183,14 @@ void ImageSimilarityData::alternate_processing()
 		}
 }
 
-void ImageSimilarityData::fill_data(GdkPixbuf *pixbuf)
+void ImageSimilarityData::fill_data(const GdkPixbuf *pixbuf)
 {
 	if (!pixbuf) return;
 
 	const gint w = gdk_pixbuf_get_width(pixbuf);
 	const gint h = gdk_pixbuf_get_height(pixbuf);
 	const gint rs = gdk_pixbuf_get_rowstride(pixbuf);
-	const guchar *pix = gdk_pixbuf_get_pixels(pixbuf);
+	const guchar *pix = gdk_pixbuf_read_pixels(pixbuf);
 	const gint p_step = gdk_pixbuf_get_has_alpha(pixbuf) ? 4 : 3;
 
 	gint x_inc = w / 32;

--- a/src/similar.h
+++ b/src/similar.h
@@ -30,11 +30,11 @@
 struct ImageSimilarityData
 {
 	ImageSimilarityData() = default;
-	ImageSimilarityData(GdkPixbuf *pixbuf);
+	ImageSimilarityData(const GdkPixbuf *pixbuf);
 
 	void alternate_processing();
 
-	void fill_data(GdkPixbuf *pixbuf);
+	void fill_data(const GdkPixbuf *pixbuf);
 	GdkPixbuf *to_pixbuf() const;
 
 	bool fill_data(FILE *f);

--- a/src/utilops.cc
+++ b/src/utilops.cc
@@ -478,13 +478,11 @@ GdkTexture *utility_texture_new_from_pixbuf(GdkPixbuf *pixbuf)
 
 	const gint height = gdk_pixbuf_get_height(pixbuf);
 	const gsize stride = gdk_pixbuf_get_rowstride(pixbuf);
-	GBytes *bytes = g_bytes_new_with_free_func(gdk_pixbuf_get_pixels(pixbuf), stride * height,
-							     reinterpret_cast<GDestroyNotify>(g_object_unref), g_object_ref(pixbuf));
+	g_autoptr(GBytes) bytes = g_bytes_new_with_free_func(gdk_pixbuf_read_pixels(pixbuf), stride * height,
+	                                                     g_object_unref, g_object_ref(pixbuf));
 	const GdkMemoryFormat format = gdk_pixbuf_get_has_alpha(pixbuf) ? GDK_MEMORY_R8G8B8A8 : GDK_MEMORY_R8G8B8;
-	GdkTexture *texture = gdk_memory_texture_new(gdk_pixbuf_get_width(pixbuf), height, format, bytes, stride);
-	g_bytes_unref(bytes);
 
-	return texture;
+	return gdk_memory_texture_new(gdk_pixbuf_get_width(pixbuf), height, format, bytes, stride);
 }
 
 UtilityListItem *utility_list_item_new(FileData *fd, GdkPixbuf *pixbuf, const gchar *sidecars)


### PR DESCRIPTION
Avoid implicit copy in `gdk_pixbuf_get_pixels()`.